### PR TITLE
Raise errors during example files walk

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -47,6 +47,8 @@ jobs:
           if ! git diff-files --quiet; then
             echo ::set-output name=changes::1
           fi
+      - name: Initialize submodules
+        run: make init_submodules
       - name: Build codegen binaries
         if: steps.gomod.outputs.changes != 0
         run: make codegen

--- a/provider/cmd/pulumi-gen-aws-native/examples.go
+++ b/provider/cmd/pulumi-gen-aws-native/examples.go
@@ -166,6 +166,9 @@ func generateExample(yaml string, metadata *pschema.CloudAPIMetadata, languages 
 func findAllExamples(folder string) ([]string, error) {
 	var fileNames, result []string
 	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() && strings.Contains(path, "aws-resource-") {
 			fileNames = append(fileNames, path)
 		}


### PR DESCRIPTION
Errors are passed to the callback to allow ignoring of individual errors. In the case of an error the path and info might be nil so we need to check for the error first. This should give us more information on the failure rather than panicking.

Init submodules during weekly updates before attempting to generate the docs.