### PR TITLE
Use TypeScript package from Yarn, not global

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build_nodejs:: VERSION := $(shell pulumictl get version --language javascript)
 build_nodejs::
 	cd ${PACKDIR}/nodejs/ && \
 		yarn install && \
-		tsc && \
+		yarn run build && \
 		cp ../../README.md ../../LICENSE package.json yarn.lock ./bin/ && \
 		sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./bin/package.json
 


### PR DESCRIPTION
See #316.

The `tsc` command on line 71 will always use a globally installed TypeScript, regardless of the one installed by yarn on the previous line.

