### PR TITLE
RFC: Use devbox to define a consistent dev environment for contributors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:stable-slim
+
+# Step 1: Installing dependencies
+RUN apt-get update
+RUN apt-get -y install bash binutils git gnupg2 xz-utils wget sudo
+
+# Step 2: Setting up devbox user
+ENV DEVBOX_USER=devbox
+RUN adduser $DEVBOX_USER
+RUN usermod -aG sudo $DEVBOX_USER
+RUN echo "devbox ALL=(ALL:ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/$DEVBOX_USER
+
+USER $DEVBOX_USER
+
+# Step 3: Installing devbox
+RUN wget --quiet --output-document=/dev/stdout https://get.jetpack.io/devbox   | bash -s -- -f
+RUN chown -R "${DEVBOX_USER}:${DEVBOX_USER}" /usr/local/bin/devbox
+
+# Step 4: Installing Nix
+RUN wget --output-document=/dev/stdout https://nixos.org/nix/install | sh -s -- --no-daemon
+RUN . ~/.nix-profile/etc/profile.d/nix.sh
+# updating PATH
+ENV PATH="/home/${DEVBOX_USER}/.nix-profile/bin:/home/${DEVBOX_USER}/.devbox/nix/profile/default/bin:${PATH}"
+
+# Step 5: Installing your devbox project
+WORKDIR /code
+RUN sudo chown $DEVBOX_USER:root /code
+COPY devbox.json devbox.json
+
+
+RUN devbox install
+
+RUN devbox shellenv --init-hook >> ~/.profile

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "Devbox Remote Container",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": ".."
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {},
+      "extensions": [
+        "jetpack-io.devbox"
+      ]
+    }
+  },
+  "remoteUser": "devbox"
+}

--- a/README.md
+++ b/README.md
@@ -24,13 +24,26 @@ To learn how to configure credentials refer to the [AWS configuration options](h
 
 ### Dependencies
 
-- Go 1.17
+- Go 1.20
 - NodeJS 10.X.X or later
+- Yarn 1.22 or later
 - Python 3.6 or later
 - .NET Core 3.1
+- Gradel 7
+- Pulumi CLI and language plugins
+- pulumictl
 
-Please refer to [Contributing to Pulumi](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) for installation
-guidance.
+You can quickly launch a shell environment with all the required dependencies using
+[devbox](https://www.jetpack.io/devbox/):
+```
+# Install devbox if needed
+$ which devbox || curl -fsSL https://get.jetpack.io/devbox | bash
+$ devbox shell
+```
+
+Alternatively, you can develop in a preconfigured container environment using 
+[an editor or service that supports the devcontainer standard](https://containers.dev/supporting#editors)
+such as [VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) or [Github Codespaces](https://codespaces.new/pulumi/pulumi-aws-native). Please note that building this project can be fairly memory intensive, if you are having trouble building in a container, please ensure you have at least 12GB of memory available for the container.
 
 ### Building locally
 

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,24 @@
+{
+  "packages": [
+    "go@1.20",
+    "nodejs@latest",
+    "python3@latest",
+    "dotnet-sdk@latest",
+    "pulumictl@latest",
+    "yarn@latest",
+    "pdm@latest",
+    "gradle_7@latest",
+    "pulumi@latest",
+    "pulumi-bin@latest"
+  ],
+  "shell": {
+    "init_hook": [
+      "export PATH=\"$(pwd)/bin/:$PATH\""
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,55 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "dotnet-sdk@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#dotnet-sdk",
+      "version": "6.0.411"
+    },
+    "go@1.20": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#go",
+      "version": "1.20.5"
+    },
+    "gradle_7@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#gradle_7",
+      "version": "7.6.1"
+    },
+    "nodejs@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_20",
+      "version": "20.3.1"
+    },
+    "pdm@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#pdm",
+      "version": "2.7.0"
+    },
+    "pulumi-bin@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#pulumi-bin",
+      "version": "3.72.1"
+    },
+    "pulumi@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#pulumi",
+      "version": "3.72.2"
+    },
+    "pulumictl@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#pulumictl",
+      "version": "0.0.43"
+    },
+    "python3@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#python311",
+      "version": "3.11.4"
+    },
+    "yarn@latest": {
+      "last_modified": "2023-06-29T16:20:38Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#yarn",
+      "version": "1.22.19"
+    }
+  }
+}


### PR DESCRIPTION
Adds `devbox.json` and `.devcontainer` files to define a reproducible build environment. Updated the README with instructions for use.

Devbox orchestrates a nix shell with a specified dependency list, which you can use directly, or inside a container. devcontainer provides a standard for editors and other tools to work inside in a container.

I personally like this approach as a relatively lightweight way to maintain a known good build environment; I'm curious to get the team's feedback. 

Ideally, we'd drive our CI off the same docker image for consistency between local builds and CI (github has some tooling to support this already: https://github.com/devcontainers/ci); I can add this if we decide to go down this path. 






