### PR TITLE
Record state for a resource that partially failed to create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   [#156](https://github.com/pulumi/pulumi-aws-native/issues/156)
 - Turn off replacement detection to prevent false replacements
   [#186](https://github.com/pulumi/pulumi-aws-native/issues/186)
+- Support partial initialization errors
+  [#208](https://github.com/pulumi/pulumi-aws-native/pull/208)
 
 ## 0.3.0 (November 2, 2021)
 

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.3.1
 	google.golang.org/grpc v1.37.0
+	google.golang.org/protobuf v1.26.0
 )
 
 replace github.com/lestrrat-go/jsschema => github.com/mikhailshilkov/jsschema v0.0.0-20210924145243-fc93fd28ee1b

--- a/provider/pkg/schema/convert.go
+++ b/provider/pkg/schema/convert.go
@@ -23,6 +23,9 @@ func SdkToCfn(res *CloudAPIResource, types map[string]CloudAPIType, properties m
 // DiffToPatch converts a Pulumi object diff to a CloudFormation-shaped patch operation slice. Update/add/delete operations are
 // mapped to corresponding patch terms, and SDK properties are translated to respective CFN names.
 func DiffToPatch(res *CloudAPIResource, types map[string]CloudAPIType, diff *resource.ObjectDiff) ([]jsonpatch.JsonPatchOperation, error) {
+	if diff == nil {
+		return []jsonpatch.JsonPatchOperation{}, nil
+	}
 	converter := sdkToCfnConverter{res, types}
 	return converter.diffToPatch(diff), nil
 }


### PR DESCRIPTION
Even in case of creation failure, check if the progress event contains a resource identifier. If so, try reading its state and treat the operation as partially succeeded.

Added a nil check in patch calculation because:
- The resource was created with properties A
- Cloud Control reported it as failed but it actually succeeded
- On the next run, Pulumi detects an update (to complete the operation) but the properties are still A
- We calculate the diff between A and A and get an empty diff (nil)
- Provider panicked in patch calculation

Fixes the orphaned resource part of #184