### PR TITLE
Clean the aws-cloudformation-schema dir before downloading new schemas

### DIFF
--- a/provider/cmd/pulumi-gen-aws-native/main.go
+++ b/provider/cmd/pulumi-gen-aws-native/main.go
@@ -219,18 +219,14 @@ func cleanDir(dir string, perm os.FileMode) error {
 		return err
 	}
 
-	err = os.MkdirAll(dir, perm)
-	if err != nil {
-		return err
-	}
-	return nil
+	return os.MkdirAll(dir, perm)
 }
 
 func downloadCloudFormationSchemas(urls []string, outDir string) error {
 	// start with an empty directory
 	err := cleanDir(outDir, 0755)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	for _, url := range urls {

--- a/provider/cmd/pulumi-gen-aws-native/main.go
+++ b/provider/cmd/pulumi-gen-aws-native/main.go
@@ -213,7 +213,26 @@ func writeSupportedResourceTypes(outDir string) error {
 	return emitFile(outDir, supportedResourcesFile, []byte(supportedContent))
 }
 
+func cleanDir(dir string, perm os.FileMode) error {
+	err := os.RemoveAll(dir)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(dir, perm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func downloadCloudFormationSchemas(urls []string, outDir string) error {
+	// start with an empty directory
+	err := cleanDir(outDir, 0755)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, url := range urls {
 		resp, err := http.Get(url)
 		if err != nil {

--- a/provider/cmd/pulumi-gen-aws-native/main_test.go
+++ b/provider/cmd/pulumi-gen-aws-native/main_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanDir(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	//create tempdir 
+	temp, err := os.MkdirTemp("", "test_CleanDir")
+	require.Nil(err)
+	t.Cleanup(func() { os.RemoveAll(temp) })
+
+	dir := temp + "/foo"
+
+	// when called on non-existent dir
+	require.NoDirExists(dir)
+	err = cleanDir(dir, 0755)
+	if assert.Nil(err) {
+		assertExistsAndEmpty(t, dir)
+	}
+
+	// when called on an existing Dir
+	require.DirExists(dir)
+	file, err := os.Create(dir + "/temp.txt")
+	require.Nil(err)
+	file.Close()
+
+	err = cleanDir(dir, 0755)
+	if assert.Nil(err) {
+		assertExistsAndEmpty(t, dir)
+	}
+}
+
+func assertExistsAndEmpty(t *testing.T, path string) bool {
+  assert := assert.New(t)
+
+	if assert.DirExists(path) {
+		dir, err := os.Open(path)
+		if assert.Nil(err) {
+			defer dir.Close()
+
+			_, err = dir.Readdirnames(1)
+			return assert.Equalf(io.EOF, err, "Non-empty dir")
+		}
+	}
+	return false
+}

--- a/provider/cmd/pulumi-gen-aws-native/main_test.go
+++ b/provider/cmd/pulumi-gen-aws-native/main_test.go
@@ -27,7 +27,7 @@ func TestCleanDir(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	//create tempdir 
+	//create tempdir
 	temp, err := os.MkdirTemp("", "test_CleanDir")
 	require.Nil(err)
 	t.Cleanup(func() { os.RemoveAll(temp) })
@@ -54,16 +54,18 @@ func TestCleanDir(t *testing.T) {
 }
 
 func assertExistsAndEmpty(t *testing.T, path string) bool {
-  assert := assert.New(t)
+	assert := assert.New(t)
 
-	if assert.DirExists(path) {
-		dir, err := os.Open(path)
-		if assert.Nil(err) {
-			defer dir.Close()
-
-			_, err = dir.Readdirnames(1)
-			return assert.Equalf(io.EOF, err, "Non-empty dir")
-		}
+	if !assert.DirExists(path) {
+		return false
 	}
-	return false
+
+	dir, err := os.Open(path)
+	if !assert.Nil(err) {
+		return false
+	}
+	defer dir.Close()
+
+	_, err = dir.Readdirnames(1)
+	return assert.Equalf(io.EOF, err, "Non-empty dir")
 }


### PR DESCRIPTION
Addresses issue #901 by deleting and recreating the aws-cloudformation-schema/ dir before downloading the new schemas.


## Testing
Added a new unit test to cover the directory cleaning behavior; ran `make discovery` manually to observe the impact.

I did not include the files changed as a result of running `make discovery` in this commit, but locally my diff shows two files deleted as a result of running with this change:
```
	deleted:    aws-cloudformation-schema/aws-gamecast-application.json
	deleted:    aws-cloudformation-schema/aws-gamecast-streamgroup.json
```

## Rollout
N/A

## Rollback/Revert
safe to revert