### PR TITLE
Whitespace only changes to bring us closer to ci-mgmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -87,14 +87,14 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
-        uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: |
           ### Does the PR have any schema changes?
 
           ${{ env.SCHEMA_CHANGES }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if:
+    - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -152,7 +152,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -194,7 +194,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Initialize submodules
@@ -250,7 +250,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -292,7 +292,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Download SDK
@@ -301,7 +301,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-        run:
+      run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
         github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
@@ -353,7 +353,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -373,13 +373,13 @@ jobs:
         role-external-id: upload-pulumi-release
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-        run:
+      run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-          args:
+        args:
             -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
         version: latest
@@ -407,7 +407,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -484,7 +484,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -513,11 +513,11 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-        run:
+      run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-        uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,15 @@ name: build
 on:
   push:
     branches:
-      - master
-      - main
-      - feature-**
+    - master
+    - main
+    - feature-**
     paths-ignore:
-      - CHANGELOG.md
+    - CHANGELOG.md
     tags-ignore:
-      - v*
-      - sdk/*
-      - "**"
+    - v*
+    - sdk/*
+    - "**"
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -45,87 +45,87 @@ jobs:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - if: github.event_name == 'pull_request'
-        name: Install Schema Tools
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: mikhailshilkov/schema-tools
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Build codegen binaries
-        run: make codegen
-      - name: Build Schema
-        run: make generate_schema
-      - if: github.event_name == 'pull_request'
-        name: Check Schema is Valid
-        run: >-
-          echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - if: github.event_name == 'pull_request'
+      name: Install Schema Tools
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: mikhailshilkov/schema-tools
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Build codegen binaries
+      run: make codegen
+    - name: Build Schema
+      run: make generate_schema
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      run: >-
+        echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-          schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
 
-          echo 'EOF' >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request'
-        name: Comment on PR with Details of Schema Check
+        echo 'EOF' >> $GITHUB_ENV
+    - if: github.event_name == 'pull_request'
+      name: Comment on PR with Details of Schema Check
         uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: |
-            ### Does the PR have any schema changes?
+      with:
+        message: |
+          ### Does the PR have any schema changes?
 
-            ${{ env.SCHEMA_CHANGES }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ${{ env.SCHEMA_CHANGES }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-          github.actor == 'pulumi-bot'
-        name: Add label if no breaking changes
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: impact/no-changelog-required
-          number: ${{ github.event.issue.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Provider
-        run: make provider
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-          pulumi-gen-${{ env.PROVIDER}}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin/provider.tar.gz
-      - name: Test Provider Library
-        run: make test_provider
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in building provider prerequisites
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        github.actor == 'pulumi-bot'
+      name: Add label if no breaking changes
+      uses: actions-ecosystem/action-add-labels@v1.1.0
+      with:
+        labels: impact/no-changelog-required
+        number: ${{ github.event.issue.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build Provider
+      run: make provider
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
+        pulumi-gen-${{ env.PROVIDER}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
+    - name: Test Provider Library
+      run: make test_provider
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in building provider prerequisites
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -133,392 +133,392 @@ jobs:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: build_sdks
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Generate SDK
-        run: make generate_${{ matrix.language }}
-      - name: Build SDK
-        run: make build_${{ matrix.language }}
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar SDK folder
-        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.language  }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure while building SDKs
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        -exec chmod +x {} \;
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Generate SDK
+      run: make generate_${{ matrix.language }}
+    - name: Build SDK
+      run: make build_${{ matrix.language }}
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar SDK folder
+      run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.language  }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
-      - build_sdks
+    - build_sdks
     strategy:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: test
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Download SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: UnTar SDK folder
+        -exec chmod +x {} \;
+    - name: Download SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.language }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: UnTar SDK folder
         run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-          github.workspace}}/sdk/${{ matrix.language}}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-      - name: Install Node dependencies
-        run: yarn global add typescript
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          version: v2.4.0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run tests
-        run: >-
-          set -euo pipefail
+        github.workspace}}/sdk/${{ matrix.language}}
+    - name: Update path
+      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+    - name: Install Node dependencies
+      run: yarn global add typescript
+    - run: dotnet nuget add source ${{ github.workspace }}/nuget
+    - name: Install Python deps
+      run: |-
+        pip3 install virtualenv==20.0.23
+        pip3 install pipenv
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.4.0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run tests
+      run: >-
+        set -euo pipefail
 
-          cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in SDK tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-11
     needs: test
     name: publish
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-external-id: upload-pulumi-release
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set PreRelease Version
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: us-east-2
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-external-id: upload-pulumi-release
+        role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+    - name: Set PreRelease Version
         run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-          >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
+        >> $GITHUB_ENV
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
           args:
             -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-            60m0s
-          version: latest
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing binaries
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+          60m0s
+        version: latest
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing binaries
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
     name: publish_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Download python SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: python-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress python SDK
-        run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-          ${{github.workspace}}/sdk/python
-      - name: Download dotnet SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: dotnet-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress dotnet SDK
-        run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-          ${{github.workspace}}/sdk/dotnet
-      - name: Download nodejs SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: nodejs-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress nodejs SDK
-        run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-          ${{github.workspace}}/sdk/nodejs
-      - name: Install Twine
-        run: python -m pip install pip twine
-      - name: Publish SDKs
-        run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing SDK
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Download python SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress python SDK
+      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
+        ${{github.workspace}}/sdk/python
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress dotnet SDK
+      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
+        ${{github.workspace}}/sdk/dotnet
+    - name: Download nodejs SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress nodejs SDK
+      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
+        ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: publish
     name: publish_java_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download java SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: java-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress java SDK
-        run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-          ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
+        gradle-version: "7.6"
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
-      - name: Publish Java SDK
+        $GITHUB_ENV
+    - name: Publish Java SDK
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-          build-root-directory: ./sdk/java
-          gradle-version: 7.4.1
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1

--- a/.github/workflows/cf2pulumi-release.yml
+++ b/.github/workflows/cf2pulumi-release.yml
@@ -4,8 +4,8 @@ name: cf2pulumi-release
 on:
   push:
     tags:
-      - v*.*.*
-      - "!v*.*.*-**"
+    - v*.*.*
+    - "!v*.*.*-**"
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: aws-native
@@ -36,27 +36,27 @@ jobs:
   release:
     runs-on: macos-11
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: 1.20.x
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          args: -p 1 -f .goreleaser.cf2pulumi.yml release --rm-dist --timeout 60m0s
-          version: latest
-      - name: Chocolatey Package Deployment
-        run: |-
-          CURRENT_TAG=v$(pulumictl get version --language generic -o)
-          pulumictl create choco-deploy -a cf2pulumi ${CURRENT_TAG}
+      with:
+        go-version: 1.20.x
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        args: -p 1 -f .goreleaser.cf2pulumi.yml release --rm-dist --timeout 60m0s
+        version: latest
+    - name: Chocolatey Package Deployment
+      run: |-
+        CURRENT_TAG=v$(pulumictl get version --language generic -o)
+        pulumictl create choco-deploy -a cf2pulumi ${CURRENT_TAG}
     name: release

--- a/.github/workflows/cf2pulumi-release.yml
+++ b/.github/workflows/cf2pulumi-release.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: 1.20.x
     - name: Run GoReleaser

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -4,8 +4,8 @@ name: command-dispatch
 on:
   issue_comment:
     types:
-      - created
-      - edited
+    - created
+    - edited
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: aws-native
@@ -37,16 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     name: command-dispatch-for-testing
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - uses: peter-evans/slash-command-dispatch@v2
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: run-acceptance-tests
-          permission: write
-          issue-type: pull-request
-          repository: pulumi/pulumi-aws-native
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - uses: peter-evans/slash-command-dispatch@v2
+      with:
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        reaction-token: ${{ secrets.GITHUB_TOKEN }}
+        commands: run-acceptance-tests
+        permission: write
+        issue-type: pull-request
+        repository: pulumi/pulumi-aws-native
     if: ${{ github.event.issue.pull_request }}

--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -3,7 +3,7 @@
 name: nightly-sdk-generation
 on:
   schedule:
-    - cron: 35 4 * * 1-5
+  - cron: 35 4 * * 1-5
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -36,80 +36,80 @@ jobs:
     runs-on: ubuntu-latest
     name: generate-sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: 1.20.x
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Cleanup SDK Folder
-        run: make clean
-      - name: Preparing Git Branch
-        run: >
-          git config --local user.email "bot@pulumi.com"
+      with:
+        go-version: 1.20.x
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Cleanup SDK Folder
+      run: make clean
+    - name: Preparing Git Branch
+      run: >
+        git config --local user.email "bot@pulumi.com"
 
-          git config --local user.name "pulumi-bot"
+        git config --local user.name "pulumi-bot"
 
-          git checkout -b generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-      - name: Commit Empty SDK
-        run: |-
-          git add . 
-          git commit -m "Preparing the SDK folder for regeneration"
-      - name: Discovery
-        run: make discovery
-      - name: Build codegen binaries
-        run: make codegen
-      - name: Build Schema + SDKs
-        run: make local_generate
-      - name: Git submodule commit hash
-        id: vars
-        run: echo ::set-output name=commit-hash::$(git rev-parse HEAD)
-        working-directory: aws-cloudformation-user-guide
-      - name: Commit changes
-        run: >-
-          git add sdk
+        git checkout -b generate-sdk/${{ github.run_id }}-${{ github.run_number }}
+    - name: Commit Empty SDK
+      run: |-
+        git add . 
+        git commit -m "Preparing the SDK folder for regeneration"
+    - name: Discovery
+      run: make discovery
+    - name: Build codegen binaries
+      run: make codegen
+    - name: Build Schema + SDKs
+      run: make local_generate
+    - name: Git submodule commit hash
+      id: vars
+      run: echo ::set-output name=commit-hash::$(git rev-parse HEAD)
+      working-directory: aws-cloudformation-user-guide
+    - name: Commit changes
+      run: >-
+        git add sdk
 
-          git commit -m "Regenerating SDKs based on aws-cloudformation-user-guide @ ${{ steps.vars.outputs.commit-hash }}" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating SDKs based on aws-cloudformation-user-guide @ ${{ steps.vars.outputs.commit-hash }}" || echo "ignore commit failure, may be empty"
 
-          git add .
+        git add .
 
-          git commit -m "Regenerating based on aws-cloudformation-user-guide @ ${{ steps.vars.outputs.commit-hash }}"
+        git commit -m "Regenerating based on aws-cloudformation-user-guide @ ${{ steps.vars.outputs.commit-hash }}"
 
-          git push origin generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-      - name: Create PR
-        id: create-pr
-        uses: repo-sync/pull-request@v2.6.2
-        with:
-          destination_branch: master
-          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          pr_body: "*Automated PR*"
-          pr_title: Automated SDK generation @ aws-cloudformation-user-guide ${{
-            steps.vars.outputs.commit-hash }}
-          author_name: pulumi-bot
-          source_branch: generate-sdk/${{ github.run_id }}-${{ github.run_number }}
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure during automated SDK generation
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        git push origin generate-sdk/${{ github.run_id }}-${{ github.run_number }}
+    - name: Create PR
+      id: create-pr
+      uses: repo-sync/pull-request@v2.6.2
+      with:
+        destination_branch: master
+        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        pr_body: "*Automated PR*"
+        pr_title: Automated SDK generation @ aws-cloudformation-user-guide ${{
+          steps.vars.outputs.commit-hash }}
+        author_name: pulumi-bot
+        source_branch: generate-sdk/${{ github.run_id }}-${{ github.run_number }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure during automated SDK generation
+        fields: repo,commit,author,action
+        status: ${{ job.status }}

--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: 1.20.x
     - name: Install pulumictl
@@ -72,7 +72,7 @@ jobs:
         git checkout -b generate-sdk/${{ github.run_id }}-${{ github.run_number }}
     - name: Commit Empty SDK
       run: |-
-        git add . 
+        git add .
         git commit -m "Preparing the SDK folder for regeneration"
     - name: Discovery
       run: make discovery

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -509,7 +509,7 @@ jobs:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-        uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -79,14 +79,14 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
-        uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: |
           ### Does the PR have any schema changes?
 
           ${{ env.SCHEMA_CHANGES }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if:
+    - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -144,7 +144,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -186,7 +186,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Initialize submodules
@@ -242,7 +242,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -284,7 +284,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Download SDK
@@ -293,7 +293,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-        run:
+      run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
         github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
@@ -345,7 +345,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -365,13 +365,13 @@ jobs:
         role-external-id: upload-pulumi-release
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-        run:
+      run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-          args:
+        args:
             -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
           60m0s
         version: latest
@@ -399,7 +399,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -476,7 +476,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -505,7 +505,7 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-        run:
+      run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,7 +4,7 @@ name: prerelease
 on:
   push:
     tags:
-      - v*.*.*-**
+    - v*.*.*-**
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: aws-native
@@ -37,87 +37,87 @@ jobs:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - if: github.event_name == 'pull_request'
-        name: Install Schema Tools
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: mikhailshilkov/schema-tools
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Build codegen binaries
-        run: make codegen
-      - name: Build Schema
-        run: make generate_schema
-      - if: github.event_name == 'pull_request'
-        name: Check Schema is Valid
-        run: >-
-          echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - if: github.event_name == 'pull_request'
+      name: Install Schema Tools
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: mikhailshilkov/schema-tools
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Build codegen binaries
+      run: make codegen
+    - name: Build Schema
+      run: make generate_schema
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      run: >-
+        echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-          schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
 
-          echo 'EOF' >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request'
-        name: Comment on PR with Details of Schema Check
+        echo 'EOF' >> $GITHUB_ENV
+    - if: github.event_name == 'pull_request'
+      name: Comment on PR with Details of Schema Check
         uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: |
-            ### Does the PR have any schema changes?
+      with:
+        message: |
+          ### Does the PR have any schema changes?
 
-            ${{ env.SCHEMA_CHANGES }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ${{ env.SCHEMA_CHANGES }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-          github.actor == 'pulumi-bot'
-        name: Add label if no breaking changes
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: impact/no-changelog-required
-          number: ${{ github.event.issue.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Provider
-        run: make provider
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-          pulumi-gen-${{ env.PROVIDER}}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin/provider.tar.gz
-      - name: Test Provider Library
-        run: make test_provider
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in building provider prerequisites
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        github.actor == 'pulumi-bot'
+      name: Add label if no breaking changes
+      uses: actions-ecosystem/action-add-labels@v1.1.0
+      with:
+        labels: impact/no-changelog-required
+        number: ${{ github.event.issue.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build Provider
+      run: make provider
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
+        pulumi-gen-${{ env.PROVIDER}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
+    - name: Test Provider Library
+      run: make test_provider
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in building provider prerequisites
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -125,392 +125,392 @@ jobs:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: build_sdks
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Generate SDK
-        run: make generate_${{ matrix.language }}
-      - name: Build SDK
-        run: make build_${{ matrix.language }}
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar SDK folder
-        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.language  }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure while building SDKs
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        -exec chmod +x {} \;
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Generate SDK
+      run: make generate_${{ matrix.language }}
+    - name: Build SDK
+      run: make build_${{ matrix.language }}
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar SDK folder
+      run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.language  }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
-      - build_sdks
+    - build_sdks
     strategy:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: test
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Download SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: UnTar SDK folder
+        -exec chmod +x {} \;
+    - name: Download SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.language }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: UnTar SDK folder
         run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-          github.workspace}}/sdk/${{ matrix.language}}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-      - name: Install Node dependencies
-        run: yarn global add typescript
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          version: v2.4.0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run tests
-        run: >-
-          set -euo pipefail
+        github.workspace}}/sdk/${{ matrix.language}}
+    - name: Update path
+      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+    - name: Install Node dependencies
+      run: yarn global add typescript
+    - run: dotnet nuget add source ${{ github.workspace }}/nuget
+    - name: Install Python deps
+      run: |-
+        pip3 install virtualenv==20.0.23
+        pip3 install pipenv
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.4.0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run tests
+      run: >-
+        set -euo pipefail
 
-          cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in SDK tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-11
     needs: test
     name: publish
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-external-id: upload-pulumi-release
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set PreRelease Version
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: us-east-2
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-external-id: upload-pulumi-release
+        role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+    - name: Set PreRelease Version
         run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-          >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
+        >> $GITHUB_ENV
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
           args:
             -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
-            60m0s
-          version: latest
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing binaries
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+          60m0s
+        version: latest
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing binaries
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
     name: publish_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Download python SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: python-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress python SDK
-        run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-          ${{github.workspace}}/sdk/python
-      - name: Download dotnet SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: dotnet-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress dotnet SDK
-        run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-          ${{github.workspace}}/sdk/dotnet
-      - name: Download nodejs SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: nodejs-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress nodejs SDK
-        run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-          ${{github.workspace}}/sdk/nodejs
-      - name: Install Twine
-        run: python -m pip install pip twine
-      - name: Publish SDKs
-        run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing SDK
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Download python SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress python SDK
+      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
+        ${{github.workspace}}/sdk/python
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress dotnet SDK
+      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
+        ${{github.workspace}}/sdk/dotnet
+    - name: Download nodejs SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress nodejs SDK
+      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
+        ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: publish
     name: publish_java_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download java SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: java-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress java SDK
-        run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-          ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
+        gradle-version: "7.6"
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
-      - name: Publish Java SDK
+        $GITHUB_ENV
+    - name: Publish Java SDK
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-          build-root-directory: ./sdk/java
-          gradle-version: 7.4.1
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,16 +34,16 @@ jobs:
     runs-on: ubuntu-latest
     name: comment-on-pr
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Comment PR
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Comment PR
         uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: >
-            PR is now waiting for a maintainer to run the acceptance tests.
+      with:
+        message: >
+          PR is now waiting for a maintainer to run the acceptance tests.
 
-            **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         lfs: true
     - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: >
           PR is now waiting for a maintainer to run the acceptance tests.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ name: release
 on:
   push:
     tags:
-      - v*.*.*
-      - "!v*.*.*-**"
+    - v*.*.*
+    - "!v*.*.*-**"
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: aws-native
@@ -37,87 +37,87 @@ jobs:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - if: github.event_name == 'pull_request'
-        name: Install Schema Tools
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: mikhailshilkov/schema-tools
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Build codegen binaries
-        run: make codegen
-      - name: Build Schema
-        run: make generate_schema
-      - if: github.event_name == 'pull_request'
-        name: Check Schema is Valid
-        run: >-
-          echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - if: github.event_name == 'pull_request'
+      name: Install Schema Tools
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: mikhailshilkov/schema-tools
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Build codegen binaries
+      run: make codegen
+    - name: Build Schema
+      run: make generate_schema
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      run: >-
+        echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-          schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
 
-          echo 'EOF' >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request'
-        name: Comment on PR with Details of Schema Check
+        echo 'EOF' >> $GITHUB_ENV
+    - if: github.event_name == 'pull_request'
+      name: Comment on PR with Details of Schema Check
         uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: |
-            ### Does the PR have any schema changes?
+      with:
+        message: |
+          ### Does the PR have any schema changes?
 
-            ${{ env.SCHEMA_CHANGES }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ${{ env.SCHEMA_CHANGES }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-          github.actor == 'pulumi-bot'
-        name: Add label if no breaking changes
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: impact/no-changelog-required
-          number: ${{ github.event.issue.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Provider
-        run: make provider
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-          pulumi-gen-${{ env.PROVIDER}}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin/provider.tar.gz
-      - name: Test Provider Library
-        run: make test_provider
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in building provider prerequisites
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        github.actor == 'pulumi-bot'
+      name: Add label if no breaking changes
+      uses: actions-ecosystem/action-add-labels@v1.1.0
+      with:
+        labels: impact/no-changelog-required
+        number: ${{ github.event.issue.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build Provider
+      run: make provider
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
+        pulumi-gen-${{ env.PROVIDER}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
+    - name: Test Provider Library
+      run: make test_provider
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in building provider prerequisites
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
     runs-on: ubuntu-latest
@@ -125,421 +125,421 @@ jobs:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: build_sdks
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Generate SDK
-        run: make generate_${{ matrix.language }}
-      - name: Build SDK
-        run: make build_${{ matrix.language }}
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar SDK folder
-        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.language  }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure while building SDKs
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        -exec chmod +x {} \;
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Generate SDK
+      run: make generate_${{ matrix.language }}
+    - name: Build SDK
+      run: make build_${{ matrix.language }}
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar SDK folder
+      run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.language  }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   test:
     runs-on: ubuntu-latest
     needs:
-      - build_sdks
+    - build_sdks
     strategy:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: test
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Download SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: UnTar SDK folder
+        -exec chmod +x {} \;
+    - name: Download SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.language }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: UnTar SDK folder
         run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-          github.workspace}}/sdk/${{ matrix.language}}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-      - name: Install Node dependencies
-        run: yarn global add typescript
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          version: v2.4.0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run tests
-        run: >-
-          set -euo pipefail
+        github.workspace}}/sdk/${{ matrix.language}}
+    - name: Update path
+      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+    - name: Install Node dependencies
+      run: yarn global add typescript
+    - run: dotnet nuget add source ${{ github.workspace }}/nuget
+    - name: Install Python deps
+      run: |-
+        pip3 install virtualenv==20.0.23
+        pip3 install pipenv
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.4.0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run tests
+      run: >-
+        set -euo pipefail
 
-          cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in SDK tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish:
     runs-on: macos-11
     needs: test
     name: publish
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: us-east-2
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 7200
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-external-id: upload-pulumi-release
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
-      - name: Set PreRelease Version
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: us-east-2
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 7200
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-external-id: upload-pulumi-release
+        role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+    - name: Set PreRelease Version
         run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
-          >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          args: -p 3 release --rm-dist --timeout 60m0s
-          version: latest
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing binaries
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        >> $GITHUB_ENV
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        args: -p 3 release --rm-dist --timeout 60m0s
+        version: latest
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing binaries
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_sdk:
     runs-on: ubuntu-latest
     needs: publish
     name: publish_sdks
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Download python SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: python-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress python SDK
-        run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-          ${{github.workspace}}/sdk/python
-      - name: Download dotnet SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: dotnet-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress dotnet SDK
-        run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-          ${{github.workspace}}/sdk/dotnet
-      - name: Download nodejs SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: nodejs-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress nodejs SDK
-        run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-          ${{github.workspace}}/sdk/nodejs
-      - name: Install Twine
-        run: python -m pip install pip twine
-      - name: Publish SDKs
-        run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in publishing SDK
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Download python SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: python-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress python SDK
+      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
+        ${{github.workspace}}/sdk/python
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress dotnet SDK
+      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
+        ${{github.workspace}}/sdk/dotnet
+    - name: Download nodejs SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress nodejs SDK
+      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
+        ${{github.workspace}}/sdk/nodejs
+    - name: Install Twine
+      run: python -m pip install pip twine
+    - name: Publish SDKs
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in publishing SDK
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
   publish_java_sdk:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: publish
     name: publish_java_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download java SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: java-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: Uncompress java SDK
-        run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-          ${{github.workspace}}/sdk/java
-      - name: Set PACKAGE_VERSION to Env
+        gradle-version: "7.6"
+    - name: Download java SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: java-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: Uncompress java SDK
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+        ${{github.workspace}}/sdk/java
+    - name: Set PACKAGE_VERSION to Env
         run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-          $GITHUB_ENV
-      - name: Publish Java SDK
+        $GITHUB_ENV
+    - name: Publish Java SDK
         uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
-          build-root-directory: ./sdk/java
-          gradle-version: 7.4.1
+      with:
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
+        build-root-directory: ./sdk/java
+        gradle-version: 7.4.1
   tag_sdk:
     runs-on: ubuntu-latest
     needs: publish_sdk
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Add SDK version tag
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Add SDK version tag
         run:
           git tag sdk/v$(pulumictl get version --language generic) && git push origin
-          sdk/v$(pulumictl get version --language generic)
+        sdk/v$(pulumictl get version --language generic)
     name: tag_sdk
   dispatch_docs_build:
     runs-on: ubuntu-latest
     needs: tag_sdk
     steps:
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Dispatch Event
-        run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
-          ${GITHUB_REF#refs/tags/}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Dispatch Event
+      run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
+        ${GITHUB_REF#refs/tags/}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: dispatch_docs_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -79,14 +79,14 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
-        uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: |
           ### Does the PR have any schema changes?
 
           ${{ env.SCHEMA_CHANGES }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if:
+    - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -144,7 +144,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -186,7 +186,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Initialize submodules
@@ -242,7 +242,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -284,7 +284,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Download SDK
@@ -293,7 +293,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-        run:
+      run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
         github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
@@ -345,7 +345,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -365,7 +365,7 @@ jobs:
         role-external-id: upload-pulumi-release
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
-        run:
+      run:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)"
         >> $GITHUB_ENV
     - name: Run GoReleaser
@@ -397,7 +397,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -474,7 +474,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -503,11 +503,11 @@ jobs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
     - name: Set PACKAGE_VERSION to Env
-        run:
+      run:
           echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
     - name: Publish Java SDK
-        uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java
@@ -525,7 +525,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Add SDK version tag
-        run:
+      run:
           git tag sdk/v$(pulumictl get version --language generic) && git push origin
         sdk/v$(pulumictl get version --language generic)
     name: tag_sdk

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -103,14 +103,14 @@ jobs:
         echo 'EOF' >> $GITHUB_ENV
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
-        uses: thollander/actions-comment-pull-request@v1
+      uses: thollander/actions-comment-pull-request@v1
       with:
         message: |
           ### Does the PR have any schema changes?
 
           ${{ env.SCHEMA_CHANGES }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - if:
+    - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
         github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
@@ -171,7 +171,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -213,7 +213,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Initialize submodules
@@ -272,7 +272,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -314,7 +314,7 @@ jobs:
       run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
         github.workspace}}/bin
     - name: Restore Binary Permissions
-        run:
+      run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
         -exec chmod +x {} \;
     - name: Download SDK
@@ -323,7 +323,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-        run:
+      run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
         github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -4,13 +4,13 @@ name: run-acceptance-tests
 on:
   repository_dispatch:
     types:
-      - run-acceptance-tests-command
+    - run-acceptance-tests-command
   pull_request:
     branches:
-      - master
-      - main
+    - master
+    - main
     paths-ignore:
-      - CHANGELOG.md
+    - CHANGELOG.md
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -44,104 +44,104 @@ jobs:
     runs-on: ubuntu-latest
     name: comment-notification
     steps:
-      - name: Create URL to the run output
-        id: vars
-        run: echo ::set-output
-          name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-      - name: Update with Result
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
-          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
-          body: "Please view the PR build: ${{ steps.vars.outputs.run-url }}"
+    - name: Create URL to the run output
+      id: vars
+      run: echo ::set-output
+        name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+    - name: Update with Result
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: "Please view the PR build: ${{ steps.vars.outputs.run-url }}"
     if: github.event_name == 'repository_dispatch'
   prerequisites:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          ref: ${{ env.PR_COMMIT_SHA }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - if: github.event_name == 'pull_request'
-        name: Install Schema Tools
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: mikhailshilkov/schema-tools
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Build codegen binaries
-        run: make codegen
-      - name: Build Schema
-        run: make generate_schema
-      - if: github.event_name == 'pull_request'
-        name: Check Schema is Valid
-        run: >-
-          echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - if: github.event_name == 'pull_request'
+      name: Install Schema Tools
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: mikhailshilkov/schema-tools
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Build codegen binaries
+      run: make codegen
+    - name: Build Schema
+      run: make generate_schema
+    - if: github.event_name == 'pull_request'
+      name: Check Schema is Valid
+      run: >-
+        echo 'SCHEMA_CHANGES<<EOF' >> $GITHUB_ENV
 
-          schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
+        schema-tools compare ${{ env.PROVIDER }} master --local-path=provider/cmd/pulumi-resource-${{ env.PROVIDER }}/schema.json >> $GITHUB_ENV
 
-          echo 'EOF' >> $GITHUB_ENV
-      - if: github.event_name == 'pull_request'
-        name: Comment on PR with Details of Schema Check
+        echo 'EOF' >> $GITHUB_ENV
+    - if: github.event_name == 'pull_request'
+      name: Comment on PR with Details of Schema Check
         uses: thollander/actions-comment-pull-request@v1
-        with:
-          message: |
-            ### Does the PR have any schema changes?
+      with:
+        message: |
+          ### Does the PR have any schema changes?
 
-            ${{ env.SCHEMA_CHANGES }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ${{ env.SCHEMA_CHANGES }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if:
           contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-          github.actor == 'pulumi-bot'
-        name: Add label if no breaking changes
-        uses: actions-ecosystem/action-add-labels@v1.1.0
-        with:
-          labels: impact/no-changelog-required
-          number: ${{ github.event.issue.number }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build Provider
-        run: make provider
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar provider binaries
-        run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
-          pulumi-gen-${{ env.PROVIDER}}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin/provider.tar.gz
-      - name: Test Provider Library
-        run: make test_provider
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in building provider prerequisites
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        github.actor == 'pulumi-bot'
+      name: Add label if no breaking changes
+      uses: actions-ecosystem/action-add-labels@v1.1.0
+      with:
+        labels: impact/no-changelog-required
+        number: ${{ github.event.issue.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build Provider
+      run: make provider
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar provider binaries
+      run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin/ pulumi-resource-${{ env.PROVIDER }}
+        pulumi-gen-${{ env.PROVIDER}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin/provider.tar.gz
+    - name: Test Provider Library
+      run: make test_provider
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in building provider prerequisites
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
@@ -151,227 +151,227 @@ jobs:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: build_sdks
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          ref: ${{ env.PR_COMMIT_SHA }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Generate SDK
-        run: make generate_${{ matrix.language }}
-      - name: Build SDK
-        run: make build_${{ matrix.language }}
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
-      - run: git status --porcelain
-      - name: Tar SDK folder
-        run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.language  }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure while building SDKs
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        -exec chmod +x {} \;
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Generate SDK
+      run: make generate_${{ matrix.language }}
+    - name: Build SDK
+      run: make build_${{ matrix.language }}
+    - name: Check worktree clean
+      run: ./ci-scripts/ci/check-worktree-is-clean
+    - run: git status --porcelain
+    - name: Tar SDK folder
+      run: tar -zcf sdk/${{ matrix.language }}.tar.gz -C sdk/${{ matrix.language }} .
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.language  }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure while building SDKs
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   test:
     runs-on: ubuntu-latest
     needs:
-      - build_sdks
+    - build_sdks
     strategy:
       fail-fast: true
       matrix:
         language:
-          - nodejs
-          - python
-          - dotnet
-          - go
-          - java
+        - nodejs
+        - python
+        - dotnet
+        - go
+        - java
     name: test
     permissions:
       contents: read
       id-token: write
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-          ref: ${{ env.PR_COMMIT_SHA }}
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v3
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+        ref: ${{ env.PR_COMMIT_SHA }}
+    - name: Checkout Scripts Repo
+      uses: actions/checkout@v3
+      with:
+        path: ci-scripts
+        repository: pulumi/scripts
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ env.JAVAVERSION }}
-          distribution: temurin
-          cache: gradle
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        java-version: ${{ env.JAVAVERSION }}
+        distribution: temurin
+        cache: gradle
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
           # Pin to known good version until #2262 is resolved
-          gradle-version: "7.6"
-      - name: Download provider + tfgen binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
-          path: ${{ github.workspace }}/bin
-      - name: UnTar provider binaries
-        run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
-          github.workspace}}/bin
-      - name: Restore Binary Permissions
+        gradle-version: "7.6"
+    - name: Download provider + tfgen binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
+        path: ${{ github.workspace }}/bin
+    - name: UnTar provider binaries
+      run: tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{
+        github.workspace}}/bin
+    - name: Restore Binary Permissions
         run:
           find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
-          -exec chmod +x {} \;
-      - name: Download SDK
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ matrix.language }}-sdk.tar.gz
-          path: ${{ github.workspace}}/sdk/
-      - name: UnTar SDK folder
+        -exec chmod +x {} \;
+    - name: Download SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: ${{ matrix.language }}-sdk.tar.gz
+        path: ${{ github.workspace}}/sdk/
+    - name: UnTar SDK folder
         run:
           tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-          github.workspace}}/sdk/${{ matrix.language}}
-      - name: Update path
-        run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-      - name: Install Node dependencies
-        run: yarn global add typescript
-      - run: dotnet nuget add source ${{ github.workspace }}/nuget
-      - name: Install Python deps
-        run: |-
-          pip3 install virtualenv==20.0.23
-          pip3 install pipenv
-      - name: Install dependencies
-        run: make install_${{ matrix.language}}_sdk
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-region: ${{ env.AWS_REGION }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-duration-seconds: 3600
-          role-session-name: ${{ env.PROVIDER }}@githubActions
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-      - name: Install gotestfmt
-        uses: GoTestTools/gotestfmt-action@v2
-        with:
-          version: v2.4.0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run tests
-        run: >-
-          set -euo pipefail
+        github.workspace}}/sdk/${{ matrix.language}}
+    - name: Update path
+      run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+    - name: Install Node dependencies
+      run: yarn global add typescript
+    - run: dotnet nuget add source ${{ github.workspace }}/nuget
+    - name: Install Python deps
+      run: |-
+        pip3 install virtualenv==20.0.23
+        pip3 install pipenv
+    - name: Install dependencies
+      run: make install_${{ matrix.language}}_sdk
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-region: ${{ env.AWS_REGION }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-duration-seconds: 3600
+        role-session-name: ${{ env.PROVIDER }}@githubActions
+        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.4.0
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run tests
+      run: >-
+        set -euo pipefail
 
-          cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-      - if: failure() && github.event_name == 'push'
-        name: Notify Slack
-        uses: 8398a7/action-slack@v3
-        with:
-          author_name: Failure in SDK tests
-          fields: repo,commit,author,action
-          status: ${{ job.status }}
+        cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
+    - if: failure() && github.event_name == 'push'
+      name: Notify Slack
+      uses: 8398a7/action-slack@v3
+      with:
+        author_name: Failure in SDK tests
+        fields: repo,commit,author,action
+        status: ${{ job.status }}
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
   sentinel:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
-      - name: Is workflow a success
-        run: echo yes
+    - name: Is workflow a success
+      run: echo yes
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     needs:
-      - test
+    - test

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Unshallow clone for tags
       run: git fetch --prune --unshallow --tags
     - name: Install Go
-        uses: actions/setup-go@v2
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
@@ -95,8 +95,8 @@ jobs:
 
         git update-index -q --refresh
 
-        if ! git diff-files --quiet; then 
-        	echo ::set-output name=changes::1 
+        if ! git diff-files --quiet; then
+          echo ::set-output name=changes::1
         fi
     - name: Initialize submodules
       run: make init_submodules

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -3,7 +3,7 @@
 name: weekly-pulumi-update
 on:
   schedule:
-    - cron: 35 12 * * 4
+  - cron: 35 12 * * 4
   workflow_dispatch: {}
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -35,110 +35,110 @@ jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          lfs: true
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+    - name: Unshallow clone for tags
+      run: git fetch --prune --unshallow --tags
+    - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.5.0
-        with:
-          repo: pulumi/pulumictl
-      - name: Install Pulumi CLI
-        uses: pulumi/action-install-pulumi-cli@v2
-      - name: Setup DotNet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ env.DOTNETVERSION }}
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODEVERSION }}
-          registry-url: https://registry.npmjs.org
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHONVERSION }}
-      - name: Update Pulumi/Pulumi
-        id: gomod
-        run: >-
-          git config --local user.email 'bot@pulumi.com'
+      with:
+        go-version: ${{ env.GOVERSION }}
+    - name: Install pulumictl
+      uses: jaxxstorm/action-install-gh-release@v1.5.0
+      with:
+        repo: pulumi/pulumictl
+    - name: Install Pulumi CLI
+      uses: pulumi/action-install-pulumi-cli@v2
+    - name: Setup DotNet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODEVERSION }}
+        registry-url: https://registry.npmjs.org
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ env.PYTHONVERSION }}
+    - name: Update Pulumi/Pulumi
+      id: gomod
+      run: >-
+        git config --local user.email 'bot@pulumi.com'
 
-          git config --local user.name 'pulumi-bot'
+        git config --local user.name 'pulumi-bot'
 
-          git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
+        git checkout -b update-pulumi/${{ github.run_id }}-${{ github.run_number }}
 
-          cd provider
+        cd provider
 
-          go get github.com/pulumi/pulumi/pkg/v3
+        go get github.com/pulumi/pulumi/pkg/v3
 
-          go get github.com/pulumi/pulumi/sdk/v3
+        go get github.com/pulumi/pulumi/sdk/v3
 
-          go mod download
+        go mod download
 
-          go mod tidy
+        go mod tidy
 
-          cd ../sdk
+        cd ../sdk
 
-          go get github.com/pulumi/pulumi/sdk/v3
+        go get github.com/pulumi/pulumi/sdk/v3
 
-          go mod download
+        go mod download
 
-          go mod tidy
+        go mod tidy
 
-          cd ..
+        cd ..
 
-          git update-index -q --refresh
+        git update-index -q --refresh
 
-          if ! git diff-files --quiet; then 
-          	echo ::set-output name=changes::1 
-          fi
-      - name: Initialize submodules
-        run: make init_submodules
-      - name: Provider with Pulumi Upgrade
-        if: steps.gomod.outputs.changes != 0
-        run: >-
-          make codegen && make local_generate
+        if ! git diff-files --quiet; then 
+        	echo ::set-output name=changes::1 
+        fi
+    - name: Initialize submodules
+      run: make init_submodules
+    - name: Provider with Pulumi Upgrade
+      if: steps.gomod.outputs.changes != 0
+      run: >-
+        make codegen && make local_generate
 
-          git add sdk/nodejs
+        git add sdk/nodejs
 
-          git commit -m "Regenerating Node.js SDK based on updated modules" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating Node.js SDK based on updated modules" || echo "ignore commit failure, may be empty"
 
-          git add sdk/python
+        git add sdk/python
 
-          git commit -m "Regenerating Python SDK based on updated modules" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating Python SDK based on updated modules" || echo "ignore commit failure, may be empty"
 
-          git add sdk/dotnet
+        git add sdk/dotnet
 
-          git commit -m "Regenerating .NET SDK based on updated modules" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating .NET SDK based on updated modules" || echo "ignore commit failure, may be empty"
 
-          git add sdk/go*
+        git add sdk/go*
 
-          git commit -m "Regenerating Go SDK based on updated modules" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating Go SDK based on updated modules" || echo "ignore commit failure, may be empty"
 
-          git add sdk/java*
+        git add sdk/java*
 
-          git commit -m "Regenerating Java SDK based on updated modules" || echo "ignore commit failure, may be empty"
+        git commit -m "Regenerating Java SDK based on updated modules" || echo "ignore commit failure, may be empty"
 
-          git add .
+        git add .
 
-          git commit -m "Updated modules"
+        git commit -m "Updated modules"
 
-          git push origin update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-      - name: Create PR
-        id: create-pr
-        if: steps.gomod.outputs.changes != 0
-        uses: repo-sync/pull-request@v2.6.2
-        with:
-          source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
-          destination_branch: master
-          pr_title: Automated Pulumi/Pulumi upgrade
-          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        git push origin update-pulumi/${{ github.run_id }}-${{ github.run_number }}
+    - name: Create PR
+      id: create-pr
+      if: steps.gomod.outputs.changes != 0
+      uses: repo-sync/pull-request@v2.6.2
+      with:
+        source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
+        destination_branch: master
+        pr_title: Automated Pulumi/Pulumi upgrade
+        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update


### PR DESCRIPTION
@aq17 Tried to update this repo using ci-mgmt in #1001, but since this repo hasn't been using ci-mgmt there were a lot of unrelated changes, mostly to whitespace. This PR contains just the whitespace changes from #1001 to hopefully make it a little easier to evaluate a move to using ci-mgmt to manage the build tooling for this repo
