### PR TITLE
Apply larger runners to all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -124,7 +124,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         status: ${{ job.status }}
   build_sdks:
     needs: prerequisites
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
Making this change to only CI verification workflow has broken the integration branch.