### PR TITLE
Handle AlreadyExists error during creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [Fix replaceOnChanges for Python programs with multi-word properties](https://github.com/pulumi/pulumi-aws-native/pull/1424)
+- [Fix handling of AlreadyExists error while creating a resource](https://github.com/pulumi/pulumi-aws-native/pull/1439)
 
 ## 0.99.0 (2024-03-14)
 

--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -75,7 +75,7 @@ func (c *clientImpl) Create(ctx context.Context, typeName string, desiredState m
 		}
 	}
 	if pi.Identifier == nil {
-		return nil, nil, errors.New("received nil identifier while reading resource state")
+		return nil, nil, errors.New("received nil identifier while awaiting completion")
 	}
 
 	// Read the state - even if there was a creation error but the progress event contains a resource ID.

--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -64,41 +64,34 @@ func (c *clientImpl) Create(ctx context.Context, typeName string, desiredState m
 	}
 
 	pi, waitErr := c.awaiter.WaitForResourceOpCompletion(ctx, res)
-
-	// Read the state - even if there was a creation error but the progress event contains a resource ID.
-	var id string
-	var readErr error
-	if pi != nil && pi.Identifier != nil {
-		// Retrieve the resource state from AWS.
-		// Note that we do so even if creation hasn't succeeded but the identifier is assigned.
-		id = *pi.Identifier
-		resourceState, err = c.api.GetResource(ctx, typeName, id)
-		if err != nil {
-			readErr = fmt.Errorf("reading resource state: %w", err)
-		}
-	}
-
 	if waitErr != nil {
-		if id == "" {
+		if pi == nil || pi.Identifier == nil {
+			return nil, nil, fmt.Errorf("creating resource (await): %w", waitErr)
+		}
+		if pi.ErrorCode == types.HandlerErrorCodeAlreadyExists {
+			// Already Exists is a special case because it's the scenario when we can't proceed to resource read
+			// to validate its existence. We should return immediately as a hard error.
 			return nil, nil, waitErr
 		}
-
-		if readErr != nil {
-			return nil, nil, fmt.Errorf("resource partially created but read failed. read error: %v, create error: %w", readErr, waitErr)
-		}
-
-		// Resource was created but failed to fully initialize.
-		// If it has some state, return a partial error.
-		return &id, resourceState, waitErr
 	}
 	if pi.Identifier == nil {
 		return nil, nil, errors.New("received nil identifier while reading resource state")
 	}
-	if readErr != nil {
-		return nil, nil, fmt.Errorf("reading resource state: %w", readErr)
+
+	// Read the state - even if there was a creation error but the progress event contains a resource ID.
+	// Retrieve the resource state from AWS.
+	// Note that we do so even if creation hasn't succeeded but the identifier is assigned.
+	resourceState, err = c.api.GetResource(ctx, typeName, *pi.Identifier)
+	if err != nil {
+		if waitErr != nil {
+			// Both wait and read fail. Provisioning failed entirely, return the wait error as more informative.
+			return nil, nil, fmt.Errorf("creating resource (await): %w", waitErr)
+		}
+		// Creation succeeded but reading failed - return the read error.
+		return nil, nil, fmt.Errorf("reading resource state: %w", err)
 	}
 
-	return &id, resourceState, nil
+	return pi.Identifier, resourceState, waitErr
 }
 
 func (c *clientImpl) Read(ctx context.Context, typeName, identifier string) (resourceState map[string]interface{}, exists bool, err error) {

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -182,7 +182,7 @@ func TestClientCreate(t *testing.T) {
 
 		id, outputs, err := client.Create(ctx, typeName, desiredState)
 
-		assert.Equal(t, "received nil identifier while reading resource state", err.Error())
+		assert.Equal(t, "received nil identifier while awaiting completion", err.Error())
 		assert.Nil(t, id)
 		assert.Nil(t, outputs)
 	})

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -99,9 +99,195 @@ func TestClientRead(t *testing.T) {
 	})
 }
 
+func TestClientCreate(t *testing.T) {
+	ctx := context.TODO()
+	typeName := "exampleType"
+	desiredState := map[string]interface{}{"input1": "value1"}
+
+	// Mock API implementation
+	mockAPI := &mockAPI{}
+	client := &clientImpl{
+		api:     mockAPI,
+		awaiter: mockAPI,
+	}
+
+	t.Run("Resource creation success", func(t *testing.T) {
+		resourceID := "exampleID"
+		resourceState := map[string]interface{}{"output1": "outvalue1"}
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return pi, nil
+		}
+		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+			if identifier != resourceID {
+				return nil, errors.New("unexpected identifier")
+			}
+			return resourceState, nil
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.NoError(t, err)
+		assert.Equal(t, &resourceID, id)
+		assert.Equal(t, resourceState, outputs)
+	})
+
+	t.Run("Resource creation failure", func(t *testing.T) {
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return nil, errors.New("creation failed")
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "creating resource: creation failed", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+
+	t.Run("Resource await failure no state", func(t *testing.T) {
+		resourceID := "exampleID"
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return nil, errors.New("creation failed")
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "creating resource (await): creation failed", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+
+	t.Run("Resource await returns no identifier", func(t *testing.T) {
+		resourceID := "exampleID"
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{Identifier: nil}, nil
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "received nil identifier while reading resource state", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+
+	t.Run("Resource await and read errors, but with identifier", func(t *testing.T) {
+		resourceID := "exampleID"
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{Identifier: &resourceID}, errors.New("await failed")
+		}
+		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+			if identifier != resourceID {
+				return nil, errors.New("unexpected identifier")
+			}
+			return nil, errors.New("read error")
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "creating resource (await): await failed", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+
+	t.Run("Resource read error", func(t *testing.T) {
+		resourceID := "exampleID"
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{Identifier: &resourceID}, nil
+		}
+		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+			if identifier != resourceID {
+				return nil, errors.New("unexpected identifier")
+			}
+			return nil, errors.New("read error")
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "reading resource state: read error", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+
+	t.Run("Resource creation succeeds, including outputs, but await returned an error", func(t *testing.T) {
+		resourceID := "exampleID"
+		resourceState := map[string]interface{}{"output1": "outvalue1"}
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{Identifier: &resourceID}, errors.New("await failed")
+		}
+		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+			if identifier != resourceID {
+				return nil, errors.New("unexpected identifier")
+			}
+			return resourceState, nil
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "await failed", err.Error())
+		assert.Equal(t, &resourceID, id)
+		assert.Equal(t, resourceState, outputs)
+	})
+
+	t.Run("AlreadyExists returns no resource state despite its existence", func(t *testing.T) {
+		resourceID := "exampleID"
+		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+				OperationStatus: types.OperationStatusSuccess,
+				Identifier:      &resourceID,
+			}, nil
+		}
+		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{Identifier: &resourceID, ErrorCode: "AlreadyExists"}, errors.New("resource with same id alteady exists")
+		}
+
+		id, outputs, err := client.Create(ctx, typeName, desiredState)
+
+		assert.Equal(t, "resource with same id alteady exists", err.Error())
+		assert.Nil(t, id)
+		assert.Nil(t, outputs)
+	})
+}
+
 // Mock API implementation
 type mockAPI struct {
-	GetResourceFunc func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error)
+	GetResourceFunc                 func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error)
+	CreateResourceFunc              func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error)
+	WaitForResourceOpCompletionFunc func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error)
 }
 
 func (m *mockAPI) GetResource(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
@@ -109,7 +295,7 @@ func (m *mockAPI) GetResource(ctx context.Context, typeName, identifier string) 
 }
 
 func (m *mockAPI) CreateResource(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
-	panic("not implemented")
+	return m.CreateResourceFunc(ctx, cfType, desiredState)
 }
 
 // UpdateResource updates a resource of the specified type with the specified changeset.
@@ -130,4 +316,8 @@ func (m *mockAPI) DeleteResource(ctx context.Context, cfType, id string) (*types
 // GetResourceRequestStatus returns the current status of a resource operation request.
 func (m *mockAPI) GetResourceRequestStatus(ctx context.Context, requestToken string) (*types.ProgressEvent, error) {
 	panic("not implemented")
+}
+
+func (m *mockAPI) WaitForResourceOpCompletion(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+	return m.WaitForResourceOpCompletionFunc(ctx, pi)
 }


### PR DESCRIPTION
The PR does three things:

1. Cover client.Create with unit tests for all branches.
2. Refactor its code to be more concise and to return as quickly as possible. Return consistent error messages.
3. Add another special case to create logic to process AlreadyExists error.

Currently, if we receive an AlreadyExists error, we follow our default flow for all await errors: we proceed to reading the resource state, we see that it exists, and we return a partial error, which saves this resource in Pulumi state. This is wrong, because we should not pull an existing resource into state unexpectedly for a user (without an import). After the fix, we hard-fail on AlreadyExists.

Fix #1263
Fix #1138