### PR TITLE
[internal] Change publish steps to happen on macos

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -250,7 +250,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         goversion: [ 1.16.x ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
   publish:
     name: publish
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         goversion: [1.16.x]


### PR DESCRIPTION
rjeczalik/notify canoot cross compile for darwin so we need to
compile on darwin - https://github.com/rjeczalik/notify/issues/181
