### PR TITLE
stop using 'replacements' options in .goreleaser.cf2pulumi.yml

### DIFF
--- a/.goreleaser.cf2pulumi.yml
+++ b/.goreleaser.cf2pulumi.yml
@@ -16,13 +16,16 @@ builds:
       dir: provider
       main: ./cmd/cf2pulumi/
 archives:
-  - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+  - name_template: >-
+      {{ .Binary }}-
+      {{ .Tag }}-
+      {{ .Os }}-
+      {{- if eq .Arch "amd64" }}x64
+      {{- else if eq .Arch "386" }}x86
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      amd64: x64
-      386: x86
 snapshot:
   name_template: "{{ .Tag }}-SNAPSHOT"
 changelog:
@@ -33,7 +36,7 @@ project_name: cf2pulumi
 brews:
   -
     name: cf2pulumi
-    tap:
+    repository:
       owner: pulumi
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
'replacements' was deprecated a few months ago and was removed in a recent version 
of goreleaser (https://goreleaser.com/deprecations/#nfpmsreplacements)
Also replaced "brews/tap" with "brews/repository" as per https://goreleaser.com/deprecations/#brewstap


# Testing
`goreleaser -f .goreleaser.cf2pulumi.yml check`