### PR TITLE
Revert deterministic autonaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (Unreleased)
 - Add support to pass AWS IAM Role to Cloud Control API [#493](https://github.com/pulumi/pulumi-aws-native/pull/493)
+- Revert use sequence numbers to generate deterministic autonames.
+  [#341](https://github.com/pulumi/pulumi-aws-native/pull/341)
 
 ## 0.17.0 (May 23, 2022)
 - Update to include the latest resource definitions
@@ -40,6 +42,7 @@
 - Use sequence numbers to generate deterministic autonames.
   [#341](https://github.com/pulumi/pulumi-aws-native/pull/341)
 - Update to include the latest resource definitions
+
 
 ## 0.11.0 (Jan 24, 2022)
 

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -16,7 +16,6 @@ package provider
 
 import (
 	"fmt"
-
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -28,7 +27,6 @@ import (
 // Defaults to the name followed by 7 random hex characters separated by a '-'.
 func getDefaultName(
 	urn resource.URN,
-	sequenceNumber int,
 	autoNamingSpec *schema.AutoNamingSpec,
 	olds,
 	news resource.PropertyMap,
@@ -69,7 +67,7 @@ func getDefaultName(
 	}
 
 	// Resource name is URN name + "-" + random suffix.
-	random, err := resource.NewUniqueHexV2(urn, sequenceNumber, prefix, randLength, maxLength)
+	random, err := resource.NewUniqueHex(prefix, randLength, maxLength)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -66,13 +66,13 @@ func Test_getDefaultName(t *testing.T) {
 	urn := resource.URN("urn:pulumi:dev::test::test-provider:testModule:TestResource::myName")
 
 	for _, tt := range tests {
-		doTest := func(t *testing.T, sequenceNumber int) {
+		t.Run(tt.name, func(t *testing.T) {
 			autoNamingSpec := &schema.AutoNamingSpec{
 				SdkName:   "autoName",
 				MinLength: tt.minLength,
 				MaxLength: tt.maxLength,
 			}
-			got, err := getDefaultName(urn, sequenceNumber, autoNamingSpec, tt.olds, tt.news)
+			got, err := getDefaultName(urn, autoNamingSpec, tt.olds, tt.news)
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
@@ -83,10 +83,7 @@ func Test_getDefaultName(t *testing.T) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", got, autoNamingSpec)
 			}
 			t.Logf("getDefaultName() = %v for spec: %+v", got, autoNamingSpec)
-		}
-
-		t.Run(tt.name+" with no sequence number", func(t *testing.T) { doTest(t, 0) })
-		t.Run(tt.name+" with sequence number", func(t *testing.T) { doTest(t, 1) })
+		})
 	}
 }
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -594,7 +594,7 @@ func (p *cfnProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*
 
 	if autoNamingSpec := spec.AutoNamingSpec; autoNamingSpec != nil {
 		// Auto-name fields if not already specified
-		val, err := getDefaultName(urn, int(req.GetSequenceNumber()), autoNamingSpec, olds, newInputs)
+		val, err := getDefaultName(urn, autoNamingSpec, olds, newInputs)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Extending changes from https://github.com/pulumi/pulumi-azure-native/issues/1718 and https://github.com/pulumi/pulumi-google-native/pull/488