### PR TITLE
Fix warning from makefile before we're run codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PROVIDER        := pulumi-resource-${PACK}
 CODEGEN         := pulumi-gen-${PACK}
 VERSION         := $(shell pulumictl get version)
 
-PROVIDER_PKGS	:= $(shell cd ./provider && go list ./...)
 WORKING_DIR		:= $(shell pwd)
 
 JAVA_GEN		 := pulumi-java-gen
@@ -63,7 +62,7 @@ cf2pulumi::
 	(cd provider && go build -o $(WORKING_DIR)/bin/cf2pulumi $(VERSION_FLAGS) $(PROJECT)/provider/cmd/cf2pulumi)
 
 test_provider::
-	(cd provider && go test -v -coverpkg=./... -coverprofile=coverage.txt $(PROVIDER_PKGS))
+	(cd provider && go test -v -coverpkg=./... -coverprofile=coverage.txt ./...)
 
 lint_provider:: provider # lint the provider code
 	cd provider && GOGC=20 golangci-lint run -c ../.golangci.yml


### PR DESCRIPTION
Fixes #1353

Avoid calling `go list ./...` from the variable which fails when embed files are missing (before we've run schema generation).