### PR TITLE
Stop unconditional population of Replaces in Diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## HEAD (Unreleased)
 
-- Update to pulumi v3.16.0 deps [#202](https://github.com/pulumi/pulumi-aws-native/pull/202)
-- Add autonaming support [#156](https://github.com/pulumi/pulumi-aws-native/issues/156)
+- Update to pulumi v3.16.0 deps
+  [#202](https://github.com/pulumi/pulumi-aws-native/pull/202)
+- Add autonaming support
+  [#156](https://github.com/pulumi/pulumi-aws-native/issues/156)
+- Turn off replacement detection to prevent false replacements
+  [#186](https://github.com/pulumi/pulumi-aws-native/issues/186)
 
 ## 0.3.0 (November 2, 2021)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -574,15 +574,8 @@ func (p *cfnProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pu
 		return &pulumirpc.DiffResponse{Changes: pulumirpc.DiffResponse_DIFF_NONE}, nil
 	}
 
-	resourceToken := string(urn.Type())
-	spec, ok := p.resourceMap.Resources[resourceToken]
-	if !ok {
-		return nil, errors.Errorf("Resource type %s not found", resourceToken)
-	}
-
 	return &pulumirpc.DiffResponse{
 		Changes:             pulumirpc.DiffResponse_DIFF_UNKNOWN,
-		Replaces:            spec.CreateOnly,
 		DeleteBeforeReplace: true,
 	}, nil
 }


### PR DESCRIPTION
It is semantically wrong to statically populate the `Replaces` property of a Diff response with all the properties that require replacement for a given resource type. This PR removes this, which means we will detect _no_ replacements. I think this is a better type of error than unneeded replacements. 

We should follow-up with a proper fix with https://github.com/pulumi/pulumi-aws-native/issues/175 (or a detailed diff calculation if #175 turns out not to work).

Fix #186
Fix #204