### PR TITLE
Fix Makefile to set Python SDK version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ build_nodejs::
 generate_python::
 	$(WORKING_DIR)/bin/$(CODEGEN) python $(CFN_SCHEMA_FILE) ${VERSION}
 
-build_python:: VERSION := $(shell pulumictl get version --language python)
+build_python:: PYPI_VERSION := $(shell pulumictl get version --language python)
 build_python::
 	cd sdk/python/ && \
         cp ../../README.md . && \
         python3 setup.py clean --all 2>/dev/null && \
         rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-        sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" -e "s/\$${PLUGIN_VERSION}/$(VERSION)/g" ./bin/setup.py && \
+        sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
         rm ./bin/setup.py.bak && \
         cd ./bin && python3 setup.py build sdist
 


### PR DESCRIPTION
A [recent change](https://github.com/pulumi/pulumi/pull/7479) to the codegen has changed the way `setup.py` is emitted that requires an update to the `Makefile` to set the version.

I also noticed both the `VERSION` and `PLUGIN_VERSION` were being set to the Python-style version. Not sure if that was intentional (unlikely), so I've fixed it up so these get the correct version styles.