### PR TITLE
Add support for allowedAccountIds and forbiddenAccountIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## HEAD (Unreleased)
-(None)
+- Add support for allowedAccountIds and forbiddenAccountIds [#508](https://github.com/pulumi/pulumi-aws-native/pull/508)
 
 ## 0.18.0 (May 26, 2022)
 - Update to include the latest resource definitions


### PR DESCRIPTION
This PR adds support for `allowedAccountIds` and `forbiddenAccountIds` to the aws-native provider.

# Fixes
- https://github.com/pulumi/pulumi-aws-native/issues/105
- https://github.com/pulumi/pulumi-aws-native/issues/109