### PR TITLE
[provider] Implement getUrlSuffix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## HEAD (Unreleased)
 
-_(none)_
+- Implement support for getUrlSuffix.
+  [#456](https://github.com/pulumi/pulumi-aws-native/pull/456)
 
 ---
 

--- a/provider/pkg/provider/partitions.go
+++ b/provider/pkg/provider/partitions.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"regexp"
+)
+
+type partition struct {
+	ID          string
+	URLSuffix   string
+	RegionRegex *regexp.Regexp
+}
+
+var partitions = []partition{
+	{
+		ID:          "aws",
+		URLSuffix:   "amazonaws.com",
+		RegionRegex: regexp.MustCompile("^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$"),
+	},
+	{
+		ID:          "aws-cn",
+		URLSuffix:   "amazonaws.com.cn",
+		RegionRegex: regexp.MustCompile("^cn\\-\\w+\\-\\d+$"),
+	},
+	{
+		ID:          "aws-us-gov",
+		URLSuffix:   "amazonaws.com",
+		RegionRegex: regexp.MustCompile("^us\\-gov\\-\\w+\\-\\d+$"),
+	},
+	{
+		ID:          "aws-iso",
+		URLSuffix:   "c2s.ic.gov",
+		RegionRegex: regexp.MustCompile("^us\\-iso\\-\\w+\\-\\d+$"),
+	},
+	{
+		ID:          "aws-iso-b",
+		URLSuffix:   "sc2s.sgov.gov",
+		RegionRegex: regexp.MustCompile("^us\\-isob\\-\\w+\\-\\d+$"),
+	},
+}
+
+func getPartition(region string) partition {
+	for _, p := range partitions {
+		if p.RegionRegex.MatchString(region) {
+			return p
+		}
+	}
+	return partitions[0]
+}

--- a/provider/pkg/provider/partitions_test.go
+++ b/provider/pkg/provider/partitions_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPartition(t *testing.T) {
+	cases := []struct {
+		region      string
+		partitionID string
+	}{
+		{
+			region:      "us-west-2",
+			partitionID: "aws",
+		},
+		{
+			region:      "us-east-1",
+			partitionID: "aws",
+		},
+		{
+			region:      "cn-north-1",
+			partitionID: "aws-cn",
+		},
+		{
+			region:      "us-gov-west-1",
+			partitionID: "aws-us-gov",
+		},
+		{
+			region:      "us-iso-east-1",
+			partitionID: "aws-iso",
+		},
+		{
+			region:      "us-isob-east-1",
+			partitionID: "aws-iso-b",
+		},
+	}
+	for _, c := range cases {
+		p := getPartition(c.region)
+		assert.Equal(t, c.partitionID, p.ID)
+	}
+}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -85,6 +85,7 @@ type cfnProvider struct {
 	version      string
 	accountID    string
 	region       string
+	partition    partition
 	resourceMap  *schema.CloudAPIMetadata
 	pulumiSchema []byte
 
@@ -270,7 +271,7 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 	if region, ok := varsOrEnv(vars, "aws-native:config:region", "AWS_REGION", "AWS_DEFAULT_REGION"); ok {
 		glog.V(4).Infof("using AWS region: %q", region)
 		loadOptions = append(loadOptions, config.WithRegion(region))
-		p.region = region
+		p.region, p.partition = region, getPartition(region)
 	} else {
 		return nil, errors.New("missing required configuration key \"aws-native:region\":" +
 			"The region where AWS operations will take place. Examples are eu-east-1, eu-west-2, etc.\n" +
@@ -410,6 +411,7 @@ var functions = map[string]func(*cfnProvider, context.Context, resource.Property
 	"aws-native:index:getAccountId":          (*cfnProvider).getAccountID,
 	"aws-native:index:getAzs":                (*cfnProvider).getAZs,
 	"aws-native:index:getRegion":             (*cfnProvider).getRegion,
+	"aws-native:index:getUrlSuffix":          (*cfnProvider).getURLSuffix,
 	"aws-native:index:cidr":                  (*cfnProvider).cidr,
 	"aws-native:index:getSsmParameterString": (*cfnProvider).getSSMParameterString,
 	"aws-native:index:getSsmParameterList":   (*cfnProvider).getSSMParameterList,

--- a/provider/pkg/provider/provider_pseudo_parameters.go
+++ b/provider/pkg/provider/provider_pseudo_parameters.go
@@ -14,6 +14,12 @@ func (p *cfnProvider) getAccountID(ctx context.Context, inputs resource.Property
 	}), nil
 }
 
+func (p *cfnProvider) getURLSuffix(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+	return resource.NewPropertyMapFromMap(map[string]interface{}{
+		"urlSuffix": p.partition.URLSuffix,
+	}), nil
+}
+
 func (p *cfnProvider) getRegion(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	return resource.NewPropertyMapFromMap(map[string]interface{}{
 		"region": p.region,


### PR DESCRIPTION
Keep a mapping from regions to partitions and partitions to URL
suffixes and discover the partition for the configured region during
startup time. getUrlSuffix then returns the URL suffix for the
configured partition.