### PR TITLE
Use NewUniqueName

### DIFF
--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -26,6 +27,7 @@ import (
 // based on its URN name, It ensures the name meets the length constraints, if known.
 // Defaults to the name followed by 7 random hex characters separated by a '-'.
 func getDefaultName(
+	randomSeed []byte,
 	urn resource.URN,
 	autoNamingSpec *schema.AutoNamingSpec,
 	olds,
@@ -67,7 +69,7 @@ func getDefaultName(
 	}
 
 	// Resource name is URN name + "-" + random suffix.
-	random, err := resource.NewUniqueHex(prefix, randLength, maxLength)
+	random, err := resource.NewUniqueName(randomSeed, prefix, randLength, maxLength, nil)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -4,10 +4,11 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_getDefaultName(t *testing.T) {
@@ -72,7 +73,7 @@ func Test_getDefaultName(t *testing.T) {
 				MinLength: tt.minLength,
 				MaxLength: tt.maxLength,
 			}
-			got, err := getDefaultName(urn, autoNamingSpec, tt.olds, tt.news)
+			got, err := getDefaultName(nil, urn, autoNamingSpec, tt.olds, tt.news)
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -638,7 +638,7 @@ func (p *cfnProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*
 
 	if autoNamingSpec := spec.AutoNamingSpec; autoNamingSpec != nil {
 		// Auto-name fields if not already specified
-		val, err := getDefaultName(urn, autoNamingSpec, olds, newInputs)
+		val, err := getDefaultName(req.RandomSeed, urn, autoNamingSpec, olds, newInputs)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is the new system for deterministic names with update plans. The engine will fill in the random seed with a non-deterministic slice of bytes for normal updates, but when using plans it will save and restore the bytes used thus allowing names to be deterministic between preview and update. NewUniqueName handles the case of old engines that didn't send anything for seed by just falling back to non-deterministic randomness. 