### PR TITLE
Make retries much more aggressive by default to enable highly parallel operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ New functions:
 - `devopsguru.getLogAnomalyDetectionIntegration`
 - `logs.getSubscriptionFilter`
 
+Enhancements:
+
+- Max retries are set to 25 by default, max rate limit disabled by default
+  [#862](https://github.com/pulumi/pulumi-aws-native/pull/862)
+
+
 ## 0.55.0 (March 28, 2023)
 
 Upstream breaking changes

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -64,6 +64,15 @@ func TestNamingConventions(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestParallelTs(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "parallel-ts"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func getJSBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	base := getBaseOptions(t)
 	baseJS := base.With(integration.ProgramTestOptions{

--- a/examples/parallel-ts/Pulumi.yaml
+++ b/examples/parallel-ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-parallel-ts
+runtime: nodejs
+description: A lot of simple resources created in parallel

--- a/examples/parallel-ts/index.ts
+++ b/examples/parallel-ts/index.ts
@@ -1,0 +1,18 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+import * as aws from "@pulumi/aws-native";
+
+for (let i = 0; i < 100; i++) {
+    new aws.iam.Role(`role-${i}`, {
+        assumeRolePolicyDocument: {
+            Version: "2012-10-17",
+            Statement: [{
+                Effect: "Allow",
+                Principal: {
+                    Service: ["grafana.amazonaws.com"],
+                },
+                Action: ["sts:AssumeRole"],
+            }],
+        },
+    });
+}

--- a/examples/parallel-ts/package.json
+++ b/examples/parallel-ts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aws-parallel-ts",
+  "devDependencies": {
+    "@types/node": "^8.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0"
+  },
+  "peerDependencies": {
+    "@pulumi/aws-native": "dev"
+  }
+}

--- a/examples/parallel-ts/tsconfig.json
+++ b/examples/parallel-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -400,9 +400,6 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 		if err != nil {
 			return nil, fmt.Errorf("invalid config value for 'maxRetries': %q: %w", maxRetriesConf, err)
 		}
-		if maxRetries < 0 {
-			return nil, fmt.Errorf("invalid config value for 'maxRetries': %d", maxRetries)
-		}
 	}
 	glog.V(4).Infof("using Max Retry Attempts: %d", maxRetries)
 


### PR DESCRIPTION
Resolve #690
Resolve #854

If we try creating a significant number of cheap resources in parallel, we easily hit the max retry limit that AWS SDKs set by default (3 retry attempts). We want this to succeed by default for our users.

This PR bumps the default retry settings to more aggressive levels:

- Max attempts are set to 25, and can be overridden by the `maxRetries` config. This is the number of attempts to retry a single SDK call.
- Rate Limiter is disabled by default, can be re-enabled by the `maxRetryRateTokens` config. This is a global limit for all requests running in parallel for a single client.
- We don't touch Max Backoff - it's left on the default value of 20 seconds.

The test confirms that we can successfully create 100 IAM roles without any explicit configuration nobs.