### PR TITLE
Move cf2pulumi to pkg

### DIFF
--- a/provider/cmd/cf2pulumi/main.go
+++ b/provider/cmd/cf2pulumi/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
 	"log"
 	"os"
 	"strings"
@@ -24,11 +25,11 @@ func main() {
 
 	target, templatePath := os.Args[1], os.Args[2]
 
-	template, err := RenderFile(templatePath)
+	template, err := cf2pulumi.RenderFile(templatePath)
 	if err != nil {
 		log.Fatalf("failed to render template: %v", err)
 	}
-	formatBody(template)
+	cf2pulumi.FormatBody(template)
 	programText := fmt.Sprintf("%v", template)
 
 	parser := syntax.NewParser()

--- a/provider/pkg/cf2pulumi/format.go
+++ b/provider/pkg/cf2pulumi/format.go
@@ -1,4 +1,6 @@
-package main
+// Copyright 2016-2021, Pulumi Corporation.
+
+package cf2pulumi
 
 import (
 	"strings"
@@ -265,8 +267,8 @@ func (f *formatter) formatBody(body *model.Body) {
 	}
 }
 
-// formatBody formats a PCL body.
-func formatBody(body *model.Body) {
+// FormatBody formats a PCL body.
+func FormatBody(body *model.Body) {
 	var f formatter
 	f.formatBody(body)
 }

--- a/provider/pkg/cf2pulumi/renderer.go
+++ b/provider/pkg/cf2pulumi/renderer.go
@@ -1,4 +1,6 @@
-package main
+// Copyright 2016-2021, Pulumi Corporation.
+
+package cf2pulumi
 
 import (
 	"fmt"
@@ -1255,7 +1257,7 @@ func RenderTemplate(file *ast.File) (*model.Body, error) {
 	}
 
 	body := &model.Body{Items: items}
-	formatBody(body)
+	FormatBody(body)
 	return body, nil
 }
 

--- a/provider/pkg/cf2pulumi/utils.go
+++ b/provider/pkg/cf2pulumi/utils.go
@@ -1,4 +1,6 @@
-package main
+// Copyright 2016-2021, Pulumi Corporation.
+
+package cf2pulumi
 
 import (
 	"strings"


### PR DESCRIPTION
This is a mechanical change of splitting cf2pulumi to a package that can be used from codegen and a bare-bone tool. The goal is reuse the code for example generation.