### PR TITLE
Fix patch calculation of object diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## HEAD (Unreleased)
+
 - Add support for specifying max retries
-  [#112](https://github.com/pulumi/pulumi-aws-native/pull/227)
+  [#112](https://github.com/pulumi/pulumi-aws-native/issues/112)
+- Fix modifying S3 bucket tags
+  [#230](https://github.com/pulumi/pulumi-aws-native/issues/230)
 
 ---
 

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -19,6 +19,21 @@ func TestSimpleTs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestUpdate(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "update", "step1"),
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      filepath.Join(getCwd(t), "update", "step2"),
+					Additive: true,
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/examples/update/step1/Pulumi.yaml
+++ b/examples/update/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-update
+runtime: nodejs
+description: A TypeScript Pulumi program with AWS Native provider testing an update

--- a/examples/update/step1/index.ts
+++ b/examples/update/step1/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+import * as aws from "@pulumi/aws-native";
+
+const logGroup = new aws.s3.Bucket("bucket", {
+    tags: [{
+        key: "foo",
+        value: "bar",
+    }]
+});

--- a/examples/update/step1/package.json
+++ b/examples/update/step1/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aws-update",
+  "devDependencies": {
+    "@types/node": "^8.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@pulumi/aws-native": "dev"
+  }
+}

--- a/examples/update/step1/tsconfig.json
+++ b/examples/update/step1/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/update/step2/Pulumi.yaml
+++ b/examples/update/step2/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-update
+runtime: nodejs
+description: A TypeScript Pulumi program with AWS Native provider testing an update

--- a/examples/update/step2/index.ts
+++ b/examples/update/step2/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+import * as aws from "@pulumi/aws-native";
+
+const logGroup = new aws.s3.Bucket("bucket", {
+    tags: [{
+        key: "foo",
+        value: "buzz", // <-- this value has changed
+    }]
+});

--- a/examples/update/step2/package.json
+++ b/examples/update/step2/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aws-update",
+  "devDependencies": {
+    "@types/node": "^8.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@pulumi/aws-native": "dev"
+  }
+}

--- a/examples/update/step2/tsconfig.json
+++ b/examples/update/step2/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/pkg/schema/convert.go
+++ b/provider/pkg/schema/convert.go
@@ -3,14 +3,12 @@
 package schema
 
 import (
-	"encoding/json"
 	"reflect"
 	"strings"
 
 	"github.com/mattbaird/jsonpatch"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // SdkToCfn converts Pulumi-SDK-shaped state to CloudFormation-shaped payload. In particular, SDK properties
@@ -132,9 +130,7 @@ func (c *sdkToCfnConverter) valueToPatch(opName, propName string, prop pschema.P
 	default:
 		sdkObj := value.MapRepl(nil, nil)
 		cfnObj := c.sdkTypedValueToCfn(&prop.TypeSpec, sdkObj)
-		jsonBytes, err := json.Marshal(cfnObj)
-		contract.AssertNoError(err)
-		op.Value = string(jsonBytes)
+		op.Value = cfnObj
 	}
 	return op
 }

--- a/provider/pkg/schema/convert_test.go
+++ b/provider/pkg/schema/convert_test.go
@@ -50,7 +50,12 @@ func TestDiffToPatch(t *testing.T) {
 		jsonpatch.NewPatch("replace", "/EnableECSManagedTags", true),
 		jsonpatch.NewPatch("add", "/LaunchType", "FARGATE"),
 		jsonpatch.NewPatch("replace", "/LoadBalancers",
-			"[{\"ContainerName\":\"my-app\",\"ContainerPort\":80}]"),
+			[]interface{}{
+				map[string]interface{}{
+					"ContainerName": "my-app",
+					"ContainerPort": 80.,
+				},
+		}),
 		jsonpatch.NewPatch("remove", "/PlatformVersion", nil),
 	}
 	res := sampleSchema.Resources["aws-native:ecs:Service"]


### PR DESCRIPTION
Fix #230

Not sure why we previously decided to serialize complex diffs to a string, but Cloud Control doesn't seem to be happy about that. I added an update test to make sure the target scenario works end-to-end. If we find a case when the approach doesn't work, let's extend that test.