### PR TITLE
Ensure that all create-only properties are inputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - Implement support for getUrlSuffix.
   [#456](https://github.com/pulumi/pulumi-aws-native/pull/456)
 
+- Ensure that all create-only properties are captured as input properties.
+  [#466](https://github.com/pulumi/pulumi-aws-native/pull/466)
+
 ---
 
 ## 0.15.0 (Apr 06, 2022)

--- a/provider/cmd/pulumi-resource-aws-native/metadata.json
+++ b/provider/cmd/pulumi-resource-aws-native/metadata.json
@@ -2886,6 +2886,14 @@
                 },
                 "description": {
                     "type": "string"
+                },
+                "domainName": {
+                    "type": "string",
+                    "language": {
+                        "csharp": {
+                            "name": "DomainNameValue"
+                        }
+                    }
                 }
             },
             "outputs": {
@@ -2911,7 +2919,8 @@
                 }
             },
             "required": [
-                "certificateArn"
+                "certificateArn",
+                "domainName"
             ],
             "createOnly": [
                 "certificateArn",
@@ -5986,6 +5995,10 @@
                     "type": "string",
                     "description": "The name of the domain."
                 },
+                "encryptionKey": {
+                    "type": "string",
+                    "description": "The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain."
+                },
                 "permissionsPolicyDocument": {
                     "$ref": "pulumi.json#/Any",
                     "description": "The access control resource policy on the provided domain."
@@ -6047,6 +6060,14 @@
                 "description": {
                     "type": "string",
                     "description": "A text description of the repository."
+                },
+                "domainName": {
+                    "type": "string",
+                    "description": "The name of the domain that contains the repository."
+                },
+                "domainOwner": {
+                    "type": "string",
+                    "description": "The 12-digit account ID of the AWS account that owns the domain."
                 },
                 "externalConnections": {
                     "type": "array",
@@ -6134,6 +6155,9 @@
                 "minLength": 2,
                 "maxLength": 100
             },
+            "required": [
+                "domainName"
+            ],
             "createOnly": [
                 "domainName",
                 "domainOwner",
@@ -14595,6 +14619,9 @@
         "aws-native:events:Archive": {
             "cf": "AWS::Events::Archive",
             "inputs": {
+                "archiveName": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -14627,6 +14654,11 @@
                 "sourceArn": {
                     "type": "string"
                 }
+            },
+            "autoNamingSpec": {
+                "sdkName": "archiveName",
+                "minLength": 1,
+                "maxLength": 48
             },
             "required": [
                 "sourceArn"
@@ -33614,6 +33646,10 @@
                     "type": "string",
                     "description": "The name of the bucket that you want to associate this Access Point with."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name."
+                },
                 "policy": {
                     "$ref": "pulumi.json#/Any",
                     "description": "The Access Point Policy you want to apply to this access point."
@@ -33666,6 +33702,11 @@
                     "$ref": "#/types/aws-native:s3:AccessPointVpcConfiguration",
                     "description": "If you include this field, Amazon S3 restricts access to this Access Point to requests from the specified Virtual Private Cloud (VPC)."
                 }
+            },
+            "autoNamingSpec": {
+                "sdkName": "name",
+                "minLength": 3,
+                "maxLength": 50
             },
             "required": [
                 "bucket"
@@ -36733,6 +36774,9 @@
                 "syncFormat": {
                     "type": "string"
                 },
+                "syncName": {
+                    "type": "string"
+                },
                 "syncSource": {
                     "$ref": "#/types/aws-native:ssm:ResourceDataSyncSyncSource"
                 },
@@ -36769,6 +36813,9 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "syncName"
+            ],
             "createOnly": [
                 "bucketName",
                 "bucketPrefix",

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -685,7 +685,7 @@ func (ctx *context) gatherResourceType() error {
 			return err
 		}
 		properties[sdkName] = *propertySpec
-		if !readOnlyProperties.Has(prop) {
+		if createOnlyProperties.Has(sdkName) || !readOnlyProperties.Has(prop) {
 			inputProperties[sdkName] = *propertySpec
 		}
 	}

--- a/sdk/dotnet/AppSync/DomainName.cs
+++ b/sdk/dotnet/AppSync/DomainName.cs
@@ -81,6 +81,9 @@ namespace Pulumi.AwsNative.AppSync
         [Input("description")]
         public Input<string>? Description { get; set; }
 
+        [Input("domainName", required: true)]
+        public Input<string> DomainNameValue { get; set; } = null!;
+
         public DomainNameArgs()
         {
         }

--- a/sdk/dotnet/CodeArtifact/Domain.cs
+++ b/sdk/dotnet/CodeArtifact/Domain.cs
@@ -109,6 +109,12 @@ namespace Pulumi.AwsNative.CodeArtifact
         public Input<string>? DomainName { get; set; }
 
         /// <summary>
+        /// The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
+        /// </summary>
+        [Input("encryptionKey")]
+        public Input<string>? EncryptionKey { get; set; }
+
+        /// <summary>
         /// The access control resource policy on the provided domain.
         /// </summary>
         [Input("permissionsPolicyDocument")]

--- a/sdk/dotnet/CodeArtifact/Repository.cs
+++ b/sdk/dotnet/CodeArtifact/Repository.cs
@@ -83,7 +83,7 @@ namespace Pulumi.AwsNative.CodeArtifact
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Repository(string name, RepositoryArgs? args = null, CustomResourceOptions? options = null)
+        public Repository(string name, RepositoryArgs args, CustomResourceOptions? options = null)
             : base("aws-native:codeartifact:Repository", name, args ?? new RepositoryArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -125,6 +125,18 @@ namespace Pulumi.AwsNative.CodeArtifact
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// The name of the domain that contains the repository.
+        /// </summary>
+        [Input("domainName", required: true)]
+        public Input<string> DomainName { get; set; } = null!;
+
+        /// <summary>
+        /// The 12-digit account ID of the AWS account that owns the domain.
+        /// </summary>
+        [Input("domainOwner")]
+        public Input<string>? DomainOwner { get; set; }
 
         [Input("externalConnections")]
         private InputList<string>? _externalConnections;

--- a/sdk/dotnet/ElastiCache/ReplicationGroup.cs
+++ b/sdk/dotnet/ElastiCache/ReplicationGroup.cs
@@ -331,6 +331,9 @@ namespace Pulumi.AwsNative.ElastiCache
         [Input("replicationGroupDescription", required: true)]
         public Input<string> ReplicationGroupDescription { get; set; } = null!;
 
+        [Input("replicationGroupId")]
+        public Input<string>? ReplicationGroupId { get; set; }
+
         [Input("securityGroupIds")]
         private InputList<string>? _securityGroupIds;
         public InputList<string> SecurityGroupIds

--- a/sdk/dotnet/Events/Archive.cs
+++ b/sdk/dotnet/Events/Archive.cs
@@ -78,6 +78,9 @@ namespace Pulumi.AwsNative.Events
 
     public sealed class ArchiveArgs : Pulumi.ResourceArgs
     {
+        [Input("archiveName")]
+        public Input<string>? ArchiveName { get; set; }
+
         [Input("description")]
         public Input<string>? Description { get; set; }
 

--- a/sdk/dotnet/GuardDuty/Master.cs
+++ b/sdk/dotnet/GuardDuty/Master.cs
@@ -76,6 +76,9 @@ namespace Pulumi.AwsNative.GuardDuty
         [Input("invitationId")]
         public Input<string>? InvitationId { get; set; }
 
+        [Input("masterId", required: true)]
+        public Input<string> MasterId { get; set; } = null!;
+
         public MasterArgs()
         {
         }

--- a/sdk/dotnet/GuardDuty/Member.cs
+++ b/sdk/dotnet/GuardDuty/Member.cs
@@ -88,6 +88,9 @@ namespace Pulumi.AwsNative.GuardDuty
         [Input("email", required: true)]
         public Input<string> Email { get; set; } = null!;
 
+        [Input("memberId", required: true)]
+        public Input<string> MemberId { get; set; } = null!;
+
         [Input("message")]
         public Input<string>? Message { get; set; }
 

--- a/sdk/dotnet/IoT1Click/Device.cs
+++ b/sdk/dotnet/IoT1Click/Device.cs
@@ -70,6 +70,9 @@ namespace Pulumi.AwsNative.IoT1Click
 
     public sealed class DeviceArgs : Pulumi.ResourceArgs
     {
+        [Input("deviceId", required: true)]
+        public Input<string> DeviceId { get; set; } = null!;
+
         [Input("enabled", required: true)]
         public Input<bool> Enabled { get; set; } = null!;
 

--- a/sdk/dotnet/S3/AccessPoint.cs
+++ b/sdk/dotnet/S3/AccessPoint.cs
@@ -118,6 +118,12 @@ namespace Pulumi.AwsNative.S3
         public Input<string> Bucket { get; set; } = null!;
 
         /// <summary>
+        /// The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
+        /// </summary>
+        [Input("name")]
+        public Input<string>? Name { get; set; }
+
+        /// <summary>
         /// The Access Point Policy you want to apply to this access point.
         /// </summary>
         [Input("policy")]

--- a/sdk/dotnet/SSM/ResourceDataSync.cs
+++ b/sdk/dotnet/SSM/ResourceDataSync.cs
@@ -50,7 +50,7 @@ namespace Pulumi.AwsNative.SSM
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public ResourceDataSync(string name, ResourceDataSyncArgs? args = null, CustomResourceOptions? options = null)
+        public ResourceDataSync(string name, ResourceDataSyncArgs args, CustomResourceOptions? options = null)
             : base("aws-native:ssm:ResourceDataSync", name, args ?? new ResourceDataSyncArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -104,6 +104,9 @@ namespace Pulumi.AwsNative.SSM
 
         [Input("syncFormat")]
         public Input<string>? SyncFormat { get; set; }
+
+        [Input("syncName", required: true)]
+        public Input<string> SyncName { get; set; } = null!;
 
         [Input("syncSource")]
         public Input<Inputs.ResourceDataSyncSyncSourceArgs>? SyncSource { get; set; }

--- a/sdk/dotnet/ServiceDiscovery/Instance.cs
+++ b/sdk/dotnet/ServiceDiscovery/Instance.cs
@@ -73,6 +73,9 @@ namespace Pulumi.AwsNative.ServiceDiscovery
         [Input("instanceAttributes", required: true)]
         public Input<object> InstanceAttributes { get; set; } = null!;
 
+        [Input("instanceId")]
+        public Input<string>? InstanceId { get; set; }
+
         [Input("serviceId", required: true)]
         public Input<string> ServiceId { get; set; } = null!;
 

--- a/sdk/go/aws/appsync/domainName.go
+++ b/sdk/go/aws/appsync/domainName.go
@@ -32,6 +32,9 @@ func NewDomainName(ctx *pulumi.Context,
 	if args.CertificateArn == nil {
 		return nil, errors.New("invalid value for required argument 'CertificateArn'")
 	}
+	if args.DomainName == nil {
+		return nil, errors.New("invalid value for required argument 'DomainName'")
+	}
 	var resource DomainName
 	err := ctx.RegisterResource("aws-native:appsync:DomainName", name, args, &resource, opts...)
 	if err != nil {
@@ -66,12 +69,14 @@ func (DomainNameState) ElementType() reflect.Type {
 type domainNameArgs struct {
 	CertificateArn string  `pulumi:"certificateArn"`
 	Description    *string `pulumi:"description"`
+	DomainName     string  `pulumi:"domainName"`
 }
 
 // The set of arguments for constructing a DomainName resource.
 type DomainNameArgs struct {
 	CertificateArn pulumi.StringInput
 	Description    pulumi.StringPtrInput
+	DomainName     pulumi.StringInput
 }
 
 func (DomainNameArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/codeartifact/domain.go
+++ b/sdk/go/aws/codeartifact/domain.go
@@ -71,6 +71,8 @@ func (DomainState) ElementType() reflect.Type {
 type domainArgs struct {
 	// The name of the domain.
 	DomainName *string `pulumi:"domainName"`
+	// The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
+	EncryptionKey *string `pulumi:"encryptionKey"`
 	// The access control resource policy on the provided domain.
 	PermissionsPolicyDocument interface{} `pulumi:"permissionsPolicyDocument"`
 	// An array of key-value pairs to apply to this resource.
@@ -81,6 +83,8 @@ type domainArgs struct {
 type DomainArgs struct {
 	// The name of the domain.
 	DomainName pulumi.StringPtrInput
+	// The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
+	EncryptionKey pulumi.StringPtrInput
 	// The access control resource policy on the provided domain.
 	PermissionsPolicyDocument pulumi.Input
 	// An array of key-value pairs to apply to this resource.

--- a/sdk/go/aws/codeartifact/repository.go
+++ b/sdk/go/aws/codeartifact/repository.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -40,9 +41,12 @@ type Repository struct {
 func NewRepository(ctx *pulumi.Context,
 	name string, args *RepositoryArgs, opts ...pulumi.ResourceOption) (*Repository, error) {
 	if args == nil {
-		args = &RepositoryArgs{}
+		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.DomainName == nil {
+		return nil, errors.New("invalid value for required argument 'DomainName'")
+	}
 	var resource Repository
 	err := ctx.RegisterResource("aws-native:codeartifact:Repository", name, args, &resource, opts...)
 	if err != nil {
@@ -77,6 +81,10 @@ func (RepositoryState) ElementType() reflect.Type {
 type repositoryArgs struct {
 	// A text description of the repository.
 	Description *string `pulumi:"description"`
+	// The name of the domain that contains the repository.
+	DomainName string `pulumi:"domainName"`
+	// The 12-digit account ID of the AWS account that owns the domain.
+	DomainOwner *string `pulumi:"domainOwner"`
 	// A list of external connections associated with the repository.
 	ExternalConnections []string `pulumi:"externalConnections"`
 	// The access control resource policy on the provided repository.
@@ -93,6 +101,10 @@ type repositoryArgs struct {
 type RepositoryArgs struct {
 	// A text description of the repository.
 	Description pulumi.StringPtrInput
+	// The name of the domain that contains the repository.
+	DomainName pulumi.StringInput
+	// The 12-digit account ID of the AWS account that owns the domain.
+	DomainOwner pulumi.StringPtrInput
 	// A list of external connections associated with the repository.
 	ExternalConnections pulumi.StringArrayInput
 	// The access control resource policy on the provided repository.

--- a/sdk/go/aws/elasticache/replicationGroup.go
+++ b/sdk/go/aws/elasticache/replicationGroup.go
@@ -141,6 +141,7 @@ type replicationGroupArgs struct {
 	ReaderEndPointPort           *string                                           `pulumi:"readerEndPointPort"`
 	ReplicasPerNodeGroup         *int                                              `pulumi:"replicasPerNodeGroup"`
 	ReplicationGroupDescription  string                                            `pulumi:"replicationGroupDescription"`
+	ReplicationGroupId           *string                                           `pulumi:"replicationGroupId"`
 	SecurityGroupIds             []string                                          `pulumi:"securityGroupIds"`
 	SnapshotArns                 []string                                          `pulumi:"snapshotArns"`
 	SnapshotName                 *string                                           `pulumi:"snapshotName"`
@@ -189,6 +190,7 @@ type ReplicationGroupArgs struct {
 	ReaderEndPointPort           pulumi.StringPtrInput
 	ReplicasPerNodeGroup         pulumi.IntPtrInput
 	ReplicationGroupDescription  pulumi.StringInput
+	ReplicationGroupId           pulumi.StringPtrInput
 	SecurityGroupIds             pulumi.StringArrayInput
 	SnapshotArns                 pulumi.StringArrayInput
 	SnapshotName                 pulumi.StringPtrInput

--- a/sdk/go/aws/events/archive.go
+++ b/sdk/go/aws/events/archive.go
@@ -65,6 +65,7 @@ func (ArchiveState) ElementType() reflect.Type {
 }
 
 type archiveArgs struct {
+	ArchiveName   *string     `pulumi:"archiveName"`
 	Description   *string     `pulumi:"description"`
 	EventPattern  interface{} `pulumi:"eventPattern"`
 	RetentionDays *int        `pulumi:"retentionDays"`
@@ -73,6 +74,7 @@ type archiveArgs struct {
 
 // The set of arguments for constructing a Archive resource.
 type ArchiveArgs struct {
+	ArchiveName   pulumi.StringPtrInput
 	Description   pulumi.StringPtrInput
 	EventPattern  pulumi.Input
 	RetentionDays pulumi.IntPtrInput

--- a/sdk/go/aws/guardduty/master.go
+++ b/sdk/go/aws/guardduty/master.go
@@ -32,6 +32,9 @@ func NewMaster(ctx *pulumi.Context,
 	if args.DetectorId == nil {
 		return nil, errors.New("invalid value for required argument 'DetectorId'")
 	}
+	if args.MasterId == nil {
+		return nil, errors.New("invalid value for required argument 'MasterId'")
+	}
 	var resource Master
 	err := ctx.RegisterResource("aws-native:guardduty:Master", name, args, &resource, opts...)
 	if err != nil {
@@ -66,12 +69,14 @@ func (MasterState) ElementType() reflect.Type {
 type masterArgs struct {
 	DetectorId   string  `pulumi:"detectorId"`
 	InvitationId *string `pulumi:"invitationId"`
+	MasterId     string  `pulumi:"masterId"`
 }
 
 // The set of arguments for constructing a Master resource.
 type MasterArgs struct {
 	DetectorId   pulumi.StringInput
 	InvitationId pulumi.StringPtrInput
+	MasterId     pulumi.StringInput
 }
 
 func (MasterArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/guardduty/member.go
+++ b/sdk/go/aws/guardduty/member.go
@@ -38,6 +38,9 @@ func NewMember(ctx *pulumi.Context,
 	if args.Email == nil {
 		return nil, errors.New("invalid value for required argument 'Email'")
 	}
+	if args.MemberId == nil {
+		return nil, errors.New("invalid value for required argument 'MemberId'")
+	}
 	var resource Member
 	err := ctx.RegisterResource("aws-native:guardduty:Member", name, args, &resource, opts...)
 	if err != nil {
@@ -73,6 +76,7 @@ type memberArgs struct {
 	DetectorId               string  `pulumi:"detectorId"`
 	DisableEmailNotification *bool   `pulumi:"disableEmailNotification"`
 	Email                    string  `pulumi:"email"`
+	MemberId                 string  `pulumi:"memberId"`
 	Message                  *string `pulumi:"message"`
 	Status                   *string `pulumi:"status"`
 }
@@ -82,6 +86,7 @@ type MemberArgs struct {
 	DetectorId               pulumi.StringInput
 	DisableEmailNotification pulumi.BoolPtrInput
 	Email                    pulumi.StringInput
+	MemberId                 pulumi.StringInput
 	Message                  pulumi.StringPtrInput
 	Status                   pulumi.StringPtrInput
 }

--- a/sdk/go/aws/iot1click/device.go
+++ b/sdk/go/aws/iot1click/device.go
@@ -29,6 +29,9 @@ func NewDevice(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.DeviceId == nil {
+		return nil, errors.New("invalid value for required argument 'DeviceId'")
+	}
 	if args.Enabled == nil {
 		return nil, errors.New("invalid value for required argument 'Enabled'")
 	}
@@ -64,12 +67,14 @@ func (DeviceState) ElementType() reflect.Type {
 }
 
 type deviceArgs struct {
-	Enabled bool `pulumi:"enabled"`
+	DeviceId string `pulumi:"deviceId"`
+	Enabled  bool   `pulumi:"enabled"`
 }
 
 // The set of arguments for constructing a Device resource.
 type DeviceArgs struct {
-	Enabled pulumi.BoolInput
+	DeviceId pulumi.StringInput
+	Enabled  pulumi.BoolInput
 }
 
 func (DeviceArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/s3/accessPoint.go
+++ b/sdk/go/aws/s3/accessPoint.go
@@ -78,6 +78,8 @@ func (AccessPointState) ElementType() reflect.Type {
 type accessPointArgs struct {
 	// The name of the bucket that you want to associate this Access Point with.
 	Bucket string `pulumi:"bucket"`
+	// The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
+	Name *string `pulumi:"name"`
 	// The Access Point Policy you want to apply to this access point.
 	Policy       interface{}             `pulumi:"policy"`
 	PolicyStatus *PolicyStatusProperties `pulumi:"policyStatus"`
@@ -91,6 +93,8 @@ type accessPointArgs struct {
 type AccessPointArgs struct {
 	// The name of the bucket that you want to associate this Access Point with.
 	Bucket pulumi.StringInput
+	// The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
+	Name pulumi.StringPtrInput
 	// The Access Point Policy you want to apply to this access point.
 	Policy       pulumi.Input
 	PolicyStatus PolicyStatusPropertiesPtrInput

--- a/sdk/go/aws/servicediscovery/instance.go
+++ b/sdk/go/aws/servicediscovery/instance.go
@@ -68,12 +68,14 @@ func (InstanceState) ElementType() reflect.Type {
 
 type instanceArgs struct {
 	InstanceAttributes interface{} `pulumi:"instanceAttributes"`
+	InstanceId         *string     `pulumi:"instanceId"`
 	ServiceId          string      `pulumi:"serviceId"`
 }
 
 // The set of arguments for constructing a Instance resource.
 type InstanceArgs struct {
 	InstanceAttributes pulumi.Input
+	InstanceId         pulumi.StringPtrInput
 	ServiceId          pulumi.StringInput
 }
 

--- a/sdk/go/aws/ssm/resourceDataSync.go
+++ b/sdk/go/aws/ssm/resourceDataSync.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -29,9 +30,12 @@ type ResourceDataSync struct {
 func NewResourceDataSync(ctx *pulumi.Context,
 	name string, args *ResourceDataSyncArgs, opts ...pulumi.ResourceOption) (*ResourceDataSync, error) {
 	if args == nil {
-		args = &ResourceDataSyncArgs{}
+		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.SyncName == nil {
+		return nil, errors.New("invalid value for required argument 'SyncName'")
+	}
 	var resource ResourceDataSync
 	err := ctx.RegisterResource("aws-native:ssm:ResourceDataSync", name, args, &resource, opts...)
 	if err != nil {
@@ -70,6 +74,7 @@ type resourceDataSyncArgs struct {
 	KMSKeyArn     *string                        `pulumi:"kMSKeyArn"`
 	S3Destination *ResourceDataSyncS3Destination `pulumi:"s3Destination"`
 	SyncFormat    *string                        `pulumi:"syncFormat"`
+	SyncName      string                         `pulumi:"syncName"`
 	SyncSource    *ResourceDataSyncSyncSource    `pulumi:"syncSource"`
 	SyncType      *string                        `pulumi:"syncType"`
 }
@@ -82,6 +87,7 @@ type ResourceDataSyncArgs struct {
 	KMSKeyArn     pulumi.StringPtrInput
 	S3Destination ResourceDataSyncS3DestinationPtrInput
 	SyncFormat    pulumi.StringPtrInput
+	SyncName      pulumi.StringInput
 	SyncSource    ResourceDataSyncSyncSourcePtrInput
 	SyncType      pulumi.StringPtrInput
 }

--- a/sdk/nodejs/appsync/domainName.ts
+++ b/sdk/nodejs/appsync/domainName.ts
@@ -37,7 +37,7 @@ export class DomainName extends pulumi.CustomResource {
     public /*out*/ readonly appSyncDomainName!: pulumi.Output<string>;
     public readonly certificateArn!: pulumi.Output<string>;
     public readonly description!: pulumi.Output<string | undefined>;
-    public /*out*/ readonly domainName!: pulumi.Output<string>;
+    public readonly domainName!: pulumi.Output<string>;
     public /*out*/ readonly hostedZoneId!: pulumi.Output<string>;
 
     /**
@@ -54,10 +54,13 @@ export class DomainName extends pulumi.CustomResource {
             if ((!args || args.certificateArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'certificateArn'");
             }
+            if ((!args || args.domainName === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'domainName'");
+            }
             resourceInputs["certificateArn"] = args ? args.certificateArn : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
+            resourceInputs["domainName"] = args ? args.domainName : undefined;
             resourceInputs["appSyncDomainName"] = undefined /*out*/;
-            resourceInputs["domainName"] = undefined /*out*/;
             resourceInputs["hostedZoneId"] = undefined /*out*/;
         } else {
             resourceInputs["appSyncDomainName"] = undefined /*out*/;
@@ -77,4 +80,5 @@ export class DomainName extends pulumi.CustomResource {
 export interface DomainNameArgs {
     certificateArn: pulumi.Input<string>;
     description?: pulumi.Input<string>;
+    domainName: pulumi.Input<string>;
 }

--- a/sdk/nodejs/codeartifact/domain.ts
+++ b/sdk/nodejs/codeartifact/domain.ts
@@ -46,7 +46,7 @@ export class Domain extends pulumi.CustomResource {
     /**
      * The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
      */
-    public /*out*/ readonly encryptionKey!: pulumi.Output<string>;
+    public readonly encryptionKey!: pulumi.Output<string>;
     /**
      * The name of the domain. This field is used for GetAtt
      */
@@ -76,10 +76,10 @@ export class Domain extends pulumi.CustomResource {
         opts = opts || {};
         if (!opts.id) {
             resourceInputs["domainName"] = args ? args.domainName : undefined;
+            resourceInputs["encryptionKey"] = args ? args.encryptionKey : undefined;
             resourceInputs["permissionsPolicyDocument"] = args ? args.permissionsPolicyDocument : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["arn"] = undefined /*out*/;
-            resourceInputs["encryptionKey"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["owner"] = undefined /*out*/;
         } else {
@@ -104,6 +104,10 @@ export interface DomainArgs {
      * The name of the domain.
      */
     domainName?: pulumi.Input<string>;
+    /**
+     * The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
+     */
+    encryptionKey?: pulumi.Input<string>;
     /**
      * The access control resource policy on the provided domain.
      */

--- a/sdk/nodejs/codeartifact/repository.ts
+++ b/sdk/nodejs/codeartifact/repository.ts
@@ -46,11 +46,11 @@ export class Repository extends pulumi.CustomResource {
     /**
      * The name of the domain that contains the repository.
      */
-    public /*out*/ readonly domainName!: pulumi.Output<string>;
+    public readonly domainName!: pulumi.Output<string>;
     /**
      * The 12-digit account ID of the AWS account that owns the domain.
      */
-    public /*out*/ readonly domainOwner!: pulumi.Output<string>;
+    public readonly domainOwner!: pulumi.Output<string>;
     /**
      * A list of external connections associated with the repository.
      */
@@ -83,19 +83,22 @@ export class Repository extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args?: RepositoryArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: RepositoryArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.domainName === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'domainName'");
+            }
             resourceInputs["description"] = args ? args.description : undefined;
+            resourceInputs["domainName"] = args ? args.domainName : undefined;
+            resourceInputs["domainOwner"] = args ? args.domainOwner : undefined;
             resourceInputs["externalConnections"] = args ? args.externalConnections : undefined;
             resourceInputs["permissionsPolicyDocument"] = args ? args.permissionsPolicyDocument : undefined;
             resourceInputs["repositoryName"] = args ? args.repositoryName : undefined;
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["upstreams"] = args ? args.upstreams : undefined;
             resourceInputs["arn"] = undefined /*out*/;
-            resourceInputs["domainName"] = undefined /*out*/;
-            resourceInputs["domainOwner"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
         } else {
             resourceInputs["arn"] = undefined /*out*/;
@@ -122,6 +125,14 @@ export interface RepositoryArgs {
      * A text description of the repository.
      */
     description?: pulumi.Input<string>;
+    /**
+     * The name of the domain that contains the repository.
+     */
+    domainName: pulumi.Input<string>;
+    /**
+     * The 12-digit account ID of the AWS account that owns the domain.
+     */
+    domainOwner?: pulumi.Input<string>;
     /**
      * A list of external connections associated with the repository.
      */

--- a/sdk/nodejs/elasticache/replicationGroup.ts
+++ b/sdk/nodejs/elasticache/replicationGroup.ts
@@ -73,7 +73,7 @@ export class ReplicationGroup extends pulumi.CustomResource {
     public readonly readerEndPointPort!: pulumi.Output<string | undefined>;
     public readonly replicasPerNodeGroup!: pulumi.Output<number | undefined>;
     public readonly replicationGroupDescription!: pulumi.Output<string>;
-    public /*out*/ readonly replicationGroupId!: pulumi.Output<string>;
+    public readonly replicationGroupId!: pulumi.Output<string>;
     public readonly securityGroupIds!: pulumi.Output<string[] | undefined>;
     public readonly snapshotArns!: pulumi.Output<string[] | undefined>;
     public readonly snapshotName!: pulumi.Output<string | undefined>;
@@ -135,6 +135,7 @@ export class ReplicationGroup extends pulumi.CustomResource {
             resourceInputs["readerEndPointPort"] = args ? args.readerEndPointPort : undefined;
             resourceInputs["replicasPerNodeGroup"] = args ? args.replicasPerNodeGroup : undefined;
             resourceInputs["replicationGroupDescription"] = args ? args.replicationGroupDescription : undefined;
+            resourceInputs["replicationGroupId"] = args ? args.replicationGroupId : undefined;
             resourceInputs["securityGroupIds"] = args ? args.securityGroupIds : undefined;
             resourceInputs["snapshotArns"] = args ? args.snapshotArns : undefined;
             resourceInputs["snapshotName"] = args ? args.snapshotName : undefined;
@@ -144,7 +145,6 @@ export class ReplicationGroup extends pulumi.CustomResource {
             resourceInputs["tags"] = args ? args.tags : undefined;
             resourceInputs["transitEncryptionEnabled"] = args ? args.transitEncryptionEnabled : undefined;
             resourceInputs["userGroupIds"] = args ? args.userGroupIds : undefined;
-            resourceInputs["replicationGroupId"] = undefined /*out*/;
         } else {
             resourceInputs["atRestEncryptionEnabled"] = undefined /*out*/;
             resourceInputs["authToken"] = undefined /*out*/;
@@ -236,6 +236,7 @@ export interface ReplicationGroupArgs {
     readerEndPointPort?: pulumi.Input<string>;
     replicasPerNodeGroup?: pulumi.Input<number>;
     replicationGroupDescription: pulumi.Input<string>;
+    replicationGroupId?: pulumi.Input<string>;
     securityGroupIds?: pulumi.Input<pulumi.Input<string>[]>;
     snapshotArns?: pulumi.Input<pulumi.Input<string>[]>;
     snapshotName?: pulumi.Input<string>;

--- a/sdk/nodejs/events/archive.ts
+++ b/sdk/nodejs/events/archive.ts
@@ -34,7 +34,7 @@ export class Archive extends pulumi.CustomResource {
         return obj['__pulumiType'] === Archive.__pulumiType;
     }
 
-    public /*out*/ readonly archiveName!: pulumi.Output<string>;
+    public readonly archiveName!: pulumi.Output<string>;
     public /*out*/ readonly arn!: pulumi.Output<string>;
     public readonly description!: pulumi.Output<string | undefined>;
     public readonly eventPattern!: pulumi.Output<any | undefined>;
@@ -55,11 +55,11 @@ export class Archive extends pulumi.CustomResource {
             if ((!args || args.sourceArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'sourceArn'");
             }
+            resourceInputs["archiveName"] = args ? args.archiveName : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["eventPattern"] = args ? args.eventPattern : undefined;
             resourceInputs["retentionDays"] = args ? args.retentionDays : undefined;
             resourceInputs["sourceArn"] = args ? args.sourceArn : undefined;
-            resourceInputs["archiveName"] = undefined /*out*/;
             resourceInputs["arn"] = undefined /*out*/;
         } else {
             resourceInputs["archiveName"] = undefined /*out*/;
@@ -78,6 +78,7 @@ export class Archive extends pulumi.CustomResource {
  * The set of arguments for constructing a Archive resource.
  */
 export interface ArchiveArgs {
+    archiveName?: pulumi.Input<string>;
     description?: pulumi.Input<string>;
     eventPattern?: any;
     retentionDays?: pulumi.Input<number>;

--- a/sdk/nodejs/guardduty/master.ts
+++ b/sdk/nodejs/guardduty/master.ts
@@ -39,7 +39,7 @@ export class Master extends pulumi.CustomResource {
 
     public readonly detectorId!: pulumi.Output<string>;
     public readonly invitationId!: pulumi.Output<string | undefined>;
-    public /*out*/ readonly masterId!: pulumi.Output<string>;
+    public readonly masterId!: pulumi.Output<string>;
 
     /**
      * Create a Master resource with the given unique name, arguments, and options.
@@ -57,9 +57,12 @@ export class Master extends pulumi.CustomResource {
             if ((!args || args.detectorId === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'detectorId'");
             }
+            if ((!args || args.masterId === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'masterId'");
+            }
             resourceInputs["detectorId"] = args ? args.detectorId : undefined;
             resourceInputs["invitationId"] = args ? args.invitationId : undefined;
-            resourceInputs["masterId"] = undefined /*out*/;
+            resourceInputs["masterId"] = args ? args.masterId : undefined;
         } else {
             resourceInputs["detectorId"] = undefined /*out*/;
             resourceInputs["invitationId"] = undefined /*out*/;
@@ -76,4 +79,5 @@ export class Master extends pulumi.CustomResource {
 export interface MasterArgs {
     detectorId: pulumi.Input<string>;
     invitationId?: pulumi.Input<string>;
+    masterId: pulumi.Input<string>;
 }

--- a/sdk/nodejs/guardduty/member.ts
+++ b/sdk/nodejs/guardduty/member.ts
@@ -40,7 +40,7 @@ export class Member extends pulumi.CustomResource {
     public readonly detectorId!: pulumi.Output<string>;
     public readonly disableEmailNotification!: pulumi.Output<boolean | undefined>;
     public readonly email!: pulumi.Output<string>;
-    public /*out*/ readonly memberId!: pulumi.Output<string>;
+    public readonly memberId!: pulumi.Output<string>;
     public readonly message!: pulumi.Output<string | undefined>;
     public readonly status!: pulumi.Output<string | undefined>;
 
@@ -63,12 +63,15 @@ export class Member extends pulumi.CustomResource {
             if ((!args || args.email === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'email'");
             }
+            if ((!args || args.memberId === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'memberId'");
+            }
             resourceInputs["detectorId"] = args ? args.detectorId : undefined;
             resourceInputs["disableEmailNotification"] = args ? args.disableEmailNotification : undefined;
             resourceInputs["email"] = args ? args.email : undefined;
+            resourceInputs["memberId"] = args ? args.memberId : undefined;
             resourceInputs["message"] = args ? args.message : undefined;
             resourceInputs["status"] = args ? args.status : undefined;
-            resourceInputs["memberId"] = undefined /*out*/;
         } else {
             resourceInputs["detectorId"] = undefined /*out*/;
             resourceInputs["disableEmailNotification"] = undefined /*out*/;
@@ -89,6 +92,7 @@ export interface MemberArgs {
     detectorId: pulumi.Input<string>;
     disableEmailNotification?: pulumi.Input<boolean>;
     email: pulumi.Input<string>;
+    memberId: pulumi.Input<string>;
     message?: pulumi.Input<string>;
     status?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iot1click/device.ts
+++ b/sdk/nodejs/iot1click/device.ts
@@ -38,7 +38,7 @@ export class Device extends pulumi.CustomResource {
     }
 
     public /*out*/ readonly arn!: pulumi.Output<string>;
-    public /*out*/ readonly deviceId!: pulumi.Output<string>;
+    public readonly deviceId!: pulumi.Output<string>;
     public readonly enabled!: pulumi.Output<boolean>;
 
     /**
@@ -54,12 +54,15 @@ export class Device extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.deviceId === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'deviceId'");
+            }
             if ((!args || args.enabled === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'enabled'");
             }
+            resourceInputs["deviceId"] = args ? args.deviceId : undefined;
             resourceInputs["enabled"] = args ? args.enabled : undefined;
             resourceInputs["arn"] = undefined /*out*/;
-            resourceInputs["deviceId"] = undefined /*out*/;
         } else {
             resourceInputs["arn"] = undefined /*out*/;
             resourceInputs["deviceId"] = undefined /*out*/;
@@ -74,5 +77,6 @@ export class Device extends pulumi.CustomResource {
  * The set of arguments for constructing a Device resource.
  */
 export interface DeviceArgs {
+    deviceId: pulumi.Input<string>;
     enabled: pulumi.Input<boolean>;
 }

--- a/sdk/nodejs/s3/accessPoint.ts
+++ b/sdk/nodejs/s3/accessPoint.ts
@@ -50,7 +50,7 @@ export class AccessPoint extends pulumi.CustomResource {
     /**
      * The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
      */
-    public /*out*/ readonly name!: pulumi.Output<string>;
+    public readonly name!: pulumi.Output<string>;
     /**
      * Indicates whether this Access Point allows access from the public Internet. If VpcConfiguration is specified for this Access Point, then NetworkOrigin is VPC, and the Access Point doesn't allow access from the public Internet. Otherwise, NetworkOrigin is Internet, and the Access Point allows access from the public Internet, subject to the Access Point and bucket access policies.
      */
@@ -84,13 +84,13 @@ export class AccessPoint extends pulumi.CustomResource {
                 throw new Error("Missing required property 'bucket'");
             }
             resourceInputs["bucket"] = args ? args.bucket : undefined;
+            resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["policy"] = args ? args.policy : undefined;
             resourceInputs["policyStatus"] = args ? args.policyStatus : undefined;
             resourceInputs["publicAccessBlockConfiguration"] = args ? args.publicAccessBlockConfiguration : undefined;
             resourceInputs["vpcConfiguration"] = args ? args.vpcConfiguration : undefined;
             resourceInputs["alias"] = undefined /*out*/;
             resourceInputs["arn"] = undefined /*out*/;
-            resourceInputs["name"] = undefined /*out*/;
             resourceInputs["networkOrigin"] = undefined /*out*/;
         } else {
             resourceInputs["alias"] = undefined /*out*/;
@@ -116,6 +116,10 @@ export interface AccessPointArgs {
      * The name of the bucket that you want to associate this Access Point with.
      */
     bucket: pulumi.Input<string>;
+    /**
+     * The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
+     */
+    name?: pulumi.Input<string>;
     /**
      * The Access Point Policy you want to apply to this access point.
      */

--- a/sdk/nodejs/servicediscovery/instance.ts
+++ b/sdk/nodejs/servicediscovery/instance.ts
@@ -38,7 +38,7 @@ export class Instance extends pulumi.CustomResource {
     }
 
     public readonly instanceAttributes!: pulumi.Output<any>;
-    public /*out*/ readonly instanceId!: pulumi.Output<string>;
+    public readonly instanceId!: pulumi.Output<string>;
     public readonly serviceId!: pulumi.Output<string>;
 
     /**
@@ -61,8 +61,8 @@ export class Instance extends pulumi.CustomResource {
                 throw new Error("Missing required property 'serviceId'");
             }
             resourceInputs["instanceAttributes"] = args ? args.instanceAttributes : undefined;
+            resourceInputs["instanceId"] = args ? args.instanceId : undefined;
             resourceInputs["serviceId"] = args ? args.serviceId : undefined;
-            resourceInputs["instanceId"] = undefined /*out*/;
         } else {
             resourceInputs["instanceAttributes"] = undefined /*out*/;
             resourceInputs["instanceId"] = undefined /*out*/;
@@ -78,5 +78,6 @@ export class Instance extends pulumi.CustomResource {
  */
 export interface InstanceArgs {
     instanceAttributes: any;
+    instanceId?: pulumi.Input<string>;
     serviceId: pulumi.Input<string>;
 }

--- a/sdk/nodejs/ssm/resourceDataSync.ts
+++ b/sdk/nodejs/ssm/resourceDataSync.ts
@@ -41,7 +41,7 @@ export class ResourceDataSync extends pulumi.CustomResource {
     public readonly kMSKeyArn!: pulumi.Output<string | undefined>;
     public readonly s3Destination!: pulumi.Output<outputs.ssm.ResourceDataSyncS3Destination | undefined>;
     public readonly syncFormat!: pulumi.Output<string | undefined>;
-    public /*out*/ readonly syncName!: pulumi.Output<string>;
+    public readonly syncName!: pulumi.Output<string>;
     public readonly syncSource!: pulumi.Output<outputs.ssm.ResourceDataSyncSyncSource | undefined>;
     public readonly syncType!: pulumi.Output<string | undefined>;
 
@@ -52,19 +52,22 @@ export class ResourceDataSync extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args?: ResourceDataSyncArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: ResourceDataSyncArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.syncName === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'syncName'");
+            }
             resourceInputs["bucketName"] = args ? args.bucketName : undefined;
             resourceInputs["bucketPrefix"] = args ? args.bucketPrefix : undefined;
             resourceInputs["bucketRegion"] = args ? args.bucketRegion : undefined;
             resourceInputs["kMSKeyArn"] = args ? args.kMSKeyArn : undefined;
             resourceInputs["s3Destination"] = args ? args.s3Destination : undefined;
             resourceInputs["syncFormat"] = args ? args.syncFormat : undefined;
+            resourceInputs["syncName"] = args ? args.syncName : undefined;
             resourceInputs["syncSource"] = args ? args.syncSource : undefined;
             resourceInputs["syncType"] = args ? args.syncType : undefined;
-            resourceInputs["syncName"] = undefined /*out*/;
         } else {
             resourceInputs["bucketName"] = undefined /*out*/;
             resourceInputs["bucketPrefix"] = undefined /*out*/;
@@ -91,6 +94,7 @@ export interface ResourceDataSyncArgs {
     kMSKeyArn?: pulumi.Input<string>;
     s3Destination?: pulumi.Input<inputs.ssm.ResourceDataSyncS3DestinationArgs>;
     syncFormat?: pulumi.Input<string>;
+    syncName: pulumi.Input<string>;
     syncSource?: pulumi.Input<inputs.ssm.ResourceDataSyncSyncSourceArgs>;
     syncType?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_aws_native/appsync/domain_name.py
+++ b/sdk/python/pulumi_aws_native/appsync/domain_name.py
@@ -14,11 +14,13 @@ __all__ = ['DomainNameArgs', 'DomainName']
 class DomainNameArgs:
     def __init__(__self__, *,
                  certificate_arn: pulumi.Input[str],
+                 domain_name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a DomainName resource.
         """
         pulumi.set(__self__, "certificate_arn", certificate_arn)
+        pulumi.set(__self__, "domain_name", domain_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
 
@@ -30,6 +32,15 @@ class DomainNameArgs:
     @certificate_arn.setter
     def certificate_arn(self, value: pulumi.Input[str]):
         pulumi.set(self, "certificate_arn", value)
+
+    @property
+    @pulumi.getter(name="domainName")
+    def domain_name(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "domain_name")
+
+    @domain_name.setter
+    def domain_name(self, value: pulumi.Input[str]):
+        pulumi.set(self, "domain_name", value)
 
     @property
     @pulumi.getter
@@ -48,6 +59,7 @@ class DomainName(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 domain_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Resource Type definition for AWS::AppSync::DomainName
@@ -81,6 +93,7 @@ class DomainName(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  certificate_arn: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 domain_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
@@ -97,8 +110,10 @@ class DomainName(pulumi.CustomResource):
                 raise TypeError("Missing required property 'certificate_arn'")
             __props__.__dict__["certificate_arn"] = certificate_arn
             __props__.__dict__["description"] = description
+            if domain_name is None and not opts.urn:
+                raise TypeError("Missing required property 'domain_name'")
+            __props__.__dict__["domain_name"] = domain_name
             __props__.__dict__["app_sync_domain_name"] = None
-            __props__.__dict__["domain_name"] = None
             __props__.__dict__["hosted_zone_id"] = None
         super(DomainName, __self__).__init__(
             'aws-native:appsync:DomainName',

--- a/sdk/python/pulumi_aws_native/codeartifact/domain.py
+++ b/sdk/python/pulumi_aws_native/codeartifact/domain.py
@@ -16,16 +16,20 @@ __all__ = ['DomainArgs', 'Domain']
 class DomainArgs:
     def __init__(__self__, *,
                  domain_name: Optional[pulumi.Input[str]] = None,
+                 encryption_key: Optional[pulumi.Input[str]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['DomainTagArgs']]]] = None):
         """
         The set of arguments for constructing a Domain resource.
         :param pulumi.Input[str] domain_name: The name of the domain.
+        :param pulumi.Input[str] encryption_key: The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
         :param Any permissions_policy_document: The access control resource policy on the provided domain.
         :param pulumi.Input[Sequence[pulumi.Input['DomainTagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
         if domain_name is not None:
             pulumi.set(__self__, "domain_name", domain_name)
+        if encryption_key is not None:
+            pulumi.set(__self__, "encryption_key", encryption_key)
         if permissions_policy_document is not None:
             pulumi.set(__self__, "permissions_policy_document", permissions_policy_document)
         if tags is not None:
@@ -42,6 +46,18 @@ class DomainArgs:
     @domain_name.setter
     def domain_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "domain_name", value)
+
+    @property
+    @pulumi.getter(name="encryptionKey")
+    def encryption_key(self) -> Optional[pulumi.Input[str]]:
+        """
+        The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
+        """
+        return pulumi.get(self, "encryption_key")
+
+    @encryption_key.setter
+    def encryption_key(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "encryption_key", value)
 
     @property
     @pulumi.getter(name="permissionsPolicyDocument")
@@ -74,6 +90,7 @@ class Domain(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  domain_name: Optional[pulumi.Input[str]] = None,
+                 encryption_key: Optional[pulumi.Input[str]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DomainTagArgs']]]]] = None,
                  __props__=None):
@@ -83,6 +100,7 @@ class Domain(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] domain_name: The name of the domain.
+        :param pulumi.Input[str] encryption_key: The ARN of an AWS Key Management Service (AWS KMS) key associated with a domain.
         :param Any permissions_policy_document: The access control resource policy on the provided domain.
         :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DomainTagArgs']]]] tags: An array of key-value pairs to apply to this resource.
         """
@@ -111,6 +129,7 @@ class Domain(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  domain_name: Optional[pulumi.Input[str]] = None,
+                 encryption_key: Optional[pulumi.Input[str]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DomainTagArgs']]]]] = None,
                  __props__=None):
@@ -126,10 +145,10 @@ class Domain(pulumi.CustomResource):
             __props__ = DomainArgs.__new__(DomainArgs)
 
             __props__.__dict__["domain_name"] = domain_name
+            __props__.__dict__["encryption_key"] = encryption_key
             __props__.__dict__["permissions_policy_document"] = permissions_policy_document
             __props__.__dict__["tags"] = tags
             __props__.__dict__["arn"] = None
-            __props__.__dict__["encryption_key"] = None
             __props__.__dict__["name"] = None
             __props__.__dict__["owner"] = None
         super(Domain, __self__).__init__(

--- a/sdk/python/pulumi_aws_native/codeartifact/repository.py
+++ b/sdk/python/pulumi_aws_native/codeartifact/repository.py
@@ -15,7 +15,9 @@ __all__ = ['RepositoryArgs', 'Repository']
 @pulumi.input_type
 class RepositoryArgs:
     def __init__(__self__, *,
+                 domain_name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
+                 domain_owner: Optional[pulumi.Input[str]] = None,
                  external_connections: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  repository_name: Optional[pulumi.Input[str]] = None,
@@ -23,15 +25,20 @@ class RepositoryArgs:
                  upstreams: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Repository resource.
+        :param pulumi.Input[str] domain_name: The name of the domain that contains the repository.
         :param pulumi.Input[str] description: A text description of the repository.
+        :param pulumi.Input[str] domain_owner: The 12-digit account ID of the AWS account that owns the domain.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] external_connections: A list of external connections associated with the repository.
         :param Any permissions_policy_document: The access control resource policy on the provided repository.
         :param pulumi.Input[str] repository_name: The name of the repository.
         :param pulumi.Input[Sequence[pulumi.Input['RepositoryTagArgs']]] tags: An array of key-value pairs to apply to this resource.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] upstreams: A list of upstream repositories associated with the repository.
         """
+        pulumi.set(__self__, "domain_name", domain_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if domain_owner is not None:
+            pulumi.set(__self__, "domain_owner", domain_owner)
         if external_connections is not None:
             pulumi.set(__self__, "external_connections", external_connections)
         if permissions_policy_document is not None:
@@ -44,6 +51,18 @@ class RepositoryArgs:
             pulumi.set(__self__, "upstreams", upstreams)
 
     @property
+    @pulumi.getter(name="domainName")
+    def domain_name(self) -> pulumi.Input[str]:
+        """
+        The name of the domain that contains the repository.
+        """
+        return pulumi.get(self, "domain_name")
+
+    @domain_name.setter
+    def domain_name(self, value: pulumi.Input[str]):
+        pulumi.set(self, "domain_name", value)
+
+    @property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[str]]:
         """
@@ -54,6 +73,18 @@ class RepositoryArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="domainOwner")
+    def domain_owner(self) -> Optional[pulumi.Input[str]]:
+        """
+        The 12-digit account ID of the AWS account that owns the domain.
+        """
+        return pulumi.get(self, "domain_owner")
+
+    @domain_owner.setter
+    def domain_owner(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "domain_owner", value)
 
     @property
     @pulumi.getter(name="externalConnections")
@@ -122,6 +153,8 @@ class Repository(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 domain_name: Optional[pulumi.Input[str]] = None,
+                 domain_owner: Optional[pulumi.Input[str]] = None,
                  external_connections: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  repository_name: Optional[pulumi.Input[str]] = None,
@@ -134,6 +167,8 @@ class Repository(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: A text description of the repository.
+        :param pulumi.Input[str] domain_name: The name of the domain that contains the repository.
+        :param pulumi.Input[str] domain_owner: The 12-digit account ID of the AWS account that owns the domain.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] external_connections: A list of external connections associated with the repository.
         :param Any permissions_policy_document: The access control resource policy on the provided repository.
         :param pulumi.Input[str] repository_name: The name of the repository.
@@ -144,7 +179,7 @@ class Repository(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: Optional[RepositoryArgs] = None,
+                 args: RepositoryArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The resource schema to create a CodeArtifact repository.
@@ -165,6 +200,8 @@ class Repository(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 domain_name: Optional[pulumi.Input[str]] = None,
+                 domain_owner: Optional[pulumi.Input[str]] = None,
                  external_connections: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  permissions_policy_document: Optional[Any] = None,
                  repository_name: Optional[pulumi.Input[str]] = None,
@@ -183,14 +220,16 @@ class Repository(pulumi.CustomResource):
             __props__ = RepositoryArgs.__new__(RepositoryArgs)
 
             __props__.__dict__["description"] = description
+            if domain_name is None and not opts.urn:
+                raise TypeError("Missing required property 'domain_name'")
+            __props__.__dict__["domain_name"] = domain_name
+            __props__.__dict__["domain_owner"] = domain_owner
             __props__.__dict__["external_connections"] = external_connections
             __props__.__dict__["permissions_policy_document"] = permissions_policy_document
             __props__.__dict__["repository_name"] = repository_name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["upstreams"] = upstreams
             __props__.__dict__["arn"] = None
-            __props__.__dict__["domain_name"] = None
-            __props__.__dict__["domain_owner"] = None
             __props__.__dict__["name"] = None
         super(Repository, __self__).__init__(
             'aws-native:codeartifact:Repository',

--- a/sdk/python/pulumi_aws_native/elasticache/replication_group.py
+++ b/sdk/python/pulumi_aws_native/elasticache/replication_group.py
@@ -50,6 +50,7 @@ class ReplicationGroupArgs:
                  reader_end_point_address: Optional[pulumi.Input[str]] = None,
                  reader_end_point_port: Optional[pulumi.Input[str]] = None,
                  replicas_per_node_group: Optional[pulumi.Input[int]] = None,
+                 replication_group_id: Optional[pulumi.Input[str]] = None,
                  security_group_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_name: Optional[pulumi.Input[str]] = None,
@@ -131,6 +132,8 @@ class ReplicationGroupArgs:
             pulumi.set(__self__, "reader_end_point_port", reader_end_point_port)
         if replicas_per_node_group is not None:
             pulumi.set(__self__, "replicas_per_node_group", replicas_per_node_group)
+        if replication_group_id is not None:
+            pulumi.set(__self__, "replication_group_id", replication_group_id)
         if security_group_ids is not None:
             pulumi.set(__self__, "security_group_ids", security_group_ids)
         if snapshot_arns is not None:
@@ -466,6 +469,15 @@ class ReplicationGroupArgs:
         pulumi.set(self, "replicas_per_node_group", value)
 
     @property
+    @pulumi.getter(name="replicationGroupId")
+    def replication_group_id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "replication_group_id")
+
+    @replication_group_id.setter
+    def replication_group_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "replication_group_id", value)
+
+    @property
     @pulumi.getter(name="securityGroupIds")
     def security_group_ids(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         return pulumi.get(self, "security_group_ids")
@@ -592,6 +604,7 @@ class ReplicationGroup(pulumi.CustomResource):
                  reader_end_point_port: Optional[pulumi.Input[str]] = None,
                  replicas_per_node_group: Optional[pulumi.Input[int]] = None,
                  replication_group_description: Optional[pulumi.Input[str]] = None,
+                 replication_group_id: Optional[pulumi.Input[str]] = None,
                  security_group_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_name: Optional[pulumi.Input[str]] = None,
@@ -667,6 +680,7 @@ class ReplicationGroup(pulumi.CustomResource):
                  reader_end_point_port: Optional[pulumi.Input[str]] = None,
                  replicas_per_node_group: Optional[pulumi.Input[int]] = None,
                  replication_group_description: Optional[pulumi.Input[str]] = None,
+                 replication_group_id: Optional[pulumi.Input[str]] = None,
                  security_group_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  snapshot_name: Optional[pulumi.Input[str]] = None,
@@ -726,6 +740,7 @@ class ReplicationGroup(pulumi.CustomResource):
             if replication_group_description is None and not opts.urn:
                 raise TypeError("Missing required property 'replication_group_description'")
             __props__.__dict__["replication_group_description"] = replication_group_description
+            __props__.__dict__["replication_group_id"] = replication_group_id
             __props__.__dict__["security_group_ids"] = security_group_ids
             __props__.__dict__["snapshot_arns"] = snapshot_arns
             __props__.__dict__["snapshot_name"] = snapshot_name
@@ -735,7 +750,6 @@ class ReplicationGroup(pulumi.CustomResource):
             __props__.__dict__["tags"] = tags
             __props__.__dict__["transit_encryption_enabled"] = transit_encryption_enabled
             __props__.__dict__["user_group_ids"] = user_group_ids
-            __props__.__dict__["replication_group_id"] = None
         super(ReplicationGroup, __self__).__init__(
             'aws-native:elasticache:ReplicationGroup',
             resource_name,

--- a/sdk/python/pulumi_aws_native/events/archive.py
+++ b/sdk/python/pulumi_aws_native/events/archive.py
@@ -14,6 +14,7 @@ __all__ = ['ArchiveArgs', 'Archive']
 class ArchiveArgs:
     def __init__(__self__, *,
                  source_arn: pulumi.Input[str],
+                 archive_name: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  event_pattern: Optional[Any] = None,
                  retention_days: Optional[pulumi.Input[int]] = None):
@@ -21,6 +22,8 @@ class ArchiveArgs:
         The set of arguments for constructing a Archive resource.
         """
         pulumi.set(__self__, "source_arn", source_arn)
+        if archive_name is not None:
+            pulumi.set(__self__, "archive_name", archive_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if event_pattern is not None:
@@ -36,6 +39,15 @@ class ArchiveArgs:
     @source_arn.setter
     def source_arn(self, value: pulumi.Input[str]):
         pulumi.set(self, "source_arn", value)
+
+    @property
+    @pulumi.getter(name="archiveName")
+    def archive_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "archive_name")
+
+    @archive_name.setter
+    def archive_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "archive_name", value)
 
     @property
     @pulumi.getter
@@ -70,6 +82,7 @@ class Archive(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 archive_name: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  event_pattern: Optional[Any] = None,
                  retention_days: Optional[pulumi.Input[int]] = None,
@@ -105,6 +118,7 @@ class Archive(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 archive_name: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  event_pattern: Optional[Any] = None,
                  retention_days: Optional[pulumi.Input[int]] = None,
@@ -121,13 +135,13 @@ class Archive(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ArchiveArgs.__new__(ArchiveArgs)
 
+            __props__.__dict__["archive_name"] = archive_name
             __props__.__dict__["description"] = description
             __props__.__dict__["event_pattern"] = event_pattern
             __props__.__dict__["retention_days"] = retention_days
             if source_arn is None and not opts.urn:
                 raise TypeError("Missing required property 'source_arn'")
             __props__.__dict__["source_arn"] = source_arn
-            __props__.__dict__["archive_name"] = None
             __props__.__dict__["arn"] = None
         super(Archive, __self__).__init__(
             'aws-native:events:Archive',

--- a/sdk/python/pulumi_aws_native/guardduty/master.py
+++ b/sdk/python/pulumi_aws_native/guardduty/master.py
@@ -14,11 +14,13 @@ __all__ = ['MasterArgs', 'Master']
 class MasterArgs:
     def __init__(__self__, *,
                  detector_id: pulumi.Input[str],
+                 master_id: pulumi.Input[str],
                  invitation_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Master resource.
         """
         pulumi.set(__self__, "detector_id", detector_id)
+        pulumi.set(__self__, "master_id", master_id)
         if invitation_id is not None:
             pulumi.set(__self__, "invitation_id", invitation_id)
 
@@ -30,6 +32,15 @@ class MasterArgs:
     @detector_id.setter
     def detector_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "detector_id", value)
+
+    @property
+    @pulumi.getter(name="masterId")
+    def master_id(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "master_id")
+
+    @master_id.setter
+    def master_id(self, value: pulumi.Input[str]):
+        pulumi.set(self, "master_id", value)
 
     @property
     @pulumi.getter(name="invitationId")
@@ -53,6 +64,7 @@ class Master(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  detector_id: Optional[pulumi.Input[str]] = None,
                  invitation_id: Optional[pulumi.Input[str]] = None,
+                 master_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Resource Type definition for AWS::GuardDuty::Master
@@ -86,6 +98,7 @@ class Master(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  detector_id: Optional[pulumi.Input[str]] = None,
                  invitation_id: Optional[pulumi.Input[str]] = None,
+                 master_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         pulumi.log.warn("""Master is deprecated: Master is not yet supported by AWS Native, so its creation will currently fail. Please use the classic AWS provider, if possible.""")
         if opts is None:
@@ -103,7 +116,9 @@ class Master(pulumi.CustomResource):
                 raise TypeError("Missing required property 'detector_id'")
             __props__.__dict__["detector_id"] = detector_id
             __props__.__dict__["invitation_id"] = invitation_id
-            __props__.__dict__["master_id"] = None
+            if master_id is None and not opts.urn:
+                raise TypeError("Missing required property 'master_id'")
+            __props__.__dict__["master_id"] = master_id
         super(Master, __self__).__init__(
             'aws-native:guardduty:Master',
             resource_name,

--- a/sdk/python/pulumi_aws_native/guardduty/member.py
+++ b/sdk/python/pulumi_aws_native/guardduty/member.py
@@ -15,6 +15,7 @@ class MemberArgs:
     def __init__(__self__, *,
                  detector_id: pulumi.Input[str],
                  email: pulumi.Input[str],
+                 member_id: pulumi.Input[str],
                  disable_email_notification: Optional[pulumi.Input[bool]] = None,
                  message: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None):
@@ -23,6 +24,7 @@ class MemberArgs:
         """
         pulumi.set(__self__, "detector_id", detector_id)
         pulumi.set(__self__, "email", email)
+        pulumi.set(__self__, "member_id", member_id)
         if disable_email_notification is not None:
             pulumi.set(__self__, "disable_email_notification", disable_email_notification)
         if message is not None:
@@ -47,6 +49,15 @@ class MemberArgs:
     @email.setter
     def email(self, value: pulumi.Input[str]):
         pulumi.set(self, "email", value)
+
+    @property
+    @pulumi.getter(name="memberId")
+    def member_id(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "member_id")
+
+    @member_id.setter
+    def member_id(self, value: pulumi.Input[str]):
+        pulumi.set(self, "member_id", value)
 
     @property
     @pulumi.getter(name="disableEmailNotification")
@@ -89,6 +100,7 @@ class Member(pulumi.CustomResource):
                  detector_id: Optional[pulumi.Input[str]] = None,
                  disable_email_notification: Optional[pulumi.Input[bool]] = None,
                  email: Optional[pulumi.Input[str]] = None,
+                 member_id: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -125,6 +137,7 @@ class Member(pulumi.CustomResource):
                  detector_id: Optional[pulumi.Input[str]] = None,
                  disable_email_notification: Optional[pulumi.Input[bool]] = None,
                  email: Optional[pulumi.Input[str]] = None,
+                 member_id: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
                  status: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -147,9 +160,11 @@ class Member(pulumi.CustomResource):
             if email is None and not opts.urn:
                 raise TypeError("Missing required property 'email'")
             __props__.__dict__["email"] = email
+            if member_id is None and not opts.urn:
+                raise TypeError("Missing required property 'member_id'")
+            __props__.__dict__["member_id"] = member_id
             __props__.__dict__["message"] = message
             __props__.__dict__["status"] = status
-            __props__.__dict__["member_id"] = None
         super(Member, __self__).__init__(
             'aws-native:guardduty:Member',
             resource_name,

--- a/sdk/python/pulumi_aws_native/iot1click/device.py
+++ b/sdk/python/pulumi_aws_native/iot1click/device.py
@@ -13,11 +13,22 @@ __all__ = ['DeviceArgs', 'Device']
 @pulumi.input_type
 class DeviceArgs:
     def __init__(__self__, *,
+                 device_id: pulumi.Input[str],
                  enabled: pulumi.Input[bool]):
         """
         The set of arguments for constructing a Device resource.
         """
+        pulumi.set(__self__, "device_id", device_id)
         pulumi.set(__self__, "enabled", enabled)
+
+    @property
+    @pulumi.getter(name="deviceId")
+    def device_id(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "device_id")
+
+    @device_id.setter
+    def device_id(self, value: pulumi.Input[str]):
+        pulumi.set(self, "device_id", value)
 
     @property
     @pulumi.getter
@@ -39,6 +50,7 @@ class Device(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 device_id: Optional[pulumi.Input[str]] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
@@ -71,6 +83,7 @@ class Device(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 device_id: Optional[pulumi.Input[str]] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         pulumi.log.warn("""Device is deprecated: Device is not yet supported by AWS Native, so its creation will currently fail. Please use the classic AWS provider, if possible.""")
@@ -85,11 +98,13 @@ class Device(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = DeviceArgs.__new__(DeviceArgs)
 
+            if device_id is None and not opts.urn:
+                raise TypeError("Missing required property 'device_id'")
+            __props__.__dict__["device_id"] = device_id
             if enabled is None and not opts.urn:
                 raise TypeError("Missing required property 'enabled'")
             __props__.__dict__["enabled"] = enabled
             __props__.__dict__["arn"] = None
-            __props__.__dict__["device_id"] = None
         super(Device, __self__).__init__(
             'aws-native:iot1click:Device',
             resource_name,

--- a/sdk/python/pulumi_aws_native/s3/access_point.py
+++ b/sdk/python/pulumi_aws_native/s3/access_point.py
@@ -17,6 +17,7 @@ __all__ = ['AccessPointArgs', 'AccessPoint']
 class AccessPointArgs:
     def __init__(__self__, *,
                  bucket: pulumi.Input[str],
+                 name: Optional[pulumi.Input[str]] = None,
                  policy: Optional[Any] = None,
                  policy_status: Optional[pulumi.Input['PolicyStatusPropertiesArgs']] = None,
                  public_access_block_configuration: Optional[pulumi.Input['AccessPointPublicAccessBlockConfigurationArgs']] = None,
@@ -24,11 +25,14 @@ class AccessPointArgs:
         """
         The set of arguments for constructing a AccessPoint resource.
         :param pulumi.Input[str] bucket: The name of the bucket that you want to associate this Access Point with.
+        :param pulumi.Input[str] name: The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
         :param Any policy: The Access Point Policy you want to apply to this access point.
         :param pulumi.Input['AccessPointPublicAccessBlockConfigurationArgs'] public_access_block_configuration: The PublicAccessBlock configuration that you want to apply to this Access Point. You can enable the configuration options in any combination. For more information about when Amazon S3 considers a bucket or object public, see https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status 'The Meaning of Public' in the Amazon Simple Storage Service Developer Guide.
         :param pulumi.Input['AccessPointVpcConfigurationArgs'] vpc_configuration: If you include this field, Amazon S3 restricts access to this Access Point to requests from the specified Virtual Private Cloud (VPC).
         """
         pulumi.set(__self__, "bucket", bucket)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
         if policy is not None:
             pulumi.set(__self__, "policy", policy)
         if policy_status is not None:
@@ -49,6 +53,18 @@ class AccessPointArgs:
     @bucket.setter
     def bucket(self, value: pulumi.Input[str]):
         pulumi.set(self, "bucket", value)
+
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter
@@ -102,6 +118,7 @@ class AccessPoint(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bucket: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  policy: Optional[Any] = None,
                  policy_status: Optional[pulumi.Input[pulumi.InputType['PolicyStatusPropertiesArgs']]] = None,
                  public_access_block_configuration: Optional[pulumi.Input[pulumi.InputType['AccessPointPublicAccessBlockConfigurationArgs']]] = None,
@@ -113,6 +130,7 @@ class AccessPoint(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] bucket: The name of the bucket that you want to associate this Access Point with.
+        :param pulumi.Input[str] name: The name you want to assign to this Access Point. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the access point name.
         :param Any policy: The Access Point Policy you want to apply to this access point.
         :param pulumi.Input[pulumi.InputType['AccessPointPublicAccessBlockConfigurationArgs']] public_access_block_configuration: The PublicAccessBlock configuration that you want to apply to this Access Point. You can enable the configuration options in any combination. For more information about when Amazon S3 considers a bucket or object public, see https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status 'The Meaning of Public' in the Amazon Simple Storage Service Developer Guide.
         :param pulumi.Input[pulumi.InputType['AccessPointVpcConfigurationArgs']] vpc_configuration: If you include this field, Amazon S3 restricts access to this Access Point to requests from the specified Virtual Private Cloud (VPC).
@@ -142,6 +160,7 @@ class AccessPoint(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bucket: Optional[pulumi.Input[str]] = None,
+                 name: Optional[pulumi.Input[str]] = None,
                  policy: Optional[Any] = None,
                  policy_status: Optional[pulumi.Input[pulumi.InputType['PolicyStatusPropertiesArgs']]] = None,
                  public_access_block_configuration: Optional[pulumi.Input[pulumi.InputType['AccessPointPublicAccessBlockConfigurationArgs']]] = None,
@@ -161,13 +180,13 @@ class AccessPoint(pulumi.CustomResource):
             if bucket is None and not opts.urn:
                 raise TypeError("Missing required property 'bucket'")
             __props__.__dict__["bucket"] = bucket
+            __props__.__dict__["name"] = name
             __props__.__dict__["policy"] = policy
             __props__.__dict__["policy_status"] = policy_status
             __props__.__dict__["public_access_block_configuration"] = public_access_block_configuration
             __props__.__dict__["vpc_configuration"] = vpc_configuration
             __props__.__dict__["alias"] = None
             __props__.__dict__["arn"] = None
-            __props__.__dict__["name"] = None
             __props__.__dict__["network_origin"] = None
         super(AccessPoint, __self__).__init__(
             'aws-native:s3:AccessPoint',

--- a/sdk/python/pulumi_aws_native/servicediscovery/instance.py
+++ b/sdk/python/pulumi_aws_native/servicediscovery/instance.py
@@ -14,12 +14,15 @@ __all__ = ['InstanceArgs', 'Instance']
 class InstanceArgs:
     def __init__(__self__, *,
                  instance_attributes: Any,
-                 service_id: pulumi.Input[str]):
+                 service_id: pulumi.Input[str],
+                 instance_id: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Instance resource.
         """
         pulumi.set(__self__, "instance_attributes", instance_attributes)
         pulumi.set(__self__, "service_id", service_id)
+        if instance_id is not None:
+            pulumi.set(__self__, "instance_id", instance_id)
 
     @property
     @pulumi.getter(name="instanceAttributes")
@@ -39,6 +42,15 @@ class InstanceArgs:
     def service_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "service_id", value)
 
+    @property
+    @pulumi.getter(name="instanceId")
+    def instance_id(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "instance_id")
+
+    @instance_id.setter
+    def instance_id(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "instance_id", value)
+
 
 warnings.warn("""Instance is not yet supported by AWS Native, so its creation will currently fail. Please use the classic AWS provider, if possible.""", DeprecationWarning)
 
@@ -51,6 +63,7 @@ class Instance(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  instance_attributes: Optional[Any] = None,
+                 instance_id: Optional[pulumi.Input[str]] = None,
                  service_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -84,6 +97,7 @@ class Instance(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  instance_attributes: Optional[Any] = None,
+                 instance_id: Optional[pulumi.Input[str]] = None,
                  service_id: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         pulumi.log.warn("""Instance is deprecated: Instance is not yet supported by AWS Native, so its creation will currently fail. Please use the classic AWS provider, if possible.""")
@@ -101,10 +115,10 @@ class Instance(pulumi.CustomResource):
             if instance_attributes is None and not opts.urn:
                 raise TypeError("Missing required property 'instance_attributes'")
             __props__.__dict__["instance_attributes"] = instance_attributes
+            __props__.__dict__["instance_id"] = instance_id
             if service_id is None and not opts.urn:
                 raise TypeError("Missing required property 'service_id'")
             __props__.__dict__["service_id"] = service_id
-            __props__.__dict__["instance_id"] = None
         super(Instance, __self__).__init__(
             'aws-native:servicediscovery:Instance',
             resource_name,

--- a/sdk/python/pulumi_aws_native/ssm/resource_data_sync.py
+++ b/sdk/python/pulumi_aws_native/ssm/resource_data_sync.py
@@ -15,6 +15,7 @@ __all__ = ['ResourceDataSyncArgs', 'ResourceDataSync']
 @pulumi.input_type
 class ResourceDataSyncArgs:
     def __init__(__self__, *,
+                 sync_name: pulumi.Input[str],
                  bucket_name: Optional[pulumi.Input[str]] = None,
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  bucket_region: Optional[pulumi.Input[str]] = None,
@@ -26,6 +27,7 @@ class ResourceDataSyncArgs:
         """
         The set of arguments for constructing a ResourceDataSync resource.
         """
+        pulumi.set(__self__, "sync_name", sync_name)
         if bucket_name is not None:
             pulumi.set(__self__, "bucket_name", bucket_name)
         if bucket_prefix is not None:
@@ -42,6 +44,15 @@ class ResourceDataSyncArgs:
             pulumi.set(__self__, "sync_source", sync_source)
         if sync_type is not None:
             pulumi.set(__self__, "sync_type", sync_type)
+
+    @property
+    @pulumi.getter(name="syncName")
+    def sync_name(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "sync_name")
+
+    @sync_name.setter
+    def sync_name(self, value: pulumi.Input[str]):
+        pulumi.set(self, "sync_name", value)
 
     @property
     @pulumi.getter(name="bucketName")
@@ -127,6 +138,7 @@ class ResourceDataSync(pulumi.CustomResource):
                  k_ms_key_arn: Optional[pulumi.Input[str]] = None,
                  s3_destination: Optional[pulumi.Input[pulumi.InputType['ResourceDataSyncS3DestinationArgs']]] = None,
                  sync_format: Optional[pulumi.Input[str]] = None,
+                 sync_name: Optional[pulumi.Input[str]] = None,
                  sync_source: Optional[pulumi.Input[pulumi.InputType['ResourceDataSyncSyncSourceArgs']]] = None,
                  sync_type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -140,7 +152,7 @@ class ResourceDataSync(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: Optional[ResourceDataSyncArgs] = None,
+                 args: ResourceDataSyncArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource Type definition for AWS::SSM::ResourceDataSync
@@ -166,6 +178,7 @@ class ResourceDataSync(pulumi.CustomResource):
                  k_ms_key_arn: Optional[pulumi.Input[str]] = None,
                  s3_destination: Optional[pulumi.Input[pulumi.InputType['ResourceDataSyncS3DestinationArgs']]] = None,
                  sync_format: Optional[pulumi.Input[str]] = None,
+                 sync_name: Optional[pulumi.Input[str]] = None,
                  sync_source: Optional[pulumi.Input[pulumi.InputType['ResourceDataSyncSyncSourceArgs']]] = None,
                  sync_type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -186,9 +199,11 @@ class ResourceDataSync(pulumi.CustomResource):
             __props__.__dict__["k_ms_key_arn"] = k_ms_key_arn
             __props__.__dict__["s3_destination"] = s3_destination
             __props__.__dict__["sync_format"] = sync_format
+            if sync_name is None and not opts.urn:
+                raise TypeError("Missing required property 'sync_name'")
+            __props__.__dict__["sync_name"] = sync_name
             __props__.__dict__["sync_source"] = sync_source
             __props__.__dict__["sync_type"] = sync_type
-            __props__.__dict__["sync_name"] = None
         super(ResourceDataSync, __self__).__init__(
             'aws-native:ssm:ResourceDataSync',
             resource_name,


### PR DESCRIPTION
These changes update the schema generator to ensure that any create-only
properties are captured in resource inputs, even if the properties are
also read-only.

This fixes the definitions for 11 resources that fall into this
scenario.