### PR TITLE
Use sequence numbers for autonames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## HEAD (Unreleased)
 
 - Update Pulumi dependencies to v3.23.0
+- Use sequence numbers to generate deterministic autonames.
+  [#341](https://github.com/pulumi/pulumi-aws-native/pull/341)
 
 ---
 

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -27,6 +28,7 @@ import (
 // Defaults to the name followed by 7 random hex characters separated by a '-'.
 func getDefaultName(
 	urn resource.URN,
+	sequenceNumber int,
 	autoNamingSpec *schema.AutoNamingSpec,
 	olds,
 	news resource.PropertyMap,
@@ -67,7 +69,7 @@ func getDefaultName(
 	}
 
 	// Resource name is URN name + "-" + random suffix.
-	random, err := resource.NewUniqueHex(prefix, randLength, maxLength)
+	random, err := resource.NewUniqueHexV2(urn, sequenceNumber, prefix, randLength, maxLength)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -66,13 +66,13 @@ func Test_getDefaultName(t *testing.T) {
 	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		doTest := func(t *testing.T, sequenceNumber int) {
 			autoNamingSpec := &schema.AutoNamingSpec{
 				SdkName:   "autoName",
 				MinLength: tt.minLength,
 				MaxLength: tt.maxLength,
 			}
-			got, err := getDefaultName(urn, autoNamingSpec, tt.olds, tt.news)
+			got, err := getDefaultName(urn, sequenceNumber, autoNamingSpec, tt.olds, tt.news)
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
@@ -83,7 +83,10 @@ func Test_getDefaultName(t *testing.T) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", got, autoNamingSpec)
 			}
 			t.Logf("getDefaultName() = %v for spec: %+v", got, autoNamingSpec)
-		})
+		}
+
+		t.Run(tt.name+" with no sequence number", func(t *testing.T) { doTest(t, 0) })
+		t.Run(tt.name+" with sequence number", func(t *testing.T) { doTest(t, 1) })
 	}
 }
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -542,7 +542,7 @@ func (p *cfnProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*
 
 	if autoNamingSpec := spec.AutoNamingSpec; autoNamingSpec != nil {
 		// Auto-name fields if not already specified
-		val, err := getDefaultName(urn, autoNamingSpec, olds, newInputs)
+		val, err := getDefaultName(urn, int(req.GetSequenceNumber()), autoNamingSpec, olds, newInputs)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Nicely you can see that this is deterministic from the test output:
```
=== RUN   Test_getDefaultName/Name_specified_explicitly_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {newName} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Name_specified_explicitly_with_sequence_number
    ids_test.go:85: getDefaultName() = {newName} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Use_old_name_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {oldName} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Use_old_name_with_sequence_number
    ids_test.go:85: getDefaultName() = {oldName} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Autoname_with_defaults_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {myName-063c094} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Autoname_with_defaults_with_sequence_number
    ids_test.go:85: getDefaultName() = {myName-c805b80} for spec: &{SdkName:autoName MinLength:0 MaxLength:0}
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_max_length_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {myName-56217} for spec: &{SdkName:autoName MinLength:0 MaxLength:12}
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_max_length_with_sequence_number
    ids_test.go:85: getDefaultName() = {myName-c805b} for spec: &{SdkName:autoName MinLength:0 MaxLength:12}
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_min_length_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {myName-8caf7ee7} for spec: &{SdkName:autoName MinLength:15 MaxLength:0}
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_min_length_with_sequence_number
    ids_test.go:85: getDefaultName() = {myName-c805b800} for spec: &{SdkName:autoName MinLength:15 MaxLength:0}
=== RUN   Test_getDefaultName/Autoname_with_max_length_too_small_with_no_sequence_number
=== RUN   Test_getDefaultName/Autoname_with_max_length_too_small_with_sequence_number
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_min_and_max_length_with_no_sequence_number
    ids_test.go:85: getDefaultName() = {myName-853c60} for spec: &{SdkName:autoName MinLength:13 MaxLength:13}
=== RUN   Test_getDefaultName/Autoname_with_constraints_on_min_and_max_length_with_sequence_number
    ids_test.go:85: getDefaultName() = {myName-c805b8} for spec: &{SdkName:autoName MinLength:13 MaxLength:13}
```

All the "with_sequence_number" tests result in c805b800 or a substring of that.