### PR TITLE
Add NYI errors for currently unsupported provider config

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -150,8 +150,6 @@ func (p *cfnProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckReque
 				return true
 			case arg.IsBool() && arg.BoolValue():
 				return true
-			default:
-				return false
 			}
 		}
 		return false


### PR DESCRIPTION
A number of the provider configs/parameters have not yet
been implemented in the provider. Return a descriptive
error if any of these NYI configs are set, and link to a
GitHub issue to get user feedback on roadmap priority
for implementing them.

Here's an example error message:
```
error: pulumi:providers:aws-native resource 'aws's property 'endpoints' value {[]} has a problem: not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/108
```

Fix #49 