### PR TITLE
Add error handling to CfnToSdk

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -764,7 +764,10 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 		cfType = spec.CfType
 
 		// Convert SDK inputs to CFN payload.
-		payload = schema.SdkToCfn(&spec, p.resourceMap.Types, inputs.MapRepl(nil, mapReplStripSecrets))
+		payload, err = schema.SdkToCfn(&spec, p.resourceMap.Types, inputs.MapRepl(nil, mapReplStripSecrets))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert value for %s: %w", resourceToken, err)
+		}
 	}
 
 	// Serialize inputs as a desired state JSON.

--- a/provider/pkg/schema/convert.go
+++ b/provider/pkg/schema/convert.go
@@ -3,6 +3,7 @@
 package schema
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -13,7 +14,7 @@ import (
 
 // SdkToCfn converts Pulumi-SDK-shaped state to CloudFormation-shaped payload. In particular, SDK properties
 // are lowerCamelCase, while CloudFormation is usually (but not always) PascalCase.
-func SdkToCfn(res *CloudAPIResource, types map[string]CloudAPIType, properties map[string]interface{}) map[string]interface{} {
+func SdkToCfn(res *CloudAPIResource, types map[string]CloudAPIType, properties map[string]interface{}) (map[string]interface{}, error) {
 	converter := sdkToCfnConverter{res, types}
 	return converter.sdkToCfn(properties)
 }
@@ -25,7 +26,7 @@ func DiffToPatch(res *CloudAPIResource, types map[string]CloudAPIType, diff *res
 		return []jsonpatch.JsonPatchOperation{}, nil
 	}
 	converter := sdkToCfnConverter{res, types}
-	return converter.diffToPatch(diff), nil
+	return converter.diffToPatch(diff)
 }
 
 type sdkToCfnConverter struct {
@@ -33,25 +34,33 @@ type sdkToCfnConverter struct {
 	types map[string]CloudAPIType
 }
 
-func (c *sdkToCfnConverter) sdkToCfn(properties map[string]interface{}) map[string]interface{} {
+func (c *sdkToCfnConverter) sdkToCfn(properties map[string]interface{}) (map[string]interface{}, error) {
 	result := map[string]interface{}{}
 	for k, prop := range c.spec.Inputs {
 		if v, ok := properties[k]; ok {
-			result[ToCfnName(k, c.spec.IrreversibleNames)] = c.sdkTypedValueToCfn(&prop.TypeSpec, v)
+			converted, err := c.sdkTypedValueToCfn(&prop.TypeSpec, v)
+			if err != nil {
+				return nil, err
+			}
+			result[ToCfnName(k, c.spec.IrreversibleNames)] = converted
 		}
 	}
 	for k, attr := range c.spec.Outputs {
 		if v, ok := properties[k]; ok {
-			result[ToCfnName(k, c.spec.IrreversibleNames)] = c.sdkTypedValueToCfn(&attr.TypeSpec, v)
+			converted, err := c.sdkTypedValueToCfn(&attr.TypeSpec, v)
+			if err != nil {
+				return nil, err
+			}
+			result[ToCfnName(k, c.spec.IrreversibleNames)] = converted
 		}
 	}
-	return result
+	return result, nil
 }
 
-func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interface{}) interface{} {
+func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interface{}) (interface{}, error) {
 	if spec.Ref != "" {
 		if spec.Ref == "pulumi.json#/Any" {
-			return v
+			return v, nil
 		}
 
 		typName := strings.TrimPrefix(spec.Ref, "#/types/")
@@ -60,53 +69,91 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 
 	if spec.OneOf != nil {
 		for _, item := range spec.OneOf {
-			converted := c.sdkTypedValueToCfn(&item, v)
-			// If the conversion resulted in a different value, return it.
-			// We should probably fail if we can't convert rather than considering change a success.
-			// This is likely to happen if one of the types is any.
-			if !reflect.DeepEqual(converted, v) {
-				return converted
+			converted, err := c.sdkTypedValueToCfn(&item, v)
+			// return the first successful conversion
+			if err == nil {
+				return converted, nil
 			}
 		}
+		return nil, &ConversionError{fmt.Sprintf("%v", *spec), v}
 	}
 
 	switch spec.Type {
 	case "array":
-		array := v.([]interface{})
-		vs := make([]interface{}, len(array))
-		for i, item := range array {
-			vs[i] = c.sdkTypedValueToCfn(spec.Items, item)
+		if array, ok := v.([]interface{}); ok {
+			vs := make([]interface{}, len(array))
+			for i, item := range array {
+				converted, err := c.sdkTypedValueToCfn(spec.Items, item)
+				if err != nil {
+					return nil, err
+				}
+				vs[i] = converted
+			}
+			return vs, nil
 		}
-		return vs
 	case "object":
-		sourceMap := v.(map[string]interface{})
-		vs := map[string]interface{}{}
-		for n, item := range sourceMap {
-			vs[n] = c.sdkTypedValueToCfn(spec.AdditionalProperties, item)
+		if sourceMap, ok := v.(map[string]interface{}); ok {
+			vs := map[string]interface{}{}
+			for n, item := range sourceMap {
+				converted, err := c.sdkTypedValueToCfn(spec.AdditionalProperties, item)
+				if err != nil {
+					return nil, err
+				}
+				vs[n] = converted
+			}
+			return vs, nil
 		}
-		return vs
+	case "string":
+		if _, ok := v.(string); ok {
+			return v, nil
+		}
+	case "number":
+		if isNumberLike(v) {
+			return v, nil
+		}
+	case "integer":
+		if isNumberLike(v) {
+			return v, nil
+		}
+	case "boolean":
+		if _, ok := v.(bool); ok {
+			return v, nil
+		}
 	default:
-		return v
+		return nil, fmt.Errorf("Unrecognized type: " + spec.Type)
 	}
+	return nil, &ConversionError{spec.Type, v}
 }
 
-func (c *sdkToCfnConverter) sdkObjectValueToCfn(typeName string, value interface{}) interface{} {
+func isNumberLike(v interface{}) bool {
+	switch v.(type) {
+	case int, uint, int32, uint32, int64, uint64, float32, float64:
+		return true
+	}
+	return false
+}
+
+func (c *sdkToCfnConverter) sdkObjectValueToCfn(typeName string, value interface{}) (interface{}, error) {
 	properties, ok := value.(map[string]interface{})
 	if !ok {
-		return value
+		return nil, &ConversionError{typeName, value}
 	}
 
 	spec := c.types[typeName]
 	result := map[string]interface{}{}
 	for k, prop := range spec.Properties {
 		if v, ok := properties[k]; ok {
-			result[ToCfnName(k, spec.IrreversibleNames)] = c.sdkTypedValueToCfn(&prop.TypeSpec, v)
+			converted, err := c.sdkTypedValueToCfn(&prop.TypeSpec, v)
+			if err != nil {
+				return nil, err
+			}
+			result[ToCfnName(k, spec.IrreversibleNames)] = converted
 		}
 	}
-	return result
+	return result, nil
 }
 
-func (c *sdkToCfnConverter) diffToPatch(diff *resource.ObjectDiff) []jsonpatch.JsonPatchOperation {
+func (c *sdkToCfnConverter) diffToPatch(diff *resource.ObjectDiff) ([]jsonpatch.JsonPatchOperation, error) {
 	var ops []jsonpatch.JsonPatchOperation
 	for sdkName, prop := range c.spec.Inputs {
 		cfnName := ToCfnName(sdkName, c.spec.IrreversibleNames)
@@ -115,26 +162,35 @@ func (c *sdkToCfnConverter) diffToPatch(diff *resource.ObjectDiff) []jsonpatch.J
 			// Check if properties are write-only, and use an "add" if so. This is because the old values of write only
 			// properties don't show up when applying the diff within CC, so we need to do an "add".
 			if c.isPropWriteOnly(sdkName) {
-				op := c.valueToPatch("add", cfnName, prop, v.New)
-				ops = append(ops, op)
+				op, err := c.valueToPatch("add", cfnName, prop, v.New)
+				if err != nil {
+					return nil, err
+				}
+				ops = append(ops, *op)
 			} else {
-				op := c.valueToPatch("replace", cfnName, prop, v.New)
-				ops = append(ops, op)
+				op, err := c.valueToPatch("replace", cfnName, prop, v.New)
+				if err != nil {
+					return nil, err
+				}
+				ops = append(ops, *op)
 			}
 		}
 		if v, ok := diff.Adds[key]; ok {
-			op := c.valueToPatch("add", cfnName, prop, v)
-			ops = append(ops, op)
+			op, err := c.valueToPatch("add", cfnName, prop, v)
+			if err != nil {
+				return nil, err
+			}
+			ops = append(ops, *op)
 		}
 		if _, ok := diff.Deletes[key]; ok {
 			op := jsonpatch.NewPatch("remove", "/"+cfnName, nil)
 			ops = append(ops, op)
 		}
 	}
-	return ops
+	return ops, nil
 }
 
-func (c *sdkToCfnConverter) valueToPatch(opName, propName string, prop pschema.PropertySpec, value resource.PropertyValue) jsonpatch.JsonPatchOperation {
+func (c *sdkToCfnConverter) valueToPatch(opName, propName string, prop pschema.PropertySpec, value resource.PropertyValue) (*jsonpatch.JsonPatchOperation, error) {
 	op := jsonpatch.NewPatch(opName, "/"+propName, nil)
 	switch {
 	case value.IsNumber() && prop.Type == "integer":
@@ -148,10 +204,13 @@ func (c *sdkToCfnConverter) valueToPatch(opName, propName string, prop pschema.P
 		op.Value = value.StringValue()
 	default:
 		sdkObj := value.MapRepl(nil, nil)
-		cfnObj := c.sdkTypedValueToCfn(&prop.TypeSpec, sdkObj)
+		cfnObj, err := c.sdkTypedValueToCfn(&prop.TypeSpec, sdkObj)
+		if err != nil {
+			return nil, err
+		}
 		op.Value = cfnObj
 	}
-	return op
+	return &op, nil
 }
 
 func (c *sdkToCfnConverter) isPropWriteOnly(cfnName string) bool {
@@ -194,4 +253,13 @@ func cfnValueToSdk(value interface{}) interface{} {
 	default:
 		return value
 	}
+}
+
+type ConversionError struct {
+	Type  string
+	Value interface{}
+}
+
+func (e *ConversionError) Error() string {
+	return fmt.Sprintf("Could not convert as type %s: %v", e.Type, e.Value)
 }

--- a/provider/pkg/schema/convert_examples_test.go
+++ b/provider/pkg/schema/convert_examples_test.go
@@ -54,6 +54,7 @@ func testConversion(t *testing.T, resource string, input map[string]interface{},
 	err = json.Unmarshal(bytes, &metadata)
 	assert.NoError(t, err)
 	res := metadata.Resources[resource]
-	actual := SdkToCfn(&res, metadata.Types, input)
+	actual, err := SdkToCfn(&res, metadata.Types, input)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/provider/pkg/schema/convert_test.go
+++ b/provider/pkg/schema/convert_test.go
@@ -19,8 +19,45 @@ func TestCfnToSdk(t *testing.T) {
 
 func TestSdkToCfn(t *testing.T) {
 	res := sampleSchema.Resources["aws-native:ecs:Service"]
-	actual := SdkToCfn(&res, sampleSchema.Types, sdkState)
+	actual, _ := SdkToCfn(&res, sampleSchema.Types, sdkState)
 	assert.Equal(t, cfnPayload, actual)
+
+	// error when value does not match type
+	badSdkState := sdkState
+	badSdkState["loadBalancers"] = map[string]interface{}{
+		"containerName":  "my-app",
+		"containerPort":  80,
+		"targetGroupArn": "arn:aws:elasticloadbalancing:us-west-2:12345:targetgroup/app-tg-a56e4c3/51317265a5dc6a1f",
+	}
+	_, err := SdkToCfn(&res, sampleSchema.Types, badSdkState)
+	cErr := &ConversionError{}
+	assert.ErrorAs(t, err, &cErr, "Should catch conversions of invalid types")
+}
+
+func TestSdkToCfnOneOf(t *testing.T) {
+	res := CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"foo": {
+				TypeSpec: pschema.TypeSpec{
+					OneOf: []pschema.TypeSpec{
+						pschema.TypeSpec{
+							Type:  "array",
+							Items: &pschema.TypeSpec{Type: "string"},
+						},
+						pschema.TypeSpec{
+							Type:                 "object",
+							AdditionalProperties: &pschema.TypeSpec{Type: "number"},
+						},
+					},
+				},
+			},
+		},
+	}
+	state := map[string]interface{}{"foo": map[string]interface{}{"bar": 1, "baz": 2}}
+	expected := map[string]interface{}{"Foo": map[string]interface{}{"bar": 1, "baz": 2}}
+	actual, err := SdkToCfn(&res, sampleSchema.Types, state)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }
 
 func TestDiffToPatch(t *testing.T) {
@@ -55,7 +92,7 @@ func TestDiffToPatch(t *testing.T) {
 					"ContainerName": "my-app",
 					"ContainerPort": 80.,
 				},
-		}),
+			}),
 		jsonpatch.NewPatch("remove", "/PlatformVersion", nil),
 	}
 	res := sampleSchema.Resources["aws-native:ecs:Service"]
@@ -156,13 +193,13 @@ var sampleSchema = &CloudAPIMetadata{
 				"assignPublicIp": {TypeSpec: pschema.TypeSpec{Type: "string"}},
 				"securityGroups": {
 					TypeSpec: pschema.TypeSpec{
-						Type: "array",
+						Type:  "array",
 						Items: &pschema.TypeSpec{Type: "string"},
 					},
 				},
 				"subnets": {
 					TypeSpec: pschema.TypeSpec{
-						Type: "array",
+						Type:  "array",
 						Items: &pschema.TypeSpec{Type: "string"},
 					},
 				},
@@ -181,8 +218,8 @@ var sampleSchema = &CloudAPIMetadata{
 						Ref: "#/types/aws-native:ecs:DeploymentCircuitBreaker",
 					},
 				},
-				"maximumPercent":           {TypeSpec: pschema.TypeSpec{Type: "integer"}},
-				"minimumHealthyPercent":    {TypeSpec: pschema.TypeSpec{Type: "integer"}},
+				"maximumPercent":        {TypeSpec: pschema.TypeSpec{Type: "integer"}},
+				"minimumHealthyPercent": {TypeSpec: pschema.TypeSpec{Type: "integer"}},
 			},
 		},
 		"aws-native:ecs:LoadBalancer": {
@@ -206,16 +243,16 @@ var sampleSchema = &CloudAPIMetadata{
 	Resources: map[string]CloudAPIResource{
 		"aws-native:ecs:Service": {
 			Inputs: map[string]pschema.PropertySpec{
-				"serviceArn":              {TypeSpec: pschema.TypeSpec{Type: "string"}},
-				"cluster":                 {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"serviceArn": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"cluster":    {TypeSpec: pschema.TypeSpec{Type: "string"}},
 				"deploymentConfiguration": {
 					TypeSpec: pschema.TypeSpec{
 						Ref: "#/types/aws-native:ecs:DeploymentConfiguration",
 					},
 				},
-				"desiredCount":            {TypeSpec: pschema.TypeSpec{Type: "integer"}},
-				"enableEcsManagedTags":    {TypeSpec: pschema.TypeSpec{Type: "boolean"}},
-				"launchType":              {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"desiredCount":         {TypeSpec: pschema.TypeSpec{Type: "integer"}},
+				"enableEcsManagedTags": {TypeSpec: pschema.TypeSpec{Type: "boolean"}},
+				"launchType":           {TypeSpec: pschema.TypeSpec{Type: "string"}},
 				"loadBalancers": {
 					TypeSpec: pschema.TypeSpec{
 						Type: "array",
@@ -229,11 +266,11 @@ var sampleSchema = &CloudAPIMetadata{
 						Ref: "#/types/aws-native:ecs:NetworkConfiguration",
 					},
 				},
-				"platformVersion":      {TypeSpec: pschema.TypeSpec{Type: "string"}},
-				"role":                 {TypeSpec: pschema.TypeSpec{Type: "string"}},
-				"schedulingStrategy":   {TypeSpec: pschema.TypeSpec{Type: "string"}},
-				"serviceName":          {TypeSpec: pschema.TypeSpec{Type: "string"}},
-				"taskDefinition":       {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"platformVersion":    {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"role":               {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"schedulingStrategy": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"serviceName":        {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"taskDefinition":     {TypeSpec: pschema.TypeSpec{Type: "string"}},
 			},
 			Outputs: map[string]pschema.PropertySpec{
 				"name": {TypeSpec: pschema.TypeSpec{Type: "string"}},

--- a/provider/pkg/schema/convert_test.go
+++ b/provider/pkg/schema/convert_test.go
@@ -34,6 +34,27 @@ func TestSdkToCfn(t *testing.T) {
 	assert.ErrorAs(t, err, &cErr, "Should catch conversions of invalid types")
 }
 
+func TestSdkToCfnEnumTypeRef(t *testing.T) {
+	res := CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"foo": {
+				TypeSpec: pschema.TypeSpec{
+					Ref: "#/types/bar",
+				},
+			},
+		},
+	}
+	// Enums just look like strings in the metadata
+	types := map[string]CloudAPIType{
+		"bar": {Type: "string"},
+	}
+	state := map[string]interface{}{"foo": "BBB"}
+	expected := map[string]interface{}{"Foo": "BBB"}
+	actual, err := SdkToCfn(&res, types, state)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
 func TestSdkToCfnOneOf(t *testing.T) {
 	res := CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{
@@ -189,6 +210,7 @@ var sdkState = map[string]interface{}{
 var sampleSchema = &CloudAPIMetadata{
 	Types: map[string]CloudAPIType{
 		"aws-native:ecs:AwsVpcConfiguration": {
+			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
 				"assignPublicIp": {TypeSpec: pschema.TypeSpec{Type: "string"}},
 				"securityGroups": {
@@ -206,12 +228,14 @@ var sampleSchema = &CloudAPIMetadata{
 			},
 		},
 		"aws-native:ecs:DeploymentCircuitBreaker": {
+			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
 				"enable":   {TypeSpec: pschema.TypeSpec{Type: "boolean"}},
 				"rollback": {TypeSpec: pschema.TypeSpec{Type: "boolean"}},
 			},
 		},
 		"aws-native:ecs:DeploymentConfiguration": {
+			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
 				"deploymentCircuitBreaker": {
 					TypeSpec: pschema.TypeSpec{
@@ -223,6 +247,7 @@ var sampleSchema = &CloudAPIMetadata{
 			},
 		},
 		"aws-native:ecs:LoadBalancer": {
+			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
 				"containerName":    {TypeSpec: pschema.TypeSpec{Type: "string"}},
 				"containerPort":    {TypeSpec: pschema.TypeSpec{Type: "integer"}},
@@ -231,6 +256,7 @@ var sampleSchema = &CloudAPIMetadata{
 			},
 		},
 		"aws-native:ecs:NetworkConfiguration": {
+			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
 				"awsvpcConfiguration": {
 					TypeSpec: pschema.TypeSpec{


### PR DESCRIPTION
Adds basic type checking errors to the internals of CfnToSdk to enable safe conversion of values
of OneOf types.

Fixes: #1009 

## Description
The CfnToSdk conversion code for values lacked any error handling and simply assumed that the value
it was handed matched the expected type. This was a problem for the conversion of values with a 
"OneOf" type as the code blindly tried to convert the value with each type in order, and
which would panic when handed a value for a later arm.

This code introduces some sanity checking around the values and uses the errors to safely find an 
arm that matches the value given.


## Testing
This code should probably get a larger suite of round trip tests but for now I just added a few cases
for basic error handling and the specific situation with oneOf types that was causing the panics
