### PR TITLE
ADD more descriptive explanation for missing aws native region config

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -289,7 +289,7 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 	} else {
 		return nil, errors.New("missing required configuration key \"aws-native:region\":" +
 			"The region where AWS operations will take place. Examples are eu-east-1, eu-west-2, etc.\n" +
-			"\tSet a value using the command `pulumi config set aws-native:region <value>`")
+			"\tSet a value using the command `pulumi config set aws-native:region <value>`, or by setting the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.")
 	}
 
 	if profile, ok := varsOrEnv(vars, "aws-native:config:profile", "AWS_PROFILE"); ok {


### PR DESCRIPTION
I got an error message from Pulumi saying I must set the AWS-native region value. I tried setting it with `pulumi config set aws-native:region us-east-2` multiple times, and it updated in my Pulumi.<stack>.yaml. Yet, the error persisted during `pulumi refresh`.

Setting the `AWS_REGION` environment variable resolved the problem. While this doesn't address the root cause, it offers a working alternative solution.

https://github.com/pulumi/pulumi-aws-native/issues/1356