### PR TITLE
Remove hard-coded name from the test to avoid concurrency failures

### DIFF
--- a/examples/lambda-update/step1/index.ts
+++ b/examples/lambda-update/step1/index.ts
@@ -75,7 +75,6 @@ export const layer = new awsNative.lambda.LayerVersion("layer", {
 });
 
 export const graphqlPublic = new awsNative.lambda.Function("sample", {
-  functionName: "fnname",
   role: graphqlPublicRole.arn,
   memorySize: 128,
   architectures: ["arm64"],

--- a/examples/lambda-update/step2/index.ts
+++ b/examples/lambda-update/step2/index.ts
@@ -75,7 +75,6 @@ export const layer = new awsNative.lambda.LayerVersion("layer", {
 });
 
 export const graphqlPublic = new awsNative.lambda.Function("sample", {
-  functionName: "fnname",
   role: graphqlPublicRole.arn,
   memorySize: 128,
   architectures: ["arm64"],


### PR DESCRIPTION
Avoids test failures like https://github.com/pulumi/pulumi-aws-native/actions/runs/8280190671/job/22656454104#step:25:303