### PR TITLE
Identify all tag styles

### DIFF
--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1003,6 +1003,8 @@ func (ctx *context) propertySpec(propName, resourceTypeName string, spec *jssche
 			oldRef := propertySpec.TypeSpec.Items.Ref
 			propertySpec.TypeSpec.Items.Ref = "#/types/" + globalCreateOnlyTagToken
 			delete(ctx.pkg.Types, oldRef)
+		case TagsStyleKeyValueArrayWithExtraProperties:
+			// Keep custom type
 		default: // Unknown
 			ctx.reports.UnexpectedTagsShapes[ctx.resourceToken] = spec
 		}

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1005,6 +1005,8 @@ func (ctx *context) propertySpec(propName, resourceTypeName string, spec *jssche
 			delete(ctx.pkg.Types, oldRef)
 		case TagsStyleKeyValueArrayWithExtraProperties:
 			// Keep custom type
+		case TagsStyleKeyValueArrayWithAlternateType:
+			// Keep custom type
 		default: // Unknown
 			ctx.reports.UnexpectedTagsShapes[ctx.resourceToken] = spec
 		}

--- a/provider/pkg/schema/gen_tags.go
+++ b/provider/pkg/schema/gen_tags.go
@@ -21,6 +21,9 @@ const (
 	// TagsStyleKeyValueCreateOnlyArray is a style where the tags are represented as an array of key-value pairs, but
 	// the tags are create-only.
 	TagsStyleKeyValueCreateOnlyArray TagsStyle = "keyValueCreateOnlyArray"
+	// TagsStyleKeyValueArrayWithExtraProperties is a style where the tags are represented as an array of key-value pairs
+	// but can have extra properties.
+	TagsStyleKeyValueArrayWithExtraProperties TagsStyle = "keyValueArrayWithExtraProperties"
 )
 
 func GetTagsProperty(originalSpec *jsschema.Schema) (string, bool) {
@@ -56,18 +59,22 @@ func (ctx *context) GetTagsStyle(propName string, typeSpec *pschema.TypeSpec) Ta
 		return TagsStyleStringMap
 	}
 
-	if ctx.tagStyleIsKeyValueArray(propName, typeSpec, false /* includeCreateOnly */) {
+	if ctx.tagStyleIsKeyValueArray(propName, typeSpec, false /* includeCreateOnly */, false /* includeExtraProperties */) {
 		return TagsStyleKeyValueArray
 	}
 
-	if ctx.tagStyleIsKeyValueArray(propName, typeSpec, true /* includeCreateOnly */) {
+	if ctx.tagStyleIsKeyValueArray(propName, typeSpec, true /* includeCreateOnly */, false /* includeExtraProperties */) {
 		return TagsStyleKeyValueCreateOnlyArray
+	}
+
+	if ctx.tagStyleIsKeyValueArray(propName, typeSpec, true /* includeCreateOnly */, true /* includeExtraProperties */) {
+		return TagsStyleKeyValueArrayWithExtraProperties
 	}
 
 	return TagsStyleUnknown
 }
 
-func (ctx *context) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.TypeSpec, includeCreateOnly bool) bool {
+func (ctx *context) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.TypeSpec, includeCreateOnly bool, includeExtraProperties bool) bool {
 	if typeSpec == nil || typeSpec.Items == nil || typeSpec.Items.Ref == "" {
 		return false
 	}
@@ -86,7 +93,7 @@ func (ctx *context) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.T
 		keyProp, keyPropExists := refType.Properties["key"]
 		valueProp, valuePropExists := refType.Properties["value"]
 		// Check if the type has exactly two properties, "key" and "value", both of type "string"
-		if keyPropExists && valuePropExists && keyProp.Type == "string" && valueProp.Type == "string" && len(refType.Properties) == 2 {
+		if keyPropExists && valuePropExists && keyProp.Type == "string" && valueProp.Type == "string" && (len(refType.Properties) == 2 || includeExtraProperties) {
 			return true
 		}
 	}

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -101,4 +101,46 @@ func TestGetTagsStyle(t *testing.T) {
 		}
 		assert.Equal(t, TagsStyleKeyValueCreateOnlyArray, ctx.GetTagsStyle("Tags", typeSpec))
 	})
+	t.Run("key value array with alternate type style", func(t *testing.T) {
+		ctx := &context{
+			pkg: &schema.PackageSpec{
+				Types: map[string]schema.ComplexTypeSpec{
+					"pulumi:types:input:common:ComponentResourceOptions:TagsEntry": {
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"key":   {TypeSpec: schema.TypeSpec{Type: "string"}},
+								"value": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+					"pulumi:types:input:common:ComponentResourceOptions:AltTagsEntry": {
+						ObjectTypeSpec: schema.ObjectTypeSpec{
+							Properties: map[string]schema.PropertySpec{
+								"tagKey":   {TypeSpec: schema.TypeSpec{Type: "string"}},
+								"tagValue": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							},
+						},
+					},
+				},
+			},
+			resourceSpec: &jsschema.Schema{
+				Extras: map[string]interface{}{
+					"createOnlyProperties": []interface{}{"/properties/Tags"},
+				},
+			},
+		}
+		typeSpec := &schema.TypeSpec{
+			Items: &schema.TypeSpec{
+				OneOf: []schema.TypeSpec{
+					{
+						Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:AltTagsEntry",
+					},
+					{
+						Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:TagsEntry",
+					},
+				},
+			},
+		}
+		assert.Equal(t, TagsStyleKeyValueArrayWithAlternateType, ctx.GetTagsStyle("Tags", typeSpec))
+	})
 }

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -1,11 +1,15 @@
 package schema
 
 import (
+	"encoding/json"
+	"os"
+	"path"
 	"testing"
 
 	jsschema "github.com/pulumi/jsschema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTagsStyle(t *testing.T) {
@@ -143,4 +147,14 @@ func TestGetTagsStyle(t *testing.T) {
 		}
 		assert.Equal(t, TagsStyleKeyValueArrayWithAlternateType, ctx.GetTagsStyle("Tags", typeSpec))
 	})
+}
+
+func TestNoUnexpectedTagsShapes(t *testing.T) {
+	path := path.Join("..", "..", "..", "reports", "unexpectedTagsShapes.json")
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var unexpectedTagsShapes map[string]interface{}
+	err = json.Unmarshal(bytes, &unexpectedTagsShapes)
+	require.NoError(t, err)
+	assert.Empty(t, unexpectedTagsShapes, "reports/unexpectedTagsShapes.json should be empty, which means that we need to update GetTagsStyle in gen_tags.go to cover new tags variations.")
 }

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -72,7 +72,7 @@ func TestGetTagsStyle(t *testing.T) {
 				Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:TagsEntry",
 			},
 		}
-		assert.NotEqual(t, TagsStyleKeyValueArray, ctx.GetTagsStyle("Tags", typeSpec))
+		assert.Equal(t, TagsStyleKeyValueArrayWithExtraProperties, ctx.GetTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value create-only array style if causes replacement", func(t *testing.T) {
 		ctx := &context{

--- a/reports/unexpectedTagsShapes.json
+++ b/reports/unexpectedTagsShapes.json
@@ -1,18 +1,1 @@
-{
-  "aws-native:appstream:AppBlock": {
-    "insertionOrder": false,
-    "items": {
-      "$ref": "#/definitions/Tag"
-    },
-    "type": "array",
-    "uniqueItems": true
-  },
-  "aws-native:appstream:Application": {
-    "insertionOrder": false,
-    "items": {
-      "$ref": "#/definitions/Tag"
-    },
-    "type": "array",
-    "uniqueItems": true
-  }
-}
+{}

--- a/reports/unexpectedTagsShapes.json
+++ b/reports/unexpectedTagsShapes.json
@@ -14,12 +14,5 @@
     },
     "type": "array",
     "uniqueItems": true
-  },
-  "aws-native:autoscaling:AutoScalingGroup": {
-    "insertionOrder": false,
-    "items": {
-      "$ref": "#/definitions/TagProperty"
-    },
-    "type": "array"
   }
 }


### PR DESCRIPTION
1. Add detection of last two observed variations.
2. Add test to fail unit test if new unexpected tag styles are found.

The purpose of complete coverage of all tags styles is to maintain quality of tag accessibility. Additionally, this will allow us to reliably apply DefaultTags in a future PR (see https://github.com/pulumi/pulumi-aws-native/issues/107).