### PR TITLE
Work around empty go.mod issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,9 +101,9 @@ build_go::
 	#cd sdk/ && go build github.com/pulumi/pulumi-aws-native/sdk/go/aws/...
 
 clean::
-	rm -rf sdk/nodejs && mkdir sdk/nodejs && touch sdk/nodejs/go.mod
-	rm -rf sdk/python && mkdir sdk/python && touch sdk/python/go.mod
-	rm -rf sdk/dotnet && mkdir sdk/dotnet && touch sdk/dotnet/go.mod
+	rm -rf sdk/nodejs && mkdir sdk/nodejs && echo "module fake_go_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/nodejs/go.mod'
+	rm -rf sdk/python && mkdir sdk/python && echo "module fake_go_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/python/go.mod'
+	rm -rf sdk/dotnet && mkdir sdk/dotnet && echo "module fake_go_module // Exclude this directory from Go tools\n\ngo 1.16" > 'sdk/dotnet/go.mod'
 	rm -rf sdk/go
 
 install_dotnet_sdk::

--- a/sdk/dotnet/go.mod
+++ b/sdk/dotnet/go.mod
@@ -1,3 +1,3 @@
 module fake_go_module // Exclude this directory from Go tools
 
-go 1.14
+go 1.16

--- a/sdk/nodejs/go.mod
+++ b/sdk/nodejs/go.mod
@@ -1,3 +1,3 @@
 module fake_go_module // Exclude this directory from Go tools
 
-go 1.14
+go 1.16

--- a/sdk/python/go.mod
+++ b/sdk/python/go.mod
@@ -1,3 +1,3 @@
 module fake_go_module // Exclude this directory from Go tools
 
-go 1.14
+go 1.16


### PR DESCRIPTION
Some IDEs complain about empty go.mod files, so add placeholder
values to the go.mod files that are used to exclude these directories.

Inspired by https://github.com/golang/go/issues/30058#issuecomment-648395486 