### PR TITLE
Refactor modules

### DIFF
--- a/examples/lambda-update/step1/index.ts
+++ b/examples/lambda-update/step1/index.ts
@@ -31,7 +31,6 @@ export const graphqlPublicZip = new aws.s3.BucketObject(
   "lambda-source",
   {
     bucket: lambdaStore.id,
-    key: "samplefn",
     source: new pulumi.asset.AssetArchive({
       "index.js": new pulumi.asset.StringAsset(
         `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`
@@ -46,7 +45,6 @@ export const layerCode = new aws.s3.BucketObject(
   "layer-source",
   {
     bucket: lambdaStore.id,
-    key: "samplefn",
     source: new pulumi.asset.AssetArchive({
       "index.js": new pulumi.asset.StringAsset(
         `module.exports = () => { console.log("placeholder"); return Promise.resolve(); }`

--- a/provider/cmd/pulumi-gen-aws-native/examples.go
+++ b/provider/cmd/pulumi-gen-aws-native/examples.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	pschema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
@@ -25,7 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
-func generateExamples(pkgSpec *schema.PackageSpec, metadata *pschema.CloudAPIMetadata, languages []string) error {
+func generateExamples(pkgSpec *schema.PackageSpec, metadata *metadata.CloudAPIMetadata, languages []string) error {
 	// Find all snippets in the AWS CloudFormation Docs repo.
 	folder := path.Join(".", "aws-cloudformation-user-guide", "doc_source")
 	examples, err := findAllExamples(folder)
@@ -78,7 +80,7 @@ func generateExamples(pkgSpec *schema.PackageSpec, metadata *pschema.CloudAPIMet
 	return nil
 }
 
-func generateExample(yaml string, metadata *pschema.CloudAPIMetadata, languages []string, bindOpts ...pcl.BindOption) (*resourceExample, error) {
+func generateExample(yaml string, metadata *metadata.CloudAPIMetadata, languages []string, bindOpts ...pcl.BindOption) (*resourceExample, error) {
 	body, diagnostics, err := cf2pulumi.RenderText(yaml, metadata)
 	if err != nil {
 		return nil, errors.Wrapf(err, "rendering YAML")
@@ -209,7 +211,7 @@ func findExamples(fileName string) ([]string, error) {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "```") {
 			if snippet && buf.Len() > 0 {
-				ex := pschema.SanitizeCfnString(buf.String())
+				ex := naming.SanitizeCfnString(buf.String())
 				result = append(result, ex)
 			}
 			snippet = !snippet

--- a/provider/cmd/pulumi-gen-aws-native/main.go
+++ b/provider/cmd/pulumi-gen-aws-native/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/pkg/errors"
 	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tools"
@@ -122,7 +123,7 @@ func main() {
 	}
 }
 
-func readJsonSchemas(schemaDir string) (res []jsschema.Schema) {
+func readJsonSchemas(schemaDir string) (res []*jsschema.Schema) {
 	var fileNames []string
 	root := filepath.Join(".", schemaDir)
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -142,13 +143,13 @@ func readJsonSchemas(schemaDir string) (res []jsschema.Schema) {
 	return
 }
 
-func readJsonSchema(schemaPath string) jsschema.Schema {
+func readJsonSchema(schemaPath string) *jsschema.Schema {
 	s, err := jsschema.ReadFile(schemaPath)
 	if err != nil {
 		panic(errors.Wrapf(err, schemaPath))
 	}
 
-	return *s
+	return s
 }
 
 const supportedResourcesFile = "supported-types.txt"
@@ -292,7 +293,7 @@ func writePulumiSchema(pkgSpec pschema.PackageSpec, outdir string, includeUncomp
 	return nil
 }
 
-func writeMetadata(metadata *schema.CloudAPIMetadata, outDir string, includeUncompressed bool) error {
+func writeMetadata(metadata *metadata.CloudAPIMetadata, outDir string, includeUncompressed bool) error {
 	compressedMeta := bytes.Buffer{}
 	compressedWriter := gzip.NewWriter(&compressedMeta)
 	err := json.NewEncoder(compressedWriter).Encode(metadata)

--- a/provider/pkg/autonaming/semantics.go
+++ b/provider/pkg/autonaming/semantics.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2023, Pulumi Corporation.
 
-package schema
+package autonaming
 
 import (
 	"fmt"

--- a/provider/pkg/default_tags/default_tags.go
+++ b/provider/pkg/default_tags/default_tags.go
@@ -1,0 +1,38 @@
+package default_tags
+
+import (
+	"strings"
+)
+
+type TagsStyle string
+
+const (
+	tagStyleKeyValueArrayPrefix = "keyValueArray"
+	// TagsStyleUnknown indicates we can't identify the style of tags.
+	TagsStyleUnknown TagsStyle = ""
+	// TagsStyleUntyped indicates the resource has no tags
+	TagsStyleNone TagsStyle = "none"
+	// TagsStyleUntyped is a style where the tags are represented as "Any" - without a schema.
+	TagsStyleUntyped TagsStyle = "untyped"
+	// TagsStyleStringMap is a style where the tags are represented as a map of strings.
+	TagsStyleStringMap TagsStyle = "stringMap"
+	// TagsStyleKeyValueArray is a style where the tags are represented as an array of key-value pairs.
+	TagsStyleKeyValueArray TagsStyle = tagStyleKeyValueArrayPrefix
+	// TagsStyleKeyValueArrayCreateOnly is a style where the tags are represented as an array of key-value pairs, but
+	// the tags are create-only.
+	TagsStyleKeyValueArrayCreateOnly TagsStyle = tagStyleKeyValueArrayPrefix + "CreateOnly"
+	// TagsStyleKeyValueArrayWithExtraProperties is a style where the tags are represented as an array of key-value pairs
+	// but can have extra properties.
+	TagsStyleKeyValueArrayWithExtraProperties TagsStyle = tagStyleKeyValueArrayPrefix + "WithExtraProperties"
+	// TagsStyleKeyValueArrayWithAlternateType is a style where the tags are represented as an array of key-value pairs
+	// but the value can also be of a different type.
+	TagsStyleKeyValueArrayWithAlternateType TagsStyle = tagStyleKeyValueArrayPrefix + "WithAlternateType"
+)
+
+func (ts TagsStyle) IsStringMap() bool {
+	return ts == TagsStyleStringMap
+}
+
+func (ts TagsStyle) IsKeyValueArray() bool {
+	return strings.HasPrefix(string(ts), tagStyleKeyValueArrayPrefix)
+}

--- a/provider/pkg/default_tags/merging.go
+++ b/provider/pkg/default_tags/merging.go
@@ -1,13 +1,12 @@
-package provider
+package default_tags
 
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func mergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string, tagsStyle schema.TagsStyle) (resource.PropertyValue, error) {
+func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string, tagsStyle TagsStyle) (resource.PropertyValue, error) {
 	if len(defaultTags) == 0 {
 		return tags, nil
 	}

--- a/provider/pkg/default_tags/merging_test.go
+++ b/provider/pkg/default_tags/merging_test.go
@@ -1,9 +1,8 @@
-package provider
+package default_tags
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,7 +17,7 @@ func TestDefaultTags(t *testing.T) {
 		expected := resource.NewPropertyValue(map[string]interface{}{
 			"defaultTag": "defaultTagValue",
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleStringMap)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -28,7 +27,7 @@ func TestDefaultTags(t *testing.T) {
 		expected := resource.PropertyValue(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 			"defaultTag": "defaultTagValue",
 		})))
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleStringMap)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -41,7 +40,7 @@ func TestDefaultTags(t *testing.T) {
 		expected := resource.NewPropertyValue(map[string]interface{}{
 			"localTag": "localTagValue",
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleStringMap)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -53,7 +52,7 @@ func TestDefaultTags(t *testing.T) {
 		expected := resource.NewPropertyValue(map[string]interface{}{
 			"defaultTag": "localTagValue",
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleStringMap)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -66,7 +65,7 @@ func TestDefaultTags(t *testing.T) {
 			"defaultTag": "defaultTagValue",
 			"localTag":   "localTagValue",
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleStringMap)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -79,7 +78,7 @@ func TestDefaultTags(t *testing.T) {
 				"value": "defaultTagValue",
 			},
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleKeyValueArray)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -92,7 +91,7 @@ func TestDefaultTags(t *testing.T) {
 				"value": "defaultTagValue",
 			},
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleKeyValueArray)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -111,7 +110,7 @@ func TestDefaultTags(t *testing.T) {
 				"value": "localTagValue",
 			},
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleKeyValueArray)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -129,7 +128,7 @@ func TestDefaultTags(t *testing.T) {
 				"value": "localTagValue",
 			},
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleKeyValueArray)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})
@@ -151,7 +150,7 @@ func TestDefaultTags(t *testing.T) {
 				"value": "defaultTagValue",
 			},
 		})
-		actual, err := mergeDefaultTags(tags, defaultTags, schema.TagsStyleKeyValueArray)
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	})

--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -1,8 +1,12 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package metadata
 
-import pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+import (
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
 
 // CloudAPIMetadata is a collection of all resources and types in the AWS Cloud Control API.
 type CloudAPIMetadata struct {
@@ -22,14 +26,14 @@ type CloudAPIResource struct {
 	WriteOnly         []string                        `json:"writeOnly,omitempty"`
 	IrreversibleNames map[string]string               `json:"irreversibleNames,omitempty"`
 	TagsProperty      string                          `json:"tagsProperty,omitempty"`
-	TagsStyle         TagsStyle                       `json:"tagsStyle,omitempty"`
+	TagsStyle         default_tags.TagsStyle          `json:"tagsStyle,omitempty"`
 }
 
 type AutoNamingSpec struct {
-	SdkName    string            `json:"sdkName"`
-	MinLength  int               `json:"minLength,omitempty"`
-	MaxLength  int               `json:"maxLength,omitempty"`
-	TriviaSpec *NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
+	SdkName    string                       `json:"sdkName"`
+	MinLength  int                          `json:"minLength,omitempty"`
+	MaxLength  int                          `json:"maxLength,omitempty"`
+	TriviaSpec *autonaming.NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
 }
 
 // CloudAPIType contains metadata for an auxiliary type.

--- a/provider/pkg/naming/convert.go
+++ b/provider/pkg/naming/convert.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package naming
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mattbaird/jsonpatch"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi-go-provider/resourcex"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -15,14 +16,14 @@ import (
 
 // SdkToCfn converts Pulumi-SDK-shaped state to CloudFormation-shaped payload. In particular, SDK properties
 // are lowerCamelCase, while CloudFormation is usually (but not always) PascalCase.
-func SdkToCfn(res *CloudAPIResource, types map[string]CloudAPIType, properties map[string]interface{}) (map[string]interface{}, error) {
+func SdkToCfn(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, properties map[string]interface{}) (map[string]interface{}, error) {
 	converter := sdkToCfnConverter{res, types}
 	return converter.sdkToCfn(properties)
 }
 
 // DiffToPatch converts a Pulumi object diff to a CloudFormation-shaped patch operation slice. Update/add/delete operations are
 // mapped to corresponding patch terms, and SDK properties are translated to respective CFN names.
-func DiffToPatch(res *CloudAPIResource, types map[string]CloudAPIType, diff *resource.ObjectDiff) ([]jsonpatch.JsonPatchOperation, error) {
+func DiffToPatch(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, diff *resource.ObjectDiff) ([]jsonpatch.JsonPatchOperation, error) {
 	if diff == nil {
 		return []jsonpatch.JsonPatchOperation{}, nil
 	}
@@ -44,8 +45,8 @@ func SanitizeCfnString(str string) string {
 }
 
 type sdkToCfnConverter struct {
-	spec  *CloudAPIResource
-	types map[string]CloudAPIType
+	spec  *metadata.CloudAPIResource
+	types map[string]metadata.CloudAPIType
 }
 
 func (c *sdkToCfnConverter) sdkToCfn(properties map[string]interface{}) (map[string]interface{}, error) {
@@ -157,7 +158,7 @@ func isNumberLike(v interface{}) bool {
 	return false
 }
 
-func (c *sdkToCfnConverter) sdkObjectValueToCfn(typeName string, spec CloudAPIType, value interface{}) (interface{}, error) {
+func (c *sdkToCfnConverter) sdkObjectValueToCfn(typeName string, spec metadata.CloudAPIType, value interface{}) (interface{}, error) {
 	properties, ok := value.(map[string]interface{})
 	if !ok {
 		return nil, &ConversionError{typeName, value}

--- a/provider/pkg/naming/convert_test.go
+++ b/provider/pkg/naming/convert_test.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package naming
 
 import (
 	"sort"
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mattbaird/jsonpatch"
 
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,7 @@ func TestSdkToCfn(t *testing.T) {
 }
 
 func TestSdkToCfnEnumTypeRef(t *testing.T) {
-	res := CloudAPIResource{
+	res := metadata.CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{
 			"foo": {
 				TypeSpec: pschema.TypeSpec{
@@ -46,7 +47,7 @@ func TestSdkToCfnEnumTypeRef(t *testing.T) {
 		},
 	}
 	// Enums just look like strings in the metadata
-	types := map[string]CloudAPIType{
+	types := map[string]metadata.CloudAPIType{
 		"bar": {Type: "string"},
 	}
 	state := map[string]interface{}{"foo": "BBB"}
@@ -57,16 +58,16 @@ func TestSdkToCfnEnumTypeRef(t *testing.T) {
 }
 
 func TestSdkToCfnOneOf(t *testing.T) {
-	res := CloudAPIResource{
+	res := metadata.CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{
 			"foo": {
 				TypeSpec: pschema.TypeSpec{
 					OneOf: []pschema.TypeSpec{
-						pschema.TypeSpec{
+						{
 							Type:  "array",
 							Items: &pschema.TypeSpec{Type: "string"},
 						},
-						pschema.TypeSpec{
+						{
 							Type:                 "object",
 							AdditionalProperties: &pschema.TypeSpec{Type: "number"},
 						},
@@ -244,8 +245,8 @@ var sdkState = map[string]interface{}{
 	"taskDefinition":     "arn:aws:ecs:us-west-2:12345:task-definition/fargate-task-definition:131",
 }
 
-var sampleSchema = &CloudAPIMetadata{
-	Types: map[string]CloudAPIType{
+var sampleSchema = &metadata.CloudAPIMetadata{
+	Types: map[string]metadata.CloudAPIType{
 		"aws-native:ecs:AwsVpcConfiguration": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
@@ -303,7 +304,7 @@ var sampleSchema = &CloudAPIMetadata{
 			},
 		},
 	},
-	Resources: map[string]CloudAPIResource{
+	Resources: map[string]metadata.CloudAPIResource{
 		"aws-native:ecs:Service": {
 			Inputs: map[string]pschema.PropertySpec{
 				"serviceArn": {TypeSpec: pschema.TypeSpec{Type: "string"}},

--- a/provider/pkg/naming/naming.go
+++ b/provider/pkg/naming/naming.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package naming
 
 import (
 	"strings"
@@ -12,7 +12,7 @@ func ToSdkName(s string) string {
 	if s == "" {
 		return s
 	}
-	s = lowerAcronyms(s)
+	s = LowerAcronyms(s)
 	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
 		s = strings.ToLower(string(r)) + s[1:]
 	}
@@ -52,7 +52,7 @@ func HasUppercaseAcronym(s string) bool {
 }
 
 // lowers the trailing chars of any uppercase acronyms
-func lowerAcronyms(s string) string {
+func LowerAcronyms(s string) string {
 	startIndex, endIndex := firstUppercaseAcronym(s)
 	if startIndex == -1 {
 		return s
@@ -61,7 +61,7 @@ func lowerAcronyms(s string) string {
 	// Note: we've defined uppercase to be ASCII [A-Z] so index math is safe here
 	startIndex = startIndex + 1 // don't lower the first char of the run
 
-	return s[:startIndex] + strings.ToLower(s[startIndex:endIndex]) + lowerAcronyms(s[endIndex:])
+	return s[:startIndex] + strings.ToLower(s[startIndex:endIndex]) + LowerAcronyms(s[endIndex:])
 }
 
 // Returns the indices of the first Uppercase acronym in the string

--- a/provider/pkg/naming/naming_test.go
+++ b/provider/pkg/naming/naming_test.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package naming
 
 import (
 	"testing"

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -17,7 +17,8 @@ package provider
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -29,7 +30,7 @@ import (
 func getDefaultName(
 	randomSeed []byte,
 	urn resource.URN,
-	autoNamingSpec *schema.AutoNamingSpec,
+	autoNamingSpec *metadata.AutoNamingSpec,
 	olds,
 	news resource.PropertyMap,
 ) (resource.PropertyValue, error) {
@@ -46,7 +47,7 @@ func getDefaultName(
 	}
 
 	// Generate naming trivia for the resource.
-	namingTriviaApplies, namingTrivia, err := schema.CheckNamingTrivia(sdkName, news, autoNamingSpec.TriviaSpec)
+	namingTriviaApplies, namingTrivia, err := autonaming.CheckNamingTrivia(sdkName, news, autoNamingSpec.TriviaSpec)
 	if err != nil {
 		return resource.PropertyValue{}, err
 	}

--- a/provider/pkg/provider/ids_test.go
+++ b/provider/pkg/provider/ids_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +68,7 @@ func Test_getDefaultName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			autoNamingSpec := &schema.AutoNamingSpec{
+			autoNamingSpec := &metadata.AutoNamingSpec{
 				SdkName:   "autoName",
 				MinLength: tt.minLength,
 				MaxLength: tt.maxLength,

--- a/provider/pkg/resources/validate.go
+++ b/provider/pkg/resources/validate.go
@@ -1,15 +1,17 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
-package schema
+package resources
 
 import (
 	"fmt"
+	"math"
+	"strings"
+
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"math"
-	"strings"
 )
 
 type ValidationFailure struct {
@@ -49,7 +51,7 @@ func validatePrimitive(primitiveType string, path string, property resource.Prop
 	return nil, nil
 }
 
-func validateProperty(types map[string]CloudAPIType, required codegen.StringSet, spec *pschema.TypeSpec, path string, property resource.PropertyValue) ([]ValidationFailure, error) {
+func validateProperty(types map[string]metadata.CloudAPIType, required codegen.StringSet, spec *pschema.TypeSpec, path string, property resource.PropertyValue) ([]ValidationFailure, error) {
 	// If the property is secret, inspect its element.
 	for property.IsSecret() {
 		property = property.SecretValue().Element
@@ -119,7 +121,7 @@ func validateProperty(types map[string]CloudAPIType, required codegen.StringSet,
 	}
 }
 
-func validateProperties(types map[string]CloudAPIType, required codegen.StringSet, propertySpecs map[string]pschema.PropertySpec, path string, properties resource.PropertyMap) ([]ValidationFailure, error) {
+func validateProperties(types map[string]metadata.CloudAPIType, required codegen.StringSet, propertySpecs map[string]pschema.PropertySpec, path string, properties resource.PropertyMap) ([]ValidationFailure, error) {
 	// Do a schema-directed check first.
 	var failures []ValidationFailure
 	remainingProperties := properties.Mappable()
@@ -152,7 +154,7 @@ func validateProperties(types map[string]CloudAPIType, required codegen.StringSe
 	return failures, nil
 }
 
-func ValidateResource(res *CloudAPIResource, types map[string]CloudAPIType, properties resource.PropertyMap) ([]ValidationFailure, error) {
+func ValidateResource(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, properties resource.PropertyMap) ([]ValidationFailure, error) {
 	required := codegen.NewStringSet(res.Required...)
 	return validateProperties(types, required, res.Inputs, "", properties)
 }

--- a/provider/pkg/schema/convert_examples_test.go
+++ b/provider/pkg/schema/convert_examples_test.go
@@ -4,9 +4,11 @@ package schema
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,13 +50,13 @@ func TestDynamoKeySchemaConversion(t *testing.T) {
 }
 
 func testConversion(t *testing.T, resource string, input map[string]interface{}, expected map[string]interface{}) {
-	bytes, err := ioutil.ReadFile("../../cmd/pulumi-resource-aws-native/metadata.json")
+	bytes, err := os.ReadFile("../../cmd/pulumi-resource-aws-native/metadata.json")
 	assert.NoError(t, err)
-	metadata := CloudAPIMetadata{}
+	metadata := metadata.CloudAPIMetadata{}
 	err = json.Unmarshal(bytes, &metadata)
 	assert.NoError(t, err)
 	res := metadata.Resources[resource]
-	actual, err := SdkToCfn(&res, metadata.Types, input)
+	actual, err := naming.SdkToCfn(&res, metadata.Types, input)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -12,6 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -23,8 +27,8 @@ const globalTagToken = "aws-native:index:Tag"
 const globalCreateOnlyTagToken = "aws-native:index:CreateOnlyTag"
 
 // GatherPackage builds a package spec based on the provided CF JSON schemas.
-func GatherPackage(supportedResourceTypes []string, jsonSchemas []jsschema.Schema,
-	genAll bool, semanticsDocument *SemanticsSpecDocument) (*pschema.PackageSpec, *CloudAPIMetadata, *Reports, error) {
+func GatherPackage(supportedResourceTypes []string, jsonSchemas []*jsschema.Schema,
+	genAll bool, semanticsDocument *autonaming.SemanticsSpecDocument) (*pschema.PackageSpec, *metadata.CloudAPIMetadata, *Reports, error) {
 	globalTagType := pschema.ObjectTypeSpec{
 		Type:        "object",
 		Description: "A set of tags to apply to the resource.",
@@ -429,15 +433,15 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []jsschema.Schem
 		},
 	})
 
-	metadata := CloudAPIMetadata{
-		Resources: map[string]CloudAPIResource{
+	metadata := metadata.CloudAPIMetadata{
+		Resources: map[string]metadata.CloudAPIResource{
 			ExtensionResourceToken: {
 				Inputs:     p.Resources[ExtensionResourceToken].InputProperties,
 				Outputs:    p.Resources[ExtensionResourceToken].Properties,
 				CreateOnly: []string{"type", "properties"},
 			},
 		},
-		Types: map[string]CloudAPIType{
+		Types: map[string]metadata.CloudAPIType{
 			globalTagToken: {
 				Type:       "object",
 				Properties: globalTagType.Properties,
@@ -447,7 +451,7 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []jsschema.Schem
 				Properties: globalCreateOnlyTagType.Properties,
 			},
 		},
-		Functions: map[string]CloudAPIFunction{},
+		Functions: map[string]metadata.CloudAPIFunction{},
 	}
 
 	reports := &Reports{
@@ -471,7 +475,7 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []jsschema.Schem
 				mod:           mod,
 				resourceName:  resourceName,
 				resourceToken: resourceToken,
-				resourceSpec:  &jsonSchema,
+				resourceSpec:  jsonSchema,
 				visitedTypes:  codegen.NewStringSet(),
 				isSupported:   isSupported,
 				semantics:     semanticsDocument,
@@ -626,7 +630,7 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []jsschema.Schem
 // cfSchemaContext holds shared information for a single CF JSON schema.
 type cfSchemaContext struct {
 	pkg           *pschema.PackageSpec
-	metadata      *CloudAPIMetadata
+	metadata      *metadata.CloudAPIMetadata
 	cfTypeName    string
 	mod           string
 	resourceName  string
@@ -634,13 +638,13 @@ type cfSchemaContext struct {
 	resourceSpec  *jsschema.Schema
 	visitedTypes  codegen.StringSet
 	isSupported   bool
-	semantics     *SemanticsSpecDocument
+	semantics     *autonaming.SemanticsSpecDocument
 	reports       *Reports
 }
 
 func (ctx *cfSchemaContext) markCreateOnlyProperties(createOnlyProperties codegen.StringSet, resource *pschema.ResourceSpec) error {
 	errs := []error{}
-	for propPath, _ := range createOnlyProperties {
+	for propPath := range createOnlyProperties {
 		// each path in createOnlyProperties is delimited with "/"
 		path := strings.Split(propPath, "/")
 		prop, ok := resource.Properties[path[0]]
@@ -697,7 +701,7 @@ func (ctx *cfSchemaContext) markCreateOnlyPropertyOnType(propName, typeRef strin
 		return errors.Errorf("Could not find referencedType: " + typeRef)
 	}
 
-	propertyName := ToSdkName(propName)
+	propertyName := naming.ToSdkName(propName)
 	innerProperty, ok := propType.Properties[propertyName]
 	if !ok {
 		return errors.Errorf("Type %s does not have property named '%s'", typeRef, propertyName)
@@ -727,7 +731,7 @@ func (ctx *cfSchemaContext) gatherInvoke() error {
 	inputNames := make([]string, len(primaryIdentifier))
 	for i, r := range primaryIdentifier {
 		n := strings.TrimPrefix(r, "/properties/")
-		sdkName := ToSdkName(n)
+		sdkName := naming.ToSdkName(n)
 		inputNames[i] = sdkName
 		s, ok := ctx.resourceSpec.Properties[n]
 		if !ok {
@@ -749,7 +753,7 @@ func (ctx *cfSchemaContext) gatherInvoke() error {
 
 	outputs := map[string]pschema.PropertySpec{}
 	for k, v := range ctx.resourceSpec.Properties {
-		sdkName := ToSdkName(k)
+		sdkName := naming.ToSdkName(k)
 		if nonOutputProperties.Has(k) {
 			continue
 		}
@@ -770,7 +774,7 @@ func (ctx *cfSchemaContext) gatherInvoke() error {
 	}
 
 	ctx.pkg.Functions[getterToken] = pschema.FunctionSpec{
-		Description: SanitizeCfnString(ctx.resourceSpec.Description),
+		Description: naming.SanitizeCfnString(ctx.resourceSpec.Description),
 		Inputs: &pschema.ObjectTypeSpec{
 			Properties: inputs,
 			Required:   inputNames,
@@ -782,9 +786,9 @@ func (ctx *cfSchemaContext) gatherInvoke() error {
 
 	identifiers := make([]string, len(primaryIdentifier))
 	for i, v := range primaryIdentifier {
-		identifiers[i] = ToSdkName(v)
+		identifiers[i] = naming.ToSdkName(v)
 	}
-	ctx.metadata.Functions[getterToken] = CloudAPIFunction{
+	ctx.metadata.Functions[getterToken] = metadata.CloudAPIFunction{
 		CfType:      ctx.cfTypeName,
 		Identifiers: identifiers,
 	}
@@ -814,7 +818,7 @@ func readPropSdkNames(resourceSpec *jsschema.Schema, listName string) codegen.St
 		pSlice := p.([]interface{})
 		for _, v := range pSlice {
 			n := strings.TrimPrefix(v.(string), "/properties/")
-			output.Add(ToSdkName(n))
+			output.Add(naming.ToSdkName(n))
 		}
 	}
 	return output
@@ -829,13 +833,13 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 	readOnlyProperties := codegen.NewStringSet(readPropNames(ctx.resourceSpec, "readOnlyProperties")...)
 	tagsProp, hasTags := GetTagsProperty(ctx.resourceSpec)
 	requiredProperties := codegen.NewStringSet(ctx.resourceSpec.Required...)
-	var tagsStyle TagsStyle
+	var tagsStyle default_tags.TagsStyle
 
 	irreversibleNames := map[string]string{}
 	inputProperties, requiredInputs := map[string]pschema.PropertySpec{}, codegen.NewStringSet()
 	properties, required := map[string]pschema.PropertySpec{}, codegen.NewStringSet()
 	for prop, spec := range ctx.resourceSpec.Properties {
-		sdkName := ToSdkName(prop)
+		sdkName := naming.ToSdkName(prop)
 		originalSdkName := sdkName
 		if sdkName == "id" {
 			sdkName = "awsId"
@@ -858,7 +862,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 				requiredInputs.Add(sdkName)
 			}
 		}
-		if HasUppercaseAcronym(prop) || ToCfnName(sdkName, nil) != prop {
+		if naming.HasUppercaseAcronym(prop) || naming.ToCfnName(sdkName, nil) != prop {
 			irreversibleNames[sdkName] = prop
 		}
 	}
@@ -875,7 +879,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 	}
 	resourceSpec := pschema.ResourceSpec{
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			Description: SanitizeCfnString(ctx.resourceSpec.Description),
+			Description: naming.SanitizeCfnString(ctx.resourceSpec.Description),
 			Properties:  properties,
 			Type:        "object",
 			Required:    required.SortedValues(),
@@ -892,7 +896,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 
 	ctx.pkg.Resources[ctx.resourceToken] = resourceSpec
 
-	ctx.metadata.Resources[ctx.resourceToken] = CloudAPIResource{
+	ctx.metadata.Resources[ctx.resourceToken] = metadata.CloudAPIResource{
 		CfType:            ctx.cfTypeName,
 		Inputs:            inputProperties,
 		Outputs:           properties,
@@ -901,7 +905,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 		AutoNamingSpec:    autoNamingSpec,
 		WriteOnly:         writeOnlyProperties.SortedValues(),
 		IrreversibleNames: irreversibleNames,
-		TagsProperty:      ToSdkName(tagsProp),
+		TagsProperty:      naming.ToSdkName(tagsProp),
 		TagsStyle:         tagsStyle,
 	}
 	return nil
@@ -916,17 +920,17 @@ func addUntypedPropDocs(propertySpec *pschema.PropertySpec, cfTypeName string) {
 	}
 }
 
-func (ctx *cfSchemaContext) createAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resourceTypeName string, properties map[string]pschema.PropertySpec) *AutoNamingSpec {
+func (ctx *cfSchemaContext) createAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resourceTypeName string, properties map[string]pschema.PropertySpec) *metadata.AutoNamingSpec {
 	// ** Autonaming **
-	var autoNameSpec *AutoNamingSpec
+	var autoNameSpec *metadata.AutoNamingSpec
 
 	semanticsSpec := ctx.semantics.Resources[ctx.resourceToken]
 
 	lookForField := func(fieldName string) func(map[string]pschema.PropertySpec) {
 		return func(properties map[string]pschema.PropertySpec) {
-			sdkName := ToSdkName(fieldName)
+			sdkName := naming.ToSdkName(fieldName)
 			if propSpec, has := inputProperties[sdkName]; has && propSpec.Type == "string" {
-				autoNameSpec = &AutoNamingSpec{
+				autoNameSpec = &metadata.AutoNamingSpec{
 					SdkName: sdkName,
 				}
 				spec, ok := ctx.resourceSpec.Properties[fieldName]
@@ -958,13 +962,13 @@ func (ctx *cfSchemaContext) createAutoNamingSpec(inputProperties map[string]psch
 }
 
 func (ctx *cfSchemaContext) propertySpec(propName, resourceTypeName string, spec *jsschema.Schema) (*pschema.PropertySpec, error) {
-	typeSpec, err := ctx.propertyTypeSpec(lowerAcronyms(propName), spec)
+	typeSpec, err := ctx.propertyTypeSpec(naming.LowerAcronyms(propName), spec)
 	if err != nil {
 		return nil, err
 	}
 	propertySpec := pschema.PropertySpec{
 		TypeSpec:    *typeSpec,
-		Description: SanitizeCfnString(spec.Description),
+		Description: naming.SanitizeCfnString(spec.Description),
 	}
 
 	// If the property name is the same as the resource type name, we need to rename the property's C# name
@@ -1007,7 +1011,7 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 			}
 		}
 
-		typName = lowerAcronyms(typName)
+		typName = naming.LowerAcronyms(typName)
 
 		tok := fmt.Sprintf("%s:%s:%s", packageName, ctx.mod, typName)
 
@@ -1060,13 +1064,13 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 
 				ctx.pkg.Types[tok] = pschema.ComplexTypeSpec{
 					ObjectTypeSpec: pschema.ObjectTypeSpec{
-						Description: SanitizeCfnString(typeSchema.Description),
+						Description: naming.SanitizeCfnString(typeSchema.Description),
 						Type:        "object",
 						Properties:  specs,
 						Required:    requiredSpecs.SortedValues(),
 					},
 				}
-				ctx.metadata.Types[tok] = CloudAPIType{
+				ctx.metadata.Types[tok] = metadata.CloudAPIType{
 					Type:              "object",
 					Properties:        specs,
 					IrreversibleNames: irreversibleNames,
@@ -1091,13 +1095,13 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 
 		ctx.pkg.Types[tok] = pschema.ComplexTypeSpec{
 			ObjectTypeSpec: pschema.ObjectTypeSpec{
-				Description: SanitizeCfnString(propSchema.Description),
+				Description: naming.SanitizeCfnString(propSchema.Description),
 				Type:        "object",
 				Properties:  specs,
 				Required:    requiredSpecs.SortedValues(),
 			},
 		}
-		ctx.metadata.Types[tok] = CloudAPIType{
+		ctx.metadata.Types[tok] = metadata.CloudAPIType{
 			Type:              "object",
 			Properties:        specs,
 			IrreversibleNames: irreversibleNames,
@@ -1246,14 +1250,14 @@ func (ctx *cfSchemaContext) genProperties(parentName string, typeSchema *jsschem
 	irreversibleNames := map[string]string{}
 	for _, name := range codegen.SortedKeys(typeSchema.Properties) {
 		value := typeSchema.Properties[name]
-		sdkName := ToSdkName(name)
+		sdkName := naming.ToSdkName(name)
 
-		typeSpec, err := ctx.propertyTypeSpec(parentName+lowerAcronyms(name), value)
+		typeSpec, err := ctx.propertyTypeSpec(parentName+naming.LowerAcronyms(name), value)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "property %s", name)
 		}
 		propertySpec := pschema.PropertySpec{
-			Description: SanitizeCfnString(value.Description),
+			Description: naming.SanitizeCfnString(value.Description),
 			TypeSpec:    *typeSpec,
 		}
 		// TODO: temporary workaround to get the 0.1.0 out, let's find a better solution later.
@@ -1266,12 +1270,12 @@ func (ctx *cfSchemaContext) genProperties(parentName string, typeSchema *jsschem
 		}
 		specs[sdkName] = propertySpec
 
-		if HasUppercaseAcronym(name) {
+		if naming.HasUppercaseAcronym(name) {
 			irreversibleNames[sdkName] = name
 		}
 	}
 	for _, name := range typeSchema.Required {
-		sdkName := ToSdkName(name)
+		sdkName := naming.ToSdkName(name)
 		if _, has := specs[sdkName]; has {
 			requiredSpecs.Add(sdkName)
 		}
@@ -1287,7 +1291,7 @@ func (ctx *cfSchemaContext) genEnumType(enumName string, propSchema *jsschema.Sc
 	if propSchema.Type[0] != jsschema.StringType {
 		return nil, nil
 	}
-	typName := lowerAcronyms(enumName)
+	typName := naming.LowerAcronyms(enumName)
 	if !strings.HasPrefix(enumName, ctx.resourceName) {
 		typName = ctx.resourceName + enumName
 	}
@@ -1300,14 +1304,14 @@ func (ctx *cfSchemaContext) genEnumType(enumName string, propSchema *jsschema.Sc
 	enumSpec := &pschema.ComplexTypeSpec{
 		Enum: []pschema.EnumValueSpec{},
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
-			Description: SanitizeCfnString(propSchema.Description),
+			Description: naming.SanitizeCfnString(propSchema.Description),
 			Type:        "string",
 		},
 	}
 
 	values := codegen.NewStringSet()
 	for _, val := range propSchema.Enum {
-		str := lowerAcronyms(ToUpperCamel(val.(string)))
+		str := naming.LowerAcronyms(naming.ToUpperCamel(val.(string)))
 		if values.Has(str) {
 			continue
 		}
@@ -1342,7 +1346,7 @@ func (ctx *cfSchemaContext) genEnumType(enumName string, propSchema *jsschema.Sc
 		}
 	}
 	ctx.pkg.Types[tok] = *enumSpec
-	ctx.metadata.Types[tok] = CloudAPIType{Type: enumSpec.Type}
+	ctx.metadata.Types[tok] = metadata.CloudAPIType{Type: enumSpec.Type}
 
 	referencedTypeName := fmt.Sprintf("#/types/%s", tok)
 	return &pschema.TypeSpec{
@@ -1372,7 +1376,7 @@ func moduleName(resourceType string) string {
 		module = "Configuration"
 	}
 
-	return lowerAcronyms(module)
+	return naming.LowerAcronyms(module)
 }
 
 func typeToken(typ string) (string, string) {
@@ -1402,7 +1406,7 @@ func typeName(typ string) string {
 		}
 		name = trimmed + "OutputResource"
 	}
-	return lowerAcronyms(name)
+	return naming.LowerAcronyms(name)
 }
 
 func primitiveTypeSpec(primitiveType string) pschema.TypeSpec {
@@ -1429,8 +1433,8 @@ func primitiveTypeSpec(primitiveType string) pschema.TypeSpec {
 	}
 }
 
-func GatherSemantics(schemaDir string) (SemanticsSpecDocument, error) {
-	var semanticsDocument SemanticsSpecDocument
+func GatherSemantics(schemaDir string) (autonaming.SemanticsSpecDocument, error) {
+	var semanticsDocument autonaming.SemanticsSpecDocument
 	semanticsPath := filepath.Join(schemaDir, "semantics.json")
 	semanticsBytes, err := os.ReadFile(semanticsPath)
 	if err != nil {
@@ -1442,3 +1446,5 @@ func GatherSemantics(schemaDir string) (SemanticsSpecDocument, error) {
 	}
 	return semanticsDocument, nil
 }
+
+var ExtensionResourceToken string = "aws-native:index:ExtensionResource"

--- a/provider/pkg/schema/gen_examples_test.go
+++ b/provider/pkg/schema/gen_examples_test.go
@@ -25,7 +25,7 @@ func TestPropertyTypeSpec(t *testing.T) {
 	test := func(tt PropertyTypeSpecTestCase) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
-			ctx := context{
+			ctx := cfSchemaContext{
 				pkg: &pschema.PackageSpec{
 					Types: map[string]pschema.ComplexTypeSpec{},
 				},
@@ -280,7 +280,7 @@ func TestEnumType(t *testing.T) {
 
 	for _, tt := range cases {
 
-		ctx := context{
+		ctx := cfSchemaContext{
 			pkg: &pschema.PackageSpec{
 				Types: map[string]pschema.ComplexTypeSpec{},
 			},
@@ -478,7 +478,7 @@ func TestMarkCreateOnlyProperties(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		ctx := context{
+		ctx := cfSchemaContext{
 			pkg: &pschema.PackageSpec{
 				Types: tt.types,
 			},

--- a/provider/pkg/schema/gen_examples_test.go
+++ b/provider/pkg/schema/gen_examples_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
@@ -30,8 +31,8 @@ func TestPropertyTypeSpec(t *testing.T) {
 					Types: map[string]pschema.ComplexTypeSpec{},
 				},
 				visitedTypes: codegen.NewStringSet(),
-				metadata: &CloudAPIMetadata{
-					Types: map[string]CloudAPIType{},
+				metadata: &metadata.CloudAPIMetadata{
+					Types: map[string]metadata.CloudAPIType{},
 				},
 				resourceSpec: &jsschema.Schema{
 					Definitions: map[string]*jsschema.Schema{
@@ -284,8 +285,8 @@ func TestEnumType(t *testing.T) {
 			pkg: &pschema.PackageSpec{
 				Types: map[string]pschema.ComplexTypeSpec{},
 			},
-			metadata: &CloudAPIMetadata{
-				Types: map[string]CloudAPIType{},
+			metadata: &metadata.CloudAPIMetadata{
+				Types: map[string]metadata.CloudAPIType{},
 			},
 		}
 		out, err := (&ctx).genEnumType(tt.name, tt.schema)

--- a/provider/pkg/schema/gen_tags.go
+++ b/provider/pkg/schema/gen_tags.go
@@ -40,7 +40,7 @@ func (ts TagsStyle) IsKeyValueArray() bool {
 	return strings.HasPrefix(string(ts), tagStyleKeyValueArrayPrefix)
 }
 
-func (ctx *context) ApplyTagsTransformation(propName string, propertySpec *pschema.PropertySpec, spec *jsschema.Schema) TagsStyle {
+func (ctx *cfSchemaContext) ApplyTagsTransformation(propName string, propertySpec *pschema.PropertySpec, spec *jsschema.Schema) TagsStyle {
 	tagsStyle := ctx.getTagsStyle(propName, &propertySpec.TypeSpec)
 	switch tagsStyle {
 	case TagsStyleUntyped:
@@ -92,7 +92,7 @@ func GetTagsProperty(originalSpec *jsschema.Schema) (string, bool) {
 	return "", false
 }
 
-func (ctx *context) getTagsStyle(propName string, typeSpec *pschema.TypeSpec) TagsStyle {
+func (ctx *cfSchemaContext) getTagsStyle(propName string, typeSpec *pschema.TypeSpec) TagsStyle {
 	if typeSpec == nil {
 		return TagsStyleUnknown
 	}
@@ -117,7 +117,7 @@ func (ctx *context) getTagsStyle(propName string, typeSpec *pschema.TypeSpec) Ta
 	return TagsStyleUnknown
 }
 
-func (ctx *context) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.TypeSpec) (bool, TagsStyle) {
+func (ctx *cfSchemaContext) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.TypeSpec) (bool, TagsStyle) {
 	if typeSpec == nil || typeSpec.Items == nil {
 		return false, TagsStyleUnknown
 	}
@@ -154,7 +154,7 @@ func (ctx *context) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.T
 	return false, TagsStyleUnknown
 }
 
-func (ctx *context) isPropCreateOnly(propName string) bool {
+func (ctx *cfSchemaContext) isPropCreateOnly(propName string) bool {
 	createOnlyProps := readPropSdkNames(ctx.resourceSpec, "createOnlyProperties")
 	return createOnlyProps.Has(ToSdkName(propName))
 }

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,14 +16,14 @@ import (
 func TestGetTagsStyle(t *testing.T) {
 	t.Run("defaults to unknown when typeSpec is nil", func(t *testing.T) {
 		ctx := &cfSchemaContext{}
-		assert.Equal(t, TagsStyleUnknown, ctx.getTagsStyle("Tags", nil))
+		assert.Equal(t, default_tags.TagsStyleUnknown, ctx.getTagsStyle("Tags", nil))
 	})
 	t.Run("untyped style", func(t *testing.T) {
 		ctx := &cfSchemaContext{}
 		typeSpec := &schema.TypeSpec{
 			Ref: "pulumi.json#/Any",
 		}
-		assert.Equal(t, TagsStyleUntyped, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleUntyped, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("string map style", func(t *testing.T) {
 		ctx := &cfSchemaContext{}
@@ -31,7 +32,7 @@ func TestGetTagsStyle(t *testing.T) {
 				Type: "string",
 			},
 		}
-		assert.Equal(t, TagsStyleStringMap, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleStringMap, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value array style", func(t *testing.T) {
 		ctx := &cfSchemaContext{
@@ -53,7 +54,7 @@ func TestGetTagsStyle(t *testing.T) {
 				Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:TagsEntry",
 			},
 		}
-		assert.Equal(t, TagsStyleKeyValueArray, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleKeyValueArray, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("not key value array style with extra field", func(t *testing.T) {
 		ctx := &cfSchemaContext{
@@ -76,7 +77,7 @@ func TestGetTagsStyle(t *testing.T) {
 				Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:TagsEntry",
 			},
 		}
-		assert.Equal(t, TagsStyleKeyValueArrayWithExtraProperties, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleKeyValueArrayWithExtraProperties, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value create-only array style if causes replacement", func(t *testing.T) {
 		ctx := &cfSchemaContext{
@@ -103,7 +104,7 @@ func TestGetTagsStyle(t *testing.T) {
 				Ref: "#/types/pulumi:types:input:common:ComponentResourceOptions:TagsEntry",
 			},
 		}
-		assert.Equal(t, TagsStyleKeyValueArrayCreateOnly, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleKeyValueArrayCreateOnly, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value array with alternate type style", func(t *testing.T) {
 		ctx := &cfSchemaContext{
@@ -145,7 +146,7 @@ func TestGetTagsStyle(t *testing.T) {
 				},
 			},
 		}
-		assert.Equal(t, TagsStyleKeyValueArrayWithAlternateType, ctx.getTagsStyle("Tags", typeSpec))
+		assert.Equal(t, default_tags.TagsStyleKeyValueArrayWithAlternateType, ctx.getTagsStyle("Tags", typeSpec))
 	})
 }
 

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -14,18 +14,18 @@ import (
 
 func TestGetTagsStyle(t *testing.T) {
 	t.Run("defaults to unknown when typeSpec is nil", func(t *testing.T) {
-		ctx := &context{}
+		ctx := &cfSchemaContext{}
 		assert.Equal(t, TagsStyleUnknown, ctx.getTagsStyle("Tags", nil))
 	})
 	t.Run("untyped style", func(t *testing.T) {
-		ctx := &context{}
+		ctx := &cfSchemaContext{}
 		typeSpec := &schema.TypeSpec{
 			Ref: "pulumi.json#/Any",
 		}
 		assert.Equal(t, TagsStyleUntyped, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("string map style", func(t *testing.T) {
-		ctx := &context{}
+		ctx := &cfSchemaContext{}
 		typeSpec := &schema.TypeSpec{
 			AdditionalProperties: &schema.TypeSpec{
 				Type: "string",
@@ -34,7 +34,7 @@ func TestGetTagsStyle(t *testing.T) {
 		assert.Equal(t, TagsStyleStringMap, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value array style", func(t *testing.T) {
-		ctx := &context{
+		ctx := &cfSchemaContext{
 			pkg: &schema.PackageSpec{
 				Types: map[string]schema.ComplexTypeSpec{
 					"pulumi:types:input:common:ComponentResourceOptions:TagsEntry": {
@@ -56,7 +56,7 @@ func TestGetTagsStyle(t *testing.T) {
 		assert.Equal(t, TagsStyleKeyValueArray, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("not key value array style with extra field", func(t *testing.T) {
-		ctx := &context{
+		ctx := &cfSchemaContext{
 			pkg: &schema.PackageSpec{
 				Types: map[string]schema.ComplexTypeSpec{
 					"pulumi:types:input:common:ComponentResourceOptions:TagsEntry": {
@@ -79,7 +79,7 @@ func TestGetTagsStyle(t *testing.T) {
 		assert.Equal(t, TagsStyleKeyValueArrayWithExtraProperties, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value create-only array style if causes replacement", func(t *testing.T) {
-		ctx := &context{
+		ctx := &cfSchemaContext{
 			pkg: &schema.PackageSpec{
 				Types: map[string]schema.ComplexTypeSpec{
 					"pulumi:types:input:common:ComponentResourceOptions:TagsEntry": {
@@ -106,7 +106,7 @@ func TestGetTagsStyle(t *testing.T) {
 		assert.Equal(t, TagsStyleKeyValueArrayCreateOnly, ctx.getTagsStyle("Tags", typeSpec))
 	})
 	t.Run("key value array with alternate type style", func(t *testing.T) {
-		ctx := &context{
+		ctx := &cfSchemaContext{
 			pkg: &schema.PackageSpec{
 				Types: map[string]schema.ComplexTypeSpec{
 					"pulumi:types:input:common:ComponentResourceOptions:TagsEntry": {

--- a/provider/pkg/schema/inputs.go
+++ b/provider/pkg/schema/inputs.go
@@ -3,10 +3,11 @@
 package schema
 
 import (
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func GetInputsFromState(res *CloudAPIResource, state resource.PropertyMap) (resource.PropertyMap, error) {
+func GetInputsFromState(res *metadata.CloudAPIResource, state resource.PropertyMap) (resource.PropertyMap, error) {
 	inputs := resource.NewPropertyMapFromMap(map[string]interface{}{})
 	for n := range res.Inputs {
 		k := resource.PropertyKey(n)


### PR DESCRIPTION
- Move lots out from schema into smaller modules with less dependencies.
- Fix a few compiler warnings along the way.
- Rename the gen `context` struct so it doesn't block us using the `context` std lib.
- Fix flakey lambda update integration test.

This was extracted from https://github.com/pulumi/pulumi-aws-native/pull/1406