### PR TITLE
Basic CDK integration prototype

### DIFF
--- a/examples/cdk/Pulumi.yaml
+++ b/examples/cdk/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-cdk
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/examples/cdk/cdk-interop.ts
+++ b/examples/cdk/cdk-interop.ts
@@ -1,0 +1,61 @@
+import * as cdk from '@aws-cdk/core';
+import * as pulumi from "@pulumi/pulumi";
+
+function firstToLower(str: string) {
+    return str.replace(
+      /\w\S*/g,
+      function(txt) {
+        return txt.charAt(0).toLowerCase() + txt.substr(1);
+      }
+    );
+}
+
+function normalize(value: any): any {
+    if (!value) return value;
+
+    if (Array.isArray(value)) {
+        const result: any[] = [];
+        for(let i=0; i<value.length; i++){
+            result[i] = normalize(value[i]);
+        }
+        return result
+    }
+
+    if (typeof value !== 'object') return value;
+
+    const result :any = {};
+    Object.entries(value).forEach(([k, v]) => {
+        result[firstToLower(k)] = normalize(v);
+    });
+    return result;
+}
+
+class CdkResource extends pulumi.CustomResource {
+    constructor(name: string, type: string, args: any, opts?: pulumi.CustomResourceOptions) {
+        const [_, mod, res] = type.split("::");
+        super(`aws-native:${mod}:${res}`, name, args, opts);
+    }
+}
+
+export class CdkComponent extends pulumi.ComponentResource {
+    constructor(name: string, args: (stack: cdk.Stack) => void, opts?: pulumi.CustomResourceOptions) {
+        super("aws-native:cdk:Component", name, args, opts);
+
+        const app = new cdk.App();
+        const stack = new cdk.Stack(app);
+        args(stack);
+
+        //debugger;
+        const template = app.synth().getStackByName(stack.stackName).template;
+        console.debug(template.Resources.appsvc.Properties);
+        const resources = template.Resources;
+
+        Object.entries(resources).forEach(
+            ([key, value]) => {
+                const typeName = (value as any).Type;
+                const sourceProps = (value as any).Properties;
+                opts = opts || { parent: this };
+                new CdkResource(key, typeName, normalize(sourceProps), opts);
+            });
+    }
+}

--- a/examples/cdk/index.ts
+++ b/examples/cdk/index.ts
@@ -1,0 +1,133 @@
+import * as pulumi from "@pulumi/pulumi";
+import { CdkComponent } from "./cdk-interop";
+
+import * as cassandra from '@aws-cdk/aws-cassandra';
+
+// A basic example of deploying a CDK resource from Pulumi.
+// Note that we don't flow any inputs/outputs.
+new CdkComponent("helloworld", stack => {
+    new cassandra.CfnKeyspace(stack, "keyspace");
+});
+
+// The full program isn't that nice because we need to figure out a way to create
+// dependencies across CDK resources and Pulumi components.
+import * as ecs from '@aws-cdk/aws-ecs';
+import * as elasticloadbalancingv2 from '@aws-cdk/aws-elasticloadbalancingv2';
+
+import * as aws from "@pulumi/aws";
+
+const defaultVpc = pulumi.output(aws.ec2.getVpc({ default: true }));
+const defaultVpcSubnets = defaultVpc.id.apply(id => aws.ec2.getSubnetIds({vpcId: id}));
+
+const group = new aws.ec2.SecurityGroup("web-secgrp", {
+	vpcId: defaultVpc.id,
+	description: "Enable HTTP access",
+	ingress: [{
+		protocol: "tcp",
+		fromPort: 80,
+		toPort: 80,
+		cidrBlocks: ["0.0.0.0/0"],
+    }],
+  	egress: [{
+		protocol:"-1",
+		fromPort: 0,
+		toPort: 0,
+		cidrBlocks: ["0.0.0.0/0"],
+    }],
+});
+
+const alb = new aws.lb.LoadBalancer("app-lb", {
+	securityGroups: [group.id],
+	subnets: defaultVpcSubnets.ids,
+});
+
+const atg = new aws.lb.TargetGroup("app-tg", {
+    port: 80,
+	protocol: "HTTP",
+	targetType: "ip",
+	vpcId: defaultVpc.id,
+});
+
+const role = new aws.iam.Role("task-exec-role", {
+	assumeRolePolicy: {
+		Version: "2008-10-17",
+		Statement: [{
+			Sid: "",
+			Effect: "Allow",
+			Principal: {
+				Service: "ecs-tasks.amazonaws.com"
+			},
+			Action: "sts:AssumeRole",
+		}],
+	},
+});
+
+const rpa = new aws.iam.RolePolicyAttachment("task-exec-policy", {
+	role: role.name,
+	policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+});
+
+export const albArn = alb.arn;
+export const albDnsName = alb.dnsName;
+export const atgArn = atg.arn;
+export const roleArn = role.arn;
+export const subnetIds = defaultVpcSubnets.ids;
+export const securityGroupId = group.id;
+
+pulumi.all([albArn, atgArn, roleArn, subnetIds, securityGroupId]).apply(([albArn, atgArn, roleArn, subnetIds, securityGroupId]) => {
+    new CdkComponent("test", stack => {
+        new cassandra.CfnKeyspace(stack, "keyspace");
+
+        const cluster = new ecs.CfnCluster(stack, "cluster");
+
+        const wl = new elasticloadbalancingv2.CfnListener(stack, "web", {
+            loadBalancerArn: albArn,
+            port: 80,
+            protocol: "HTTP",
+            defaultActions: [{
+                type: "forward",
+                targetGroupArn: atgArn,
+            }],
+        });
+
+        const taskDefinition = new ecs.CfnTaskDefinition(stack, "app-task", {
+            family: "fargate-task-definition",
+            cpu: "256",
+            memory: "512",
+            networkMode: "awsvpc",
+            requiresCompatibilities: ["FARGATE"],
+            executionRoleArn: roleArn,
+            containerDefinitions:[{
+                name: "my-app",
+                image: "nginx",
+                portMappings: [{
+                    containerPort: 80,
+                    hostPort: 80,
+                    protocol: "tcp"
+                }],
+            }],
+        });
+
+        console.debug(cluster.attrArn);
+
+        const service = new ecs.CfnService(stack, "app-svc", {
+            serviceName: "app-svc-cloud-api",
+            cluster: cluster.attrArn,
+            desiredCount: 1,
+            launchType: "FARGATE",
+            taskDefinition: taskDefinition.attrTaskDefinitionArn,
+            networkConfiguration: {
+                awsvpcConfiguration: {
+                    assignPublicIp: "ENABLED",
+                    subnets: subnetIds,
+                    securityGroups: [securityGroupId],
+                },
+            },
+            loadBalancers: [{
+                targetGroupArn: atgArn,
+                containerName: "my-app",
+                containerPort: 80,
+            }],
+        }/*, { dependsOn: [wl] }*/);
+    });
+});

--- a/examples/cdk/package.json
+++ b/examples/cdk/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "pulumi-aws-cdk",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@aws-cdk/aws-cassandra": "^1.107.0",
+        "@aws-cdk/aws-ecs": "^1.107.0",
+        "@aws-cdk/aws-elasticloadbalancingv2": "^1.107.0",
+        "@aws-cdk/aws-s3": "^1.107.0",
+        "@aws-cdk/core": "1.107.0",
+        "@pulumi/aws": "^4.6.0",
+        "@pulumi/pulumi": "^3.0.0"
+    }
+}

--- a/examples/cdk/tsconfig.json
+++ b/examples/cdk/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
As a part of my June 2021 hackathon, I spent some time learning CDK and its tooling and thinking of a possible integration of CDK components inside Pulumi programs with the AWS native provider.

A basic example was fairly simple to make:

- Import CDK to the program
- Create a pair of App and Stack
- Pass those to CDK resources
- Call `synth` on the Stack to produce CF
- Parse CF resources and instantiate them one-by-one as Pulumi resources
- Provider takes care of creating the resources with AWS API
 
![image](https://user-images.githubusercontent.com/1454008/121339338-acc92f80-c91e-11eb-8816-abb215d12303.png)

However, a meaningful program requires flowing output properties of some resources to the inputs of other resources. CDK and Pulumi are different in this regards.

CDK uses magic strings with internal pointers to track resource outputs. At the time of `synth`, they convert those magic strings to CF references. Our integration would have to parse those references to Pulumi engine as dependencies. I dove into our SDKs but wasn't able to achieve this translation - there doesn't seem to an API readily available for this.

An even larger problem is flowing Pulumi outputs to CDK programs and CDK outputs to Pulumi resources. The former is somewhat possible with `apply` but then CDK does not run in preview which is detrimental to the experience. I see three broad directions here:

1. Suck it up and mandate a clear boundary between Pulumi resources and CDK resources.
2. Create a helper function to convert a Pulumi output to a CDK magic string.
3. Build a code generation facility, based on or similar to projen, that uses JSII of CDK constructs to produce a normal-looking Pulumi multi-language component. The Pulumi component has SDKs in all four languages but the implementation is hosted in Node.js and executes the CDK component internally.

(3) could potentially provide the best "native" experience in Pulumi but requires a heavy machinery of wrapping CDK components in Pulumi components (on a case-by-case basic, or in bulk). It's somewhat similar in spirit to Luke's prototype where an AWSX component was wrapped in a multi-language component.

Anyway, that's as far as I got here. Overall, I'd say I came out less optimistic about the potential of CDK integration than before I started.