### PR TITLE
Revert "Update GitHub Actions workflows."

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,15 +355,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
-    - name: Clear GitHub Actions Ubuntu runner disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        tool-cache: false
-        dotnet: false
-        android: true
-        haskell: true
-        swap-storage: true
-        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -386,7 +377,8 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
+          60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/.github/workflows/cf2pulumi-release.yml
+++ b/.github/workflows/cf2pulumi-release.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 1 -f .goreleaser.cf2pulumi.yml release --clean --timeout 60m0s
+        args: -p 1 -f .goreleaser.cf2pulumi.yml release --rm-dist --timeout 60m0s
         version: latest
     - name: Chocolatey Package Deployment
       run: |-

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -346,15 +346,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
-    - name: Clear GitHub Actions Ubuntu runner disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        tool-cache: false
-        dotnet: false
-        android: true
-        haskell: true
-        swap-storage: true
-        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -377,7 +368,8 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout 60m0s
+        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
+          60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,15 +346,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ env.GOVERSION }}
-    - name: Clear GitHub Actions Ubuntu runner disk space
-      uses: jlumbroso/free-disk-space@v1.3.1
-      with:
-        tool-cache: false
-        dotnet: false
-        android: true
-        haskell: true
-        swap-storage: true
-        large-packages: false
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
@@ -377,7 +368,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v5
       with:
-        args: -p 3 release --clean --timeout 60m0s
+        args: -p 3 release --rm-dist --timeout 60m0s
         version: latest
     - if: failure() && github.event_name == 'push'
       name: Notify Slack


### PR DESCRIPTION
Reverts pulumi/pulumi-aws-native#1413

[Breaks the publishing step](https://github.com/pulumi/pulumi-aws-native/actions/runs/8280097860/job/22656434168)

```
/Users/runner/work/_temp/329c61db-f30e-4ac8-b540-d1ce697025dd.sh: line 28: numfmt: command not found
/Users/runner/work/_temp/329c61db-f30e-4ac8-b540-d1ce697025dd.sh: line 28: numfmt: command not found
sudo: docker: command not found
/Users/runner/work/_temp/329c61db-f30e-4ac8-b540-d1ce697025dd.sh: line 28: numfmt: command not found
sudo: swapoff: command not found
/Users/runner/work/_temp/329c61db-f30e-4ac8-b540-d1ce697025dd.sh: line 173: free: command not found
```