### PR TITLE
fix annotation of vendored and generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Mark contents under sdk directory as generated to keep PRs manageable
-sdk/* linguist-generated=true
+sdk/** linguist-generated=true
+aws-cloudformation-schema/** liguist-vendored=true


### PR DESCRIPTION
looks like we'd intended to mark the sdk directory as generated, but the syntax was incorrect. Figured I'd also mark the cloudformation schemas as vendored as while while I'm here 