### PR TITLE
Fix goreleaser.cf2pulumi name_template to strip spaces

### DIFF
--- a/.goreleaser.cf2pulumi.yml
+++ b/.goreleaser.cf2pulumi.yml
@@ -17,12 +17,12 @@ builds:
       main: ./cmd/cf2pulumi/
 archives:
   - name_template: >-
-      {{ .Binary }}-
-      {{ .Tag }}-
-      {{ .Os }}-
+      {{- .Binary }}-
+      {{- .Tag }}-
+      {{- .Os }}-
       {{- if eq .Arch "amd64" }}x64
       {{- else if eq .Arch "386" }}x86
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- else }}{{ .Arch }}{{ end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
The change in https://github.com/pulumi/pulumi-aws-native/pull/1005 to update .goreleaser.cf2pulumi accidentally introduced extra spaces into the archive name. This change adds the obscure syntax that strips whitespace around the template variables.

Fixes #1020

## Testing
Banded my head agains goreleaser until I got it to generate the correct archive names locally.