### PR TITLE
Succeed when deleting a non-existing resource

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -654,7 +654,14 @@ func (p *cfnProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) 
 	if err != nil {
 		return nil, err
 	}
-	if _, err = p.waitForResourceOpCompletion(ctx, res.ProgressEvent); err != nil {
+	if pi, err := p.waitForResourceOpCompletion(ctx, res.ProgressEvent); err != nil {
+		if pi != nil {
+			errorCode := aws.StringValue(pi.ErrorCode)
+			if errorCode == cloudformation.HandlerErrorCodeNotFound {
+				// NotFound means that the resource was already deleted, so the operation can succeed.
+				return &pbempty.Empty{}, nil
+			}
+		}
 		return nil, err
 	}
 
@@ -749,7 +756,7 @@ func (p *cfnProvider) waitForResourceOpCompletion(ctx context.Context, pi *cloud
 		case "SUCCESS":
 			return pi, nil
 		case "FAILED":
-			return nil, errors.Errorf("operation %s failed with %q: %s", aws.StringValue(pi.Operation), aws.StringValue(pi.ErrorCode), aws.StringValue(pi.StatusMessage))
+			return pi, errors.Errorf("operation %s failed with %q: %s", aws.StringValue(pi.Operation), aws.StringValue(pi.ErrorCode), aws.StringValue(pi.StatusMessage))
 		case "IN_PROGRESS":
 			// TODO: back-off?
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
If a `DeleteResource` operation reports that a resource is not found, consider the deletion successful instead of failing with an error.