### PR TITLE
Fix conversion of dynamo table resource payloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -271,6 +276,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -483,6 +493,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -171,6 +171,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -263,6 +268,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -475,6 +485,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -263,6 +268,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -474,6 +484,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download java SDK
       uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -198,6 +198,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:
@@ -293,6 +298,11 @@ jobs:
         java-version: ${{ env.JAVAVERSION }}
         distribution: temurin
         cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        # Pin to known good version until #2262 is resolved
+        gradle-version: "7.6"
     - name: Download provider + tfgen binaries
       uses: actions/download-artifact@v2
       with:

--- a/provider/pkg/schema/convert.go
+++ b/provider/pkg/schema/convert.go
@@ -58,6 +58,18 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 		return c.sdkObjectValueToCfn(typName, v)
 	}
 
+	if spec.OneOf != nil {
+		for _, item := range spec.OneOf {
+			converted := c.sdkTypedValueToCfn(&item, v)
+			// If the conversion resulted in a different value, return it.
+			// We should probably fail if we can't convert rather than considering change a success.
+			// This is likely to happen if one of the types is any.
+			if !reflect.DeepEqual(converted, v) {
+				return converted
+			}
+		}
+	}
+
 	switch spec.Type {
 	case "array":
 		array := v.([]interface{})

--- a/provider/pkg/schema/convert_examples_test.go
+++ b/provider/pkg/schema/convert_examples_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+package schema
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynamoKeySchemaConversion(t *testing.T) {
+	input := map[string]interface{}{
+		"keySchema": []interface{}{
+			map[string]interface{}{
+				"attributeName": "test",
+				"keyType":       "HASH",
+			},
+			map[string]interface{}{
+				"attributeName": "Part",
+				"keyType":       "RANGE",
+			},
+		},
+	}
+	expected := map[string]interface{}{
+		"KeySchema": []interface{}{
+			map[string]interface{}{
+				"AttributeName": "test",
+				"KeyType":       "HASH",
+			},
+			map[string]interface{}{
+				"AttributeName": "Part",
+				"KeyType":       "RANGE",
+			},
+		},
+	}
+	testConversion(t, "aws-native:dynamodb:Table", input, expected)
+}
+
+func testConversion(t *testing.T, resource string, input map[string]interface{}, expected map[string]interface{}) {
+	bytes, err := ioutil.ReadFile("../../cmd/pulumi-resource-aws-native/metadata.json")
+	assert.NoError(t, err)
+	metadata := CloudAPIMetadata{}
+	err = json.Unmarshal(bytes, &metadata)
+	assert.NoError(t, err)
+	res := metadata.Resources[resource]
+	actual := SdkToCfn(&res, metadata.Types, input)
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Fixes #728
- Add testing of conversion for real resources from the real metadata.
- Add conversion of OneOf specs.
- Ignore conversions of OneOf specs which result in no change. E.g. Any