### PR TITLE
Send unchanged write-only properties as adds on update

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -44,6 +44,21 @@ func TestUpdate(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestLambdaUpdate(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "lambda-update", "step1"),
+			EditDirs: []integration.EditDir{
+				{
+					Dir:      filepath.Join(getCwd(t), "lambda-update", "step2"),
+					Additive: true,
+				},
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestNamingConventions(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{

--- a/examples/lambda-update/step1/Pulumi.yaml
+++ b/examples/lambda-update/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-simple-ts
+runtime: nodejs
+description: A TypeScript Pulumi program with AWS Native provider

--- a/examples/lambda-update/step1/index.ts
+++ b/examples/lambda-update/step1/index.ts
@@ -1,0 +1,90 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as awsNative from "@pulumi/aws-native";
+import * as aws from "@pulumi/aws";
+
+// export const layout = vpc.subnets;
+export const lambdaStore = new awsNative.s3.Bucket("ls", {
+  accessControl: "Private",
+  versioningConfiguration: {
+    status: "Enabled",
+  },
+  lifecycleConfiguration: {
+    rules: [
+      {
+        id: "keepLastX",
+        status: "Enabled",
+        noncurrentVersionExpiration: {
+          // keep last 10, even if a service isn't touched for a while
+          newerNoncurrentVersions: 10,
+          // keep anything from last 30 days
+          noncurrentDays: 30,
+        },
+      },
+    ],
+  },
+});
+
+// file is a placeholder, overwritten by external deploys in the lambda
+export const graphqlPublicZip = new aws.s3.BucketObject(
+  "lambda-source",
+  {
+    bucket: lambdaStore.id,
+    key: "samplefn",
+    source: new pulumi.asset.AssetArchive({
+      "index.js": new pulumi.asset.StringAsset(
+        `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`
+      ),
+    }),
+  },
+  { ignoreChanges: ["source"] }
+);
+
+// file is a placeholder, overwritten by external deploys in the lambda
+export const layerCode = new aws.s3.BucketObject(
+  "layer-source",
+  {
+    bucket: lambdaStore.id,
+    key: "samplefn",
+    source: new pulumi.asset.AssetArchive({
+      "index.js": new pulumi.asset.StringAsset(
+        `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`
+      ),
+    }),
+  },
+  { ignoreChanges: ["source"] }
+);
+
+const graphqlPublicRole = new aws.iam.Role("lambda-role", {
+  assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal(
+    aws.iam.Principals.LambdaPrincipal
+  ),
+  managedPolicyArns: [
+    /** Can execute lambdas and send logs to cloudwatch */
+    aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
+  ],
+});
+
+export const layer = new awsNative.lambda.LayerVersion("layer", {
+  content: {
+    s3Bucket: lambdaStore.id,
+    s3Key: layerCode.key,
+    s3ObjectVersion: layerCode.versionId,
+  },
+});
+
+export const graphqlPublic = new awsNative.lambda.Function("sample", {
+  functionName: "fnname",
+  role: graphqlPublicRole.arn,
+  memorySize: 128,
+  architectures: ["arm64"],
+  runtime: "nodejs16.x",
+  handler: "index.handler",
+  code: {
+    s3Bucket: lambdaStore.id,
+    s3Key: graphqlPublicZip.key,
+    s3ObjectVersion: graphqlPublicZip.versionId,
+  },
+  //   layers: [layer.layerVersionArn],
+});

--- a/examples/lambda-update/step1/package.json
+++ b/examples/lambda-update/step1/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-simple-ts",
+  "devDependencies": {
+    "@types/node": "^8.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/aws": "^6.25.0"
+  },
+  "peerDependencies": {
+    "@pulumi/aws-native": "dev"
+  }
+}

--- a/examples/lambda-update/step1/tsconfig.json
+++ b/examples/lambda-update/step1/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/lambda-update/step2/index.ts
+++ b/examples/lambda-update/step2/index.ts
@@ -1,0 +1,90 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as awsNative from "@pulumi/aws-native";
+import * as aws from "@pulumi/aws";
+
+// export const layout = vpc.subnets;
+export const lambdaStore = new awsNative.s3.Bucket("ls", {
+  accessControl: "Private",
+  versioningConfiguration: {
+    status: "Enabled",
+  },
+  lifecycleConfiguration: {
+    rules: [
+      {
+        id: "keepLastX",
+        status: "Enabled",
+        noncurrentVersionExpiration: {
+          // keep last 10, even if a service isn't touched for a while
+          newerNoncurrentVersions: 10,
+          // keep anything from last 30 days
+          noncurrentDays: 30,
+        },
+      },
+    ],
+  },
+});
+
+// file is a placeholder, overwritten by external deploys in the lambda
+export const graphqlPublicZip = new aws.s3.BucketObject(
+  "lambda-source",
+  {
+    bucket: lambdaStore.id,
+    key: "samplefn",
+    source: new pulumi.asset.AssetArchive({
+      "index.js": new pulumi.asset.StringAsset(
+        `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`
+      ),
+    }),
+  },
+  { ignoreChanges: ["source"] }
+);
+
+// file is a placeholder, overwritten by external deploys in the lambda
+export const layerCode = new aws.s3.BucketObject(
+  "layer-source",
+  {
+    bucket: lambdaStore.id,
+    key: "samplefn",
+    source: new pulumi.asset.AssetArchive({
+      "index.js": new pulumi.asset.StringAsset(
+        `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`
+      ),
+    }),
+  },
+  { ignoreChanges: ["source"] }
+);
+
+const graphqlPublicRole = new aws.iam.Role("lambda-role", {
+  assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal(
+    aws.iam.Principals.LambdaPrincipal
+  ),
+  managedPolicyArns: [
+    /** Can execute lambdas and send logs to cloudwatch */
+    aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
+  ],
+});
+
+export const layer = new awsNative.lambda.LayerVersion("layer", {
+  content: {
+    s3Bucket: lambdaStore.id,
+    s3Key: layerCode.key,
+    s3ObjectVersion: layerCode.versionId,
+  },
+});
+
+export const graphqlPublic = new awsNative.lambda.Function("sample", {
+  functionName: "fnname",
+  role: graphqlPublicRole.arn,
+  memorySize: 128,
+  architectures: ["arm64"],
+  runtime: "nodejs16.x",
+  handler: "index.handler",
+  code: {
+    s3Bucket: lambdaStore.id,
+    s3Key: graphqlPublicZip.key,
+    s3ObjectVersion: graphqlPublicZip.versionId,
+  },
+  layers: [layer.layerVersionArn],
+});

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1075,6 +1075,8 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 		return nil, err
 	}
 
+	// Write-only properties can't even be read internally within the CloudControl service so they must be included in
+	// patch requests as adds to ensure the updated model validates.
 	for _, writeOnlyPropName := range spec.WriteOnly {
 		propKey := resource.PropertyKey(writeOnlyPropName)
 		if _, ok := diff.Sames[propKey]; ok {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -754,7 +754,17 @@ func (p *cfnProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pu
 	label := fmt.Sprintf("%s.Diff(%s)", p.name, urn)
 	glog.V(9).Infof("%s executing", label)
 
-	diff, err := p.diffState(req.GetOlds(), req.GetNews(), label)
+	newInputs, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
+		Label:        fmt.Sprintf("%s.properties", label),
+		KeepUnknowns: true,
+		RejectAssets: true,
+		KeepSecrets:  true,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse inputs for update")
+	}
+
+	diff, err := p.diffState(req.GetOlds(), newInputs, label)
 	if err != nil {
 		return nil, err
 	}
@@ -1050,9 +1060,27 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 	}
 
 	news := req.GetNews()
-	diff, err := p.diffState(req.GetOlds(), news, label)
+	newInputs, err := plugin.UnmarshalProperties(news, plugin.MarshalOptions{
+		Label:        fmt.Sprintf("%s.properties", label),
+		KeepUnknowns: true,
+		RejectAssets: true,
+		KeepSecrets:  true,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse inputs for update")
+	}
+
+	diff, err := p.diffState(req.GetOlds(), newInputs, label)
 	if err != nil {
 		return nil, err
+	}
+
+	for _, writeOnlyPropName := range spec.WriteOnly {
+		propKey := resource.PropertyKey(writeOnlyPropName)
+		if _, ok := diff.Sames[propKey]; ok {
+			delete(diff.Sames, propKey)
+			diff.Adds[propKey] = newInputs[propKey]
+		}
 	}
 
 	ops, err := schema.DiffToPatch(&spec, p.resourceMap.Types, diff)
@@ -1063,16 +1091,6 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 	doc, err := json.Marshal(ops)
 	if err != nil {
 		return nil, errors.Wrapf(err, "serializing patch as json")
-	}
-
-	inputs, err := plugin.UnmarshalProperties(news, plugin.MarshalOptions{
-		Label:        fmt.Sprintf("%s.properties", label),
-		KeepUnknowns: true,
-		RejectAssets: true,
-		KeepSecrets:  true,
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse inputs for update")
 	}
 
 	docAsString := string(doc)
@@ -1100,7 +1118,7 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 
 	// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent from the inputs.
 	if len(spec.WriteOnly) > 0 {
-		inputsMap := inputs.Mappable()
+		inputsMap := newInputs.Mappable()
 		for _, writeOnlyProp := range spec.WriteOnly {
 			if _, ok := outputs[writeOnlyProp]; !ok {
 				inputValue, ok := inputsMap[writeOnlyProp]
@@ -1113,7 +1131,7 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 
 	// Store both outputs and inputs into the state and return RPC checkpoint.
 	checkpoint, err := plugin.MarshalProperties(
-		checkpointObject(inputs, outputs),
+		checkpointObject(newInputs, outputs),
 		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
 	)
 	if err != nil {
@@ -1296,7 +1314,7 @@ func mapReplStripSecrets(v resource.PropertyValue) (interface{}, bool) {
 }
 
 // diffState extracts old and new inputs and calculates a diff between them.
-func (p *cfnProvider) diffState(olds *pbstruct.Struct, news *pbstruct.Struct, label string) (*resource.ObjectDiff, error) {
+func (p *cfnProvider) diffState(olds *pbstruct.Struct, newInputs resource.PropertyMap, label string) (*resource.ObjectDiff, error) {
 	oldState, err := plugin.UnmarshalProperties(olds, plugin.MarshalOptions{
 		Label:        fmt.Sprintf("%s.oldState", label),
 		KeepUnknowns: true,
@@ -1310,17 +1328,9 @@ func (p *cfnProvider) diffState(olds *pbstruct.Struct, news *pbstruct.Struct, la
 	// Extract old inputs from the `__inputs` field of the old state.
 	oldInputs := parseCheckpointObject(oldState)
 
-	newInputs, err := plugin.UnmarshalProperties(news, plugin.MarshalOptions{
-		Label:        fmt.Sprintf("%s.newInputs", label),
-		KeepUnknowns: true,
-		RejectAssets: true,
-		KeepSecrets:  true,
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "diff failed because malformed resource inputs")
-	}
+	diff := oldInputs.Diff(newInputs)
 
-	return oldInputs.Diff(newInputs), nil
+	return diff, nil
 }
 
 // applyDiff produces a new map as a merge of a calculated diff into an existing map of values.


### PR DESCRIPTION
Write-only properties can't even be read internally within the CloudControl service so they must be included in PATCH requests to ensure the updated model validates.
- Refactor where we unmarshal inputs to avoid duplicate work.

Fixes https://github.com/pulumi/pulumi-aws-native/issues/906

Might also fix https://github.com/pulumi/pulumi-aws-native/issues/1243 but there's no code to reproduce the issue.