### PR TITLE
Handle PENDING Operation Status  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+Fix: Handle PENDING status (<https://github.com/pulumi/pulumi-aws-native/issues/1219>)
+
 ## 0.90.0 (2023-12-04)
 
 ### New resources:

--- a/examples/get-ts/index.ts
+++ b/examples/get-ts/index.ts
@@ -7,8 +7,12 @@ const logGroup = new aws.logs.LogGroup("log-test", {
   retentionInDays: 90,
 });
 
+// Wait on the id to be populated so we don't fetch the log group before it's created.
+// The name is immediately available because Pulumi generates it during the preview.
 const fetchedLogGroup = aws.logs.getLogGroupOutput({
-  logGroupName: logGroup.logGroupName.apply((n) => n ?? ""),
+  logGroupName: logGroup.id.apply(() =>
+    logGroup.logGroupName.apply((n) => n ?? "")
+  ),
 });
 
 export const arns = pulumi

--- a/examples/parallel-ts/index.ts
+++ b/examples/parallel-ts/index.ts
@@ -2,7 +2,7 @@
 
 import * as aws from "@pulumi/aws-native";
 
-for (let i = 0; i < 100; i++) {
+for (let i = 0; i < 30; i++) {
     new aws.iam.Role(`role-${i}`, {
         assumeRolePolicyDocument: {
             Version: "2012-10-17",

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_hasFinished(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         types.OperationStatus
+		statusMessage  string
+		operation      types.Operation
+		errorCode      types.HandlerErrorCode
+		expectError    string
+		expectFinished bool
+	}{
+		{
+			status:         "SUCCESS",
+			expectFinished: true,
+		},
+		{
+			status:         "PENDING",
+			expectFinished: false,
+		},
+		{
+			status:         "IN_PROGRESS",
+			expectFinished: false,
+		},
+		{
+			status:         "FAILED",
+			statusMessage:  "failure message",
+			operation:      "GET",
+			errorCode:      "400",
+			expectFinished: true,
+			expectError:    fmt.Sprintf("operation %s failed with %q: %s", "GET", "400", "failure message"),
+		},
+		{
+			status:         "BOBOB",
+			expectFinished: true,
+			expectError:    fmt.Sprintf("unknown status %q: ", "BOBOB"),
+		},
+		{
+			status:         "CANCEL_COMPLETE", // This is a real unhandled status that might be returned
+			expectFinished: true,
+			expectError:    fmt.Sprintf("unknown status %q: ", "CANCEL_COMPLETE"),
+		},
+		{
+			status:         "CANCEL_IN_PROGRESS", // This is a real unhandled status that might be returned
+			expectFinished: true,
+			expectError:    fmt.Sprintf("unknown status %q: ", "CANCEL_IN_PROGRESS"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status)+" "+tt.name, func(t *testing.T) {
+			pi := types.ProgressEvent{
+				OperationStatus: tt.status,
+				StatusMessage:   &tt.statusMessage,
+				Operation:       tt.operation,
+				ErrorCode:       tt.errorCode,
+			}
+			finished, err := hasFinished(&pi)
+			if tt.expectError != "" {
+				assert.ErrorContains(t, err, tt.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectFinished, finished)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-aws-native/issues/1219

This could have been a one liner, but I decided to pull out a helper method to add a test. There are a couple other values of `OperationStatus` that we may need to handle in the future, but I'm punting on those, b/c I haven't seen them in the wild and I'm not 100% sure how they ought to be handled. 