### PR TITLE
Use native IAM role to improve reliability

### DIFF
--- a/examples/update/step1/index.ts
+++ b/examples/update/step1/index.ts
@@ -1,55 +1,61 @@
 // Copyright 2016-2021, Pulumi Corporation.
-import * as pulumi from "@pulumi/pulumi";
-import * as awsClassic from "@pulumi/aws";
+
 import * as aws from "@pulumi/aws-native";
 
 const logGroup = new aws.s3.Bucket("bucket", {
-    tags: [{
-        key: "foo",
-        value: "bar",
-    }]
+  tags: [
+    {
+      key: "foo",
+      value: "bar",
+    },
+  ],
 });
 
-const lambdaRole = new awsClassic.iam.Role("lambdaRole", {
-    assumeRolePolicy: awsClassic.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
-    inlinePolicies: [{
-        name: "lambdaAccess", policy: JSON.stringify({
-            Version: "2012-10-17",
-            Statement: [{
-                Effect: "Allow",
-                Action: [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                ],
-                Resource: "arn:aws:logs:*:*:*",
-            }],
-        })
-    }]
+const lambdaRole = new aws.iam.Role("lambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "AllowAssumeRole",
+        Effect: "Allow",
+        Principal: {
+          Service: "lambda.amazonaws.com",
+        },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "lambdaAccess",
+      policyDocument: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+            ],
+            Resource: "arn:aws:logs:*:*:*",
+          },
+        ],
+      }),
+    },
+  ],
 });
-
-class DelayResource extends pulumi.dynamic.Resource {
-    constructor(name: string, props: { ms: number }, opts?: pulumi.CustomResourceOptions) {
-        const delay = props.ms;
-        super({
-            create: async (inputs) => {
-                await new Promise(resolve => setTimeout(resolve, delay))
-                return { id: "delay", outs: {} };
-            }
-        }, name, props ?? {}, opts,);
-    }
-}
 
 const func = new aws.lambda.Function("function", {
-    runtime: "nodejs16.x",
-    role: lambdaRole.arn,
-    handler: "index.handler",
-    code: {
-        zipFile: `
+  runtime: "nodejs16.x",
+  role: lambdaRole.arn,
+  handler: "index.handler",
+  code: {
+    zipFile: `
 exports.handler =  async function(event, context) {
   console.log("Running")
   return "foo"
 }
 `,
-    },
-}, { dependsOn: new DelayResource("delay", { ms: 60 * 1000 }, { dependsOn: lambdaRole }) });
+  },
+});

--- a/examples/update/step1/package.json
+++ b/examples/update/step1/package.json
@@ -4,8 +4,7 @@
     "@types/node": "^8.0.0"
   },
   "dependencies": {
-    "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/aws": "^5.19.0"
+    "@pulumi/pulumi": "^3.0.0"
   },
   "peerDependencies": {
     "@pulumi/aws-native": "dev"

--- a/examples/update/step2/index.ts
+++ b/examples/update/step2/index.ts
@@ -1,43 +1,43 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-import * as awsClassic from "@pulumi/aws";
 import * as aws from "@pulumi/aws-native";
 
 const logGroup = new aws.s3.Bucket("bucket", {
-    tags: [{
-        key: "foo",
-        value: "buzz", // <-- this value has changed
-    }]
+  tags: [
+    {
+      key: "foo",
+      value: "buzz", // <-- this value has changed
+    },
+  ],
 });
 
-const lambdaRole = new awsClassic.iam.Role("lambdaRole", {
-    assumeRolePolicy: awsClassic.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
-    inlinePolicies: [{
-        name: "lambdaAccess", policy: JSON.stringify({
-            Version: "2012-10-17",
-            Statement: [{
-                Effect: "Allow",
-                Action: [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                ],
-                Resource: "arn:aws:logs:*:*:*",
-            }],
-        })
-    }]
+const lambdaRole = new aws.iam.Role("lambdaRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "AllowAssumeRole",
+        Effect: "Allow",
+        Principal: {
+          Service: "lambda.amazonaws.com",
+        },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  // Remove policies to avoid deletion issue: https://github.com/pulumi/pulumi-aws-native/issues/416
 });
 
 const func = new aws.lambda.Function("function", {
-    runtime: "nodejs16.x",
-    role: lambdaRole.arn,
-    handler: "index.handler",
-    code: {
-        zipFile: `
-exports.handler =  async function(event, context) {
-  console.log("Running")
-  return "bar" // <-- this value has changed
-}
-`,
-    },
+  runtime: "nodejs16.x",
+  role: lambdaRole.arn,
+  handler: "index.handler",
+  code: {
+    zipFile: `
+  exports.handler =  async function(event, context) {
+    console.log("Running")
+    return "bar"  // <-- this value has changed
+  }
+  `,
+  },
 });

--- a/examples/update/step2/package.json
+++ b/examples/update/step2/package.json
@@ -4,8 +4,7 @@
     "@types/node": "^8.0.0"
   },
   "dependencies": {
-    "@pulumi/pulumi": "^3.0.0",
-    "@pulumi/aws": "^5.19.0"
+    "@pulumi/pulumi": "^3.0.0"
   },
   "peerDependencies": {
     "@pulumi/aws-native": "dev"


### PR DESCRIPTION
Wait issue doesn't happen via CloudControl so can remove artificial delay. We do, however, have to remove the inline policies in step 2 to avoid deletion error: https://github.com/pulumi/pulumi-aws-native/issues/416