### PR TITLE
Prepare v0.97.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.97.0 (2024-02-21)
+
 - [Fix types which are maps](https://github.com/pulumi/pulumi-aws-native/pull/1342)
   - Resources parameters affected:
     - `aws-native:apigateway:Method`: `requestModels`, `requestParameters`
@@ -81,6 +83,22 @@
     - `aws-native:imagebuilder:LifecyclePolicyAmiExclusionRules`: `tagMap`
     - `aws-native:imagebuilder:LifecyclePolicyExclusionRules`: `tagMap`
     - `aws-native:imagebuilder:LifecyclePolicyResourceSelection`: `tagMap`
+
+### Breaking Changes
+
+#### Resources
+
+- "aws-native:ec2:PrefixList": required: `maxEntries` property is no longer Required
+
+#### New resources:
+
+- `cognito.UserPoolRiskConfigurationAttachment`
+
+#### New functions:
+
+- `cognito.getUserPoolRiskConfigurationAttachment`
+- `ec2.getTransitGatewayRouteTableAssociation`
+
 
 ## 0.96.0 (2024-02-09)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To learn how to configure credentials refer to the [AWS configuration options](h
 - NodeJS 10.X.X or later
 - Yarn 1.22 or later
 - Python 3.6 or later
-- .NET Core 3.1
+- .NET 6 or greater
 - Gradel 7
 - Pulumi CLI and language plugins
 - pulumictl


### PR DESCRIPTION
This release contains only Cloud Formation updates until February 15. After that, we're holding off for the time being due to [this issue](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1930).