### PR TITLE
Fix a panic in cf2pulumi codepath

### DIFF
--- a/provider/pkg/cf2pulumi/renderer.go
+++ b/provider/pkg/cf2pulumi/renderer.go
@@ -160,7 +160,7 @@ func (ctx *renderContext) renderSub(name string, value ast.Node) (model.Expressi
 		return nil, fmt.Errorf("the first argument to 'Fn::Sub' must be a string")
 	}
 
-	var environment map[string]model.Expression
+	environment := make(map[string]model.Expression)
 	if len(arr) == 2 {
 		values, ok := mapValues(arr[1])
 		if !ok {


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-aws-native/issues/149, we are panicking trying to convert a valid CloudFormation template. The root cause for that is that a map doesn't ever get initialized, leading to an "assignment to entry in nil map" panic on any code paths that try to use it. Fix is simple: initialize it to an empty map.

Unfortunately, that yields a new error, `failed to render template: unsupported property 'Condition' in resource 'Leaf5'`. That is caused by the following YAML

```
Conditions:
  CreateLeaf5: !Or
    - !Condition 'CreateLeaf6'
    - !Equals
      - !Ref 'NumLeaves'
      - 5
```

It appears we don't support referencing other conditions from within conditions. I'm not sure how easy that will be to fix, but I figure fixing the panic is a good thing to get in regardless.