### PR TITLE
Add VSCode settings for Go

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "go.buildTags": "all",
+    "go.testTimeout": "1h",
+    "gopls": {
+        // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
+        "build.directoryFilters": [
+            "-sdk/dotnet/",
+            "-sdk/nodejs/",
+            "-sdk/python/"
+        ],
+        // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
+        "experimentalWorkspaceModule": true,
+    },
+}


### PR DESCRIPTION
- Enable multiple modules in the workspace.
- Disable go checking the non-go SDK folders.