### PR TITLE
Use cancelation context to handle operation cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
 - Explain how to add missing region config [#220](https://github.com/pulumi/pulumi-aws-native/issues/220).
+- Allow cancellation during ongoing operations [#43](https://github.com/pulumi/pulumi-aws-native/issues/43)
 
 ---
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1021,7 +1021,7 @@ func (p *cfnProvider) waitForResourceOpCompletion(ctx context.Context, pi *types
 		select {
 		case <-p.canceler.context.Done():
 			return nil, p.canceler.context.Err()
-		default:
+		default: // Continue to wait
 		}
 
 		output, err := p.cctl.GetResourceRequestStatus(p.canceler.context, &cloudcontrol.GetResourceRequestStatusInput{

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -640,7 +640,7 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 	// Create the resource with Cloud API.
 	clientToken := uuid.New().String()
 	glog.V(9).Infof("%s.CreateResource %q token %q state %q", label, cfType, clientToken, desiredState)
-	res, err := p.cctl.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
+	res, err := p.cctl.CreateResource(p.canceler.context, &cloudcontrol.CreateResourceInput{
 		ClientToken:  aws.String(clientToken),
 		TypeName:     aws.String(cfType),
 		DesiredState: aws.String(desiredState),
@@ -841,7 +841,7 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 	docAsString := string(doc)
 	clientToken := uuid.New().String()
 	glog.V(9).Infof("%s.UpdateResource %q id %q token %q state %+v", label, spec.CfType, id, clientToken, ops)
-	res, err := p.cctl.UpdateResource(ctx, &cloudcontrol.UpdateResourceInput{
+	res, err := p.cctl.UpdateResource(p.canceler.context, &cloudcontrol.UpdateResourceInput{
 		ClientToken:   aws.String(clientToken),
 		TypeName:      aws.String(spec.CfType),
 		Identifier:    aws.String(id),
@@ -912,7 +912,7 @@ func (p *cfnProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) 
 
 	clientToken := uuid.New().String()
 	glog.V(9).Infof("%s.DeleteResource %q id %q token %q", label, cfType, id, clientToken)
-	res, err := p.cctl.DeleteResource(ctx, &cloudcontrol.DeleteResourceInput{
+	res, err := p.cctl.DeleteResource(p.canceler.context, &cloudcontrol.DeleteResourceInput{
 		ClientToken: aws.String(clientToken),
 		TypeName:    aws.String(cfType),
 		Identifier:  aws.String(id),
@@ -962,7 +962,7 @@ func (p *cfnProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, e
 }
 
 func (p *cfnProvider) readResourceState(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
-	getRes, err := p.cctl.GetResource(ctx, &cloudcontrol.GetResourceInput{
+	getRes, err := p.cctl.GetResource(p.canceler.context, &cloudcontrol.GetResourceInput{
 		TypeName:   aws.String(typeName),
 		Identifier: aws.String(identifier),
 	})
@@ -1018,7 +1018,7 @@ func (p *cfnProvider) waitForResourceOpCompletion(ctx context.Context, pi *types
 			return nil, errors.Errorf("unknown status %q: %+v", status, pi)
 		}
 
-		output, err := p.cctl.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
+		output, err := p.cctl.GetResourceRequestStatus(p.canceler.context, &cloudcontrol.GetResourceRequestStatusInput{
 			RequestToken: pi.RequestToken,
 		})
 		if err != nil {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1018,6 +1018,12 @@ func (p *cfnProvider) waitForResourceOpCompletion(ctx context.Context, pi *types
 			return nil, errors.Errorf("unknown status %q: %+v", status, pi)
 		}
 
+		select {
+		case <-p.canceler.context.Done():
+			return nil, p.canceler.context.Err()
+		default:
+		}
+
 		output, err := p.cctl.GetResourceRequestStatus(p.canceler.context, &cloudcontrol.GetResourceRequestStatusInput{
 			RequestToken: pi.RequestToken,
 		})

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1020,7 +1020,7 @@ func (p *cfnProvider) waitForResourceOpCompletion(ctx context.Context, pi *types
 
 		select {
 		case <-ctx.Done():
-			return nil, p.canceler.context.Err()
+			return nil, ctx.Err()
 		default: // Continue to wait
 		}
 


### PR DESCRIPTION
Closes #43 

Summary: 
1. Pass the cancellable context down into any cloud control operations so they will also be cancelled.
2. Manually check for cancellation in the wait loop.

Rules for cancellation:
- Do allow cancellation during any wait operation
- Don't cancel during initial create
- Allow cancellation during most read operations*
- *Don't cancel when reading after create

Note: If the wait during create fails for any reason it returns a partial error.