### PR TITLE
Improve autonaming

### DIFF
--- a/examples/default-tags-py/__main__.py
+++ b/examples/default-tags-py/__main__.py
@@ -12,7 +12,6 @@ log_group = logs.LogGroup(
 
 policy = resiliencehub.ResiliencyPolicy(
   "policy",
-  policy_name="my-policy",
   tier=resiliencehub.ResiliencyPolicyTier.NON_CRITICAL,
   policy={
     'Software': resiliencehub.ResiliencyPolicyFailurePolicyArgs(

--- a/provider/pkg/autonaming/semantics.go
+++ b/provider/pkg/autonaming/semantics.go
@@ -5,63 +5,13 @@ package autonaming
 import (
 	"fmt"
 
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-type NamingPredicate string
-
-const (
-	NamingPredicateEquals             NamingPredicate = "equal"
-	NamingPredicateNotEqual           NamingPredicate = "notEqual"
-	NamingPredicateContains           NamingPredicate = "contains"
-	NamingPredicateNotContains        NamingPredicate = "notContains"
-	NamingPredicateStartsWith         NamingPredicate = "startsWith"
-	NamingPredicateNotStartsWith      NamingPredicate = "notStartsWith"
-	NamingPredicateEndsWith           NamingPredicate = "endsWith"
-	NamingPredicateNotEndsWith        NamingPredicate = "notEndsWith"
-	NamingPredicateLessThan           NamingPredicate = "lessThan"
-	NamingPredicateLessThanOrEqual    NamingPredicate = "lessThanOrEqual"
-	NamingPredicateGreaterThan        NamingPredicate = "greaterThan"
-	NamingPredicateGreaterThanOrEqual NamingPredicate = "greaterThanOrEqual"
-	NamingPredicateIn                 NamingPredicate = "in"
-	NamingPredicateNotIn              NamingPredicate = "notIn"
-	NamingPredicateExists             NamingPredicate = "exists"
-	NamingPredicateNotExists          NamingPredicate = "notExists"
-)
-
-type NamingCondition struct {
-	Predicate NamingPredicate        `json:"predicate,omitempty"`
-	Value     resource.PropertyValue `json:"value,omitempty"`
-}
-
-type NamingRule struct {
-	Field     resource.PropertyKey `json:"field,omitempty"`
-	Condition *NamingCondition     `json:"condition,omitempty"`
-}
-
-type SemanticsSpecDocument struct {
-	Resources map[string]SemanticsSpec `json:"resources,omitempty"`
-}
-
-type SemanticsSpec struct {
-	CfType           string                      `json:"cf,omitempty"`
-	NamingTriviaSpec map[string]NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
-}
-
-type NamingTriviaSpec struct {
-	Rule   *NamingRule   `json:"rule,omitempty"`
-	Trivia *NamingTrivia `json:"trivia,omitempty"`
-}
-
-// NamingTrivia is a struct which contains any derived information
-// about a resource's name that is used to generate a random name.
-type NamingTrivia struct {
-	Suffix string `json:"suffix,omitempty"`
-}
-
-func CheckTriviaCondition(props resource.PropertyMap, rule *NamingRule) (bool, error) {
+func CheckTriviaCondition(props resource.PropertyMap, rule *metadata.NamingRule) (bool, error) {
 	switch rule.Condition.Predicate {
-	case NamingPredicateEquals:
+	case metadata.NamingPredicateEquals:
 		return props[rule.Field].DeepEqualsIncludeUnknowns(rule.Condition.Value), nil
 	default:
 		return false, fmt.Errorf("unsupported naming trivia predicate: %s", rule.Condition.Predicate)
@@ -69,7 +19,7 @@ func CheckTriviaCondition(props resource.PropertyMap, rule *NamingRule) (bool, e
 }
 
 // Checks naming trivia for a resource, returning whether the naming trivia applies and the naming trivia.
-func CheckNamingTrivia(sdkName string, props resource.PropertyMap, spec *NamingTriviaSpec) (bool, *NamingTrivia, error) {
+func CheckNamingTrivia(sdkName string, props resource.PropertyMap, spec *metadata.NamingTriviaSpec) (bool, *metadata.NamingTrivia, error) {
 	if spec == nil {
 		return false, nil, nil
 	}
@@ -83,23 +33,16 @@ func CheckNamingTrivia(sdkName string, props resource.PropertyMap, spec *NamingT
 }
 
 // Extracts naming trivia from a resource name, returning the name and the trivia.
-func (n NamingTrivia) extractNamingTrivia(sdkName string, name string) string {
+func extractNamingTrivia(trivia *metadata.NamingTrivia, name string) string {
 	canonicalName := name
-	if len(name) > len(n.Suffix) && name[len(name)-len(n.Suffix):] == n.Suffix {
-		canonicalName = name[:len(name)-len(n.Suffix)]
+	if len(name) > len(trivia.Suffix) && name[len(name)-len(trivia.Suffix):] == trivia.Suffix {
+		canonicalName = name[:len(name)-len(trivia.Suffix)]
 	}
 	return canonicalName
 }
 
 // Applies structured trivia data to an existing resource name.
-func (n NamingTrivia) ApplyTrivia(sdkName, name string) string {
-	canonicalName := n.extractNamingTrivia(sdkName, name)
-	return fmt.Sprintf("%s%s", canonicalName, n.Suffix)
-}
-
-func (trivia *NamingTrivia) Length() int {
-	if trivia == nil {
-		return 0
-	}
-	return len(trivia.Suffix)
+func ApplyTrivia(trivia *metadata.NamingTrivia, name string) string {
+	canonicalName := extractNamingTrivia(trivia, name)
+	return fmt.Sprintf("%s%s", canonicalName, trivia.Suffix)
 }

--- a/provider/pkg/autonaming/spec.go
+++ b/provider/pkg/autonaming/spec.go
@@ -7,39 +7,58 @@ import (
 
 	jsschema "github.com/pulumi/jsschema"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 func CreateAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resourceTypeName string, jsonSchemaProperties map[string]*jsschema.Schema, semanticsSpec metadata.SemanticsSpec) *metadata.AutoNamingSpec {
-	tryMakeSpecForField := func(cfPropName string) (spec *metadata.AutoNamingSpec) {
-		if prop, has := inputProperties[naming.ToSdkName(cfPropName)]; !has || prop.Type != "string" {
+	type names struct {
+		cfName  string
+		sdkName string
+	}
+	// Lowercase all keys so we can do case-insensitive lookups.
+	fieldsLowered := make(map[string]names, len(jsonSchemaProperties))
+	for k := range jsonSchemaProperties {
+		fieldsLowered[strings.ToLower(k)] = names{cfName: k}
+	}
+	for k := range inputProperties {
+		lowered := strings.ToLower(k)
+		if v, ok := fieldsLowered[lowered]; ok {
+			v.sdkName = k
+			fieldsLowered[lowered] = v
+		} else {
+			fieldsLowered[lowered] = names{sdkName: k}
+		}
+	}
+
+	tryMakeSpecForField := func(loweredName string) (spec *metadata.AutoNamingSpec) {
+		sdkName := fieldsLowered[loweredName].sdkName
+		if prop, has := inputProperties[sdkName]; !has || prop.Type != "string" {
 			return nil
 		}
-		jsonSpec := jsonSchemaProperties[cfPropName]
+		jsonSpec := jsonSchemaProperties[fieldsLowered[loweredName].cfName]
 		if jsonSpec == nil {
 			return nil
 		}
 		return &metadata.AutoNamingSpec{
-			SdkName:   naming.ToSdkName(cfPropName),
+			SdkName:   sdkName,
 			MinLength: jsonSpec.MinLength.Val,
 			MaxLength: jsonSpec.MaxLength.Val,
 		}
 	}
 
 	// 1. Look for a property named "Name"
-	autoNameSpec := tryMakeSpecForField("Name")
+	autoNameSpec := tryMakeSpecForField("name")
 	if autoNameSpec == nil {
 		// 2. Look for a property named "<ResourceTypeName>Name"
-		autoNameSpec = tryMakeSpecForField(resourceTypeName + "Name")
+		autoNameSpec = tryMakeSpecForField(strings.ToLower(resourceTypeName) + "name")
 	}
 	if autoNameSpec == nil {
 		// 3. Look for a property that ends with "*Name" where that prefix is also contained in the resource name.
 		// E.g. ScalingPolicy has a field "PolicyName".
 		var potentialSpecs []*metadata.AutoNamingSpec
-		for k := range jsonSchemaProperties {
-			if before, ok := strings.CutSuffix(k, "Name"); ok {
-				if strings.HasSuffix(resourceTypeName, before) {
+		for k := range fieldsLowered {
+			if before, ok := strings.CutSuffix(k, "name"); ok {
+				if strings.HasSuffix(strings.ToLower(resourceTypeName), before) {
 					potentialSpec := tryMakeSpecForField(k)
 					if potentialSpec != nil {
 						potentialSpecs = append(potentialSpecs, potentialSpec)

--- a/provider/pkg/autonaming/spec.go
+++ b/provider/pkg/autonaming/spec.go
@@ -1,0 +1,64 @@
+// Copyright 2024, Pulumi Corporation.
+
+package autonaming
+
+import (
+	"strings"
+
+	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+func CreateAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resourceTypeName string, jsonSchemaProperties map[string]*jsschema.Schema, semanticsSpec metadata.SemanticsSpec) *metadata.AutoNamingSpec {
+	tryMakeSpecForField := func(cfPropName string) (spec *metadata.AutoNamingSpec) {
+		if prop, has := inputProperties[naming.ToSdkName(cfPropName)]; !has || prop.Type != "string" {
+			return nil
+		}
+		jsonSpec := jsonSchemaProperties[cfPropName]
+		if jsonSpec == nil {
+			return nil
+		}
+		return &metadata.AutoNamingSpec{
+			SdkName:   naming.ToSdkName(cfPropName),
+			MinLength: jsonSpec.MinLength.Val,
+			MaxLength: jsonSpec.MaxLength.Val,
+		}
+	}
+
+	// 1. Look for a property named "Name"
+	autoNameSpec := tryMakeSpecForField("Name")
+	if autoNameSpec == nil {
+		// 2. Look for a property named "<ResourceTypeName>Name"
+		autoNameSpec = tryMakeSpecForField(resourceTypeName + "Name")
+	}
+	if autoNameSpec == nil {
+		// 3. Look for a property that ends with "*Name" where that prefix is also contained in the resource name.
+		// E.g. ScalingPolicy has a field "PolicyName".
+		var potentialSpecs []*metadata.AutoNamingSpec
+		for k := range jsonSchemaProperties {
+			if before, ok := strings.CutSuffix(k, "Name"); ok {
+				if strings.HasSuffix(resourceTypeName, before) {
+					potentialSpec := tryMakeSpecForField(k)
+					if potentialSpec != nil {
+						potentialSpecs = append(potentialSpecs, potentialSpec)
+					}
+				}
+			}
+		}
+		// Only proceed if there is exactly one matched property name to avoid ambiguity.
+		if len(potentialSpecs) == 1 {
+			autoNameSpec = potentialSpecs[0]
+		}
+	}
+
+	if autoNameSpec != nil {
+		namingTriviaSpec, ok := semanticsSpec.NamingTriviaSpec[autoNameSpec.SdkName]
+		if ok {
+			autoNameSpec.TriviaSpec = &namingTriviaSpec
+		}
+	}
+
+	return autoNameSpec
+}

--- a/provider/pkg/autonaming/spec_test.go
+++ b/provider/pkg/autonaming/spec_test.go
@@ -124,4 +124,20 @@ func TestCreateAutoNamingSpec(t *testing.T) {
 		})
 		assert.Nil(t, spec)
 	})
+
+	t.Run("handles oddly cased acryonyms", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "tlsInspectionConfigurationName",
+		}
+		spec := create(args{
+			resourceTypeName: "TlsInspectionConfiguration",
+			inputProperties: map[string]schema.PropertySpec{
+				"tlsInspectionConfigurationName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"TLSInspectionConfigurationName": {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
 }

--- a/provider/pkg/autonaming/spec_test.go
+++ b/provider/pkg/autonaming/spec_test.go
@@ -1,0 +1,127 @@
+package autonaming
+
+import (
+	"testing"
+
+	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateAutoNamingSpec(t *testing.T) {
+	type args struct {
+		resourceTypeName     string
+		inputProperties      map[string]schema.PropertySpec
+		jsonSchemaProperties map[string]*jsschema.Schema
+		semanticsSpec        metadata.SemanticsSpec
+	}
+	create := func(args args) *metadata.AutoNamingSpec {
+		return CreateAutoNamingSpec(args.inputProperties, args.resourceTypeName, args.jsonSchemaProperties, args.semanticsSpec)
+	}
+	t.Run("literal name", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "name",
+		}
+		spec := create(args{
+			inputProperties: map[string]schema.PropertySpec{
+				"name": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"Name": {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
+
+	t.Run("skips if not input", func(t *testing.T) {
+		spec := create(args{
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"Name": {},
+			},
+		})
+		assert.Nil(t, spec)
+	})
+
+	t.Run("literal name preferred", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "name",
+		}
+		spec := create(args{
+			inputProperties: map[string]schema.PropertySpec{
+				"name":         {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"resourceName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"Name":         {},
+				"ResourceName": {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
+
+	t.Run("resource plus name", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "resourceName",
+		}
+		spec := create(args{
+			resourceTypeName: "Resource",
+			inputProperties: map[string]schema.PropertySpec{
+				"resourceName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"ResourceName": {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
+
+	t.Run("resource plus name preferred over partial", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "fooBarName",
+		}
+		spec := create(args{
+			resourceTypeName: "FooBar",
+			inputProperties: map[string]schema.PropertySpec{
+				"fooBarName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"barName":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"FooBarName": {},
+				"BarName":    {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
+
+	t.Run("partial overlap with type name", func(t *testing.T) {
+		expected := &metadata.AutoNamingSpec{
+			SdkName: "barName",
+		}
+		spec := create(args{
+			resourceTypeName: "FooBar",
+			inputProperties: map[string]schema.PropertySpec{
+				"barName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"BarName": {},
+			},
+		})
+		assert.Equal(t, expected, spec)
+	})
+
+	t.Run("skips when multiple names overlap", func(t *testing.T) {
+		spec := create(args{
+			resourceTypeName: "FooBarBaz",
+			inputProperties: map[string]schema.PropertySpec{
+				"bazName":    {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"barBazName": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			jsonSchemaProperties: map[string]*jsschema.Schema{
+				"BazName":    {},
+				"BarBazName": {},
+			},
+		})
+		assert.Nil(t, spec)
+	})
+}

--- a/provider/pkg/metadata/autonaming.go
+++ b/provider/pkg/metadata/autonaming.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2023, Pulumi Corporation.
+
+package metadata
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type NamingPredicate string
+
+const (
+	NamingPredicateEquals             NamingPredicate = "equal"
+	NamingPredicateNotEqual           NamingPredicate = "notEqual"
+	NamingPredicateContains           NamingPredicate = "contains"
+	NamingPredicateNotContains        NamingPredicate = "notContains"
+	NamingPredicateStartsWith         NamingPredicate = "startsWith"
+	NamingPredicateNotStartsWith      NamingPredicate = "notStartsWith"
+	NamingPredicateEndsWith           NamingPredicate = "endsWith"
+	NamingPredicateNotEndsWith        NamingPredicate = "notEndsWith"
+	NamingPredicateLessThan           NamingPredicate = "lessThan"
+	NamingPredicateLessThanOrEqual    NamingPredicate = "lessThanOrEqual"
+	NamingPredicateGreaterThan        NamingPredicate = "greaterThan"
+	NamingPredicateGreaterThanOrEqual NamingPredicate = "greaterThanOrEqual"
+	NamingPredicateIn                 NamingPredicate = "in"
+	NamingPredicateNotIn              NamingPredicate = "notIn"
+	NamingPredicateExists             NamingPredicate = "exists"
+	NamingPredicateNotExists          NamingPredicate = "notExists"
+)
+
+type NamingCondition struct {
+	Predicate NamingPredicate        `json:"predicate,omitempty"`
+	Value     resource.PropertyValue `json:"value,omitempty"`
+}
+
+type NamingRule struct {
+	Field     resource.PropertyKey `json:"field,omitempty"`
+	Condition *NamingCondition     `json:"condition,omitempty"`
+}
+
+type SemanticsSpecDocument struct {
+	Resources map[string]SemanticsSpec `json:"resources,omitempty"`
+}
+
+type SemanticsSpec struct {
+	CfType           string                      `json:"cf,omitempty"`
+	NamingTriviaSpec map[string]NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
+}
+
+type NamingTriviaSpec struct {
+	Rule   *NamingRule   `json:"rule,omitempty"`
+	Trivia *NamingTrivia `json:"trivia,omitempty"`
+}
+
+// NamingTrivia is a struct which contains any derived information
+// about a resource's name that is used to generate a random name.
+type NamingTrivia struct {
+	Suffix string `json:"suffix,omitempty"`
+}
+
+func (trivia *NamingTrivia) Length() int {
+	if trivia == nil {
+		return 0
+	}
+	return len(trivia.Suffix)
+}

--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -3,7 +3,6 @@
 package metadata
 
 import (
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
@@ -30,10 +29,10 @@ type CloudAPIResource struct {
 }
 
 type AutoNamingSpec struct {
-	SdkName    string                       `json:"sdkName"`
-	MinLength  int                          `json:"minLength,omitempty"`
-	MaxLength  int                          `json:"maxLength,omitempty"`
-	TriviaSpec *autonaming.NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
+	SdkName    string            `json:"sdkName"`
+	MinLength  int               `json:"minLength,omitempty"`
+	MaxLength  int               `json:"maxLength,omitempty"`
+	TriviaSpec *NamingTriviaSpec `json:"namingTriviaSpec,omitempty"`
 }
 
 // CloudAPIType contains metadata for an auxiliary type.

--- a/provider/pkg/provider/ids.go
+++ b/provider/pkg/provider/ids.go
@@ -90,7 +90,7 @@ func getDefaultName(
 
 	// Apply naming trivia to the generated name.
 	if namingTriviaApplies {
-		random = namingTrivia.ApplyTrivia(sdkName, random)
+		random = autonaming.ApplyTrivia(namingTrivia, random)
 	}
 
 	return resource.NewStringProperty(random), nil

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -454,9 +454,7 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []*jsschema.Sche
 		Functions: map[string]metadata.CloudAPIFunction{},
 	}
 
-	reports := &Reports{
-		UnexpectedTagsShapes: map[string]interface{}{},
-	}
+	reports := NewReports()
 
 	supportedResources := codegen.NewStringSet(supportedResourceTypes...)
 
@@ -871,6 +869,11 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 	// If a field can be auto-named, its no longer required.
 	if autoNamingSpec != nil {
 		delete(requiredInputs, autoNamingSpec.SdkName)
+	} else {
+		ctx.reports.MissedAutonaming[ctx.resourceToken] = map[string]any{
+			"cfTypeName": ctx.cfTypeName,
+			"properties": inputProperties,
+		}
 	}
 
 	var deprecationMessage string

--- a/provider/pkg/schema/gen_report.go
+++ b/provider/pkg/schema/gen_report.go
@@ -14,6 +14,15 @@ import (
 type Reports struct {
 	// UnexpectedTagsShapes is a map of the resource token of resources which have a `Tags` field but don't match an expected pattern.
 	UnexpectedTagsShapes map[string]interface{}
+	// MissedAutonaming is a map of the resource token of resources we haven't identified as autonameable.
+	MissedAutonaming map[string]interface{}
+}
+
+func NewReports() *Reports {
+	return &Reports{
+		UnexpectedTagsShapes: make(map[string]interface{}),
+		MissedAutonaming:     make(map[string]interface{}),
+	}
 }
 
 func (r *Reports) WriteToDirectory(dir string) error {
@@ -38,6 +47,9 @@ func (r *Reports) WriteToDirectory(dir string) error {
 	}
 
 	if err = writeFile("unexpectedTagsShapes.json", r.UnexpectedTagsShapes); err != nil {
+		return err
+	}
+	if err = writeFile("missedAutonaming.json", r.MissedAutonaming); err != nil {
 		return err
 	}
 	return nil

--- a/reports/README.md
+++ b/reports/README.md
@@ -5,3 +5,7 @@ The purpose of these reports are to highlight information from within the genera
 ## Unexpected Tags Shapes
 
 This report lists each resource which has a field called "Tags" but it doesn't match one of our expected heuristics for its shape (either a list of Tags objects or a map of string to string). The key is the Pulumi resource token and the value is the original JSON schema for the Tags property.
+
+## Missed Autonaming
+
+This report lists each resource for which our autonaming has not managed to identify a field which is the logical "name" and therefore we won't be able to automatically create a name based on the Pulumi resource name. There are many resources where this is a valid limitation e.g. it's identifier is composed of two other resource's identifiers or it doesn't contain any kind of user-facing name.

--- a/reports/missedAutonaming.json
+++ b/reports/missedAutonaming.json
@@ -1,0 +1,12741 @@
+{
+  "aws-native:acmpca:Certificate": {
+    "cfTypeName": "AWS::ACMPCA::Certificate",
+    "properties": {
+      "apiPassthrough": {
+        "$ref": "#/types/aws-native:acmpca:CertificateApiPassthrough",
+        "description": "Specifies X.509 certificate information to be included in the issued certificate. An ``APIPassthrough`` or ``APICSRPassthrough`` template variant must be selected, or else this parameter is ignored."
+      },
+      "certificateAuthorityArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the private CA issues the certificate."
+      },
+      "certificateSigningRequest": {
+        "type": "string",
+        "description": "The certificate signing request (CSR) for the certificate."
+      },
+      "signingAlgorithm": {
+        "type": "string",
+        "description": "The name of the algorithm that will be used to sign the certificate to be issued. \n This parameter should not be confused with the ``SigningAlgorithm`` parameter used to sign a CSR in the ``CreateCertificateAuthority`` action.\n  The specified signing algorithm family (RSA or ECDSA) must match the algorithm family of the CA's secret key."
+      },
+      "templateArn": {
+        "type": "string",
+        "description": "Specifies a custom configuration template to use when issuing a certificate. If this parameter is not provided, PCAshort defaults to the ``EndEntityCertificate/V1`` template. For more information about PCAshort templates, see [Using Templates](https://docs.aws.amazon.com/privateca/latest/userguide/UsingTemplates.html)."
+      },
+      "validity": {
+        "$ref": "#/types/aws-native:acmpca:CertificateValidity",
+        "description": "The period of time during which the certificate will be valid."
+      },
+      "validityNotBefore": {
+        "$ref": "#/types/aws-native:acmpca:CertificateValidity",
+        "description": "Information describing the start of the validity period of the certificate. This parameter sets the \"Not Before\" date for the certificate.\n By default, when issuing a certificate, PCAshort sets the \"Not Before\" date to the issuance time minus 60 minutes. This compensates for clock inconsistencies across computer systems. The ``ValidityNotBefore`` parameter can be used to customize the \"Not Before\" value. \n Unlike the ``Validity`` parameter, the ``ValidityNotBefore`` parameter is optional.\n The ``ValidityNotBefore`` value is expressed as an explicit date and time, using the ``Validity`` type value ``ABSOLUTE``."
+      }
+    }
+  },
+  "aws-native:acmpca:CertificateAuthority": {
+    "cfTypeName": "AWS::ACMPCA::CertificateAuthority",
+    "properties": {
+      "csrExtensions": {
+        "$ref": "#/types/aws-native:acmpca:CertificateAuthorityCsrExtensions",
+        "description": "Structure that contains CSR pass through extension information used by the CreateCertificateAuthority action."
+      },
+      "keyAlgorithm": {
+        "type": "string",
+        "description": "Public key algorithm and size, in bits, of the key pair that your CA creates when it issues a certificate."
+      },
+      "keyStorageSecurityStandard": {
+        "type": "string",
+        "description": "KeyStorageSecurityStadard defines a cryptographic key management compliance standard used for handling CA keys."
+      },
+      "revocationConfiguration": {
+        "$ref": "#/types/aws-native:acmpca:CertificateAuthorityRevocationConfiguration",
+        "description": "Certificate revocation information used by the CreateCertificateAuthority and UpdateCertificateAuthority actions."
+      },
+      "signingAlgorithm": {
+        "type": "string",
+        "description": "Algorithm your CA uses to sign certificate requests."
+      },
+      "subject": {
+        "$ref": "#/types/aws-native:acmpca:CertificateAuthoritySubject",
+        "description": "Structure that contains X.500 distinguished name information for your CA."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of the certificate authority."
+      },
+      "usageMode": {
+        "type": "string",
+        "description": "Usage mode of the ceritificate authority."
+      }
+    }
+  },
+  "aws-native:acmpca:CertificateAuthorityActivation": {
+    "cfTypeName": "AWS::ACMPCA::CertificateAuthorityActivation",
+    "properties": {
+      "certificate": {
+        "type": "string",
+        "description": "Certificate Authority certificate that will be installed in the Certificate Authority."
+      },
+      "certificateAuthorityArn": {
+        "type": "string",
+        "description": "Arn of the Certificate Authority."
+      },
+      "certificateChain": {
+        "type": "string",
+        "description": "Certificate chain for the Certificate Authority certificate."
+      },
+      "status": {
+        "type": "string",
+        "description": "The status of the Certificate Authority."
+      }
+    }
+  },
+  "aws-native:acmpca:Permission": {
+    "cfTypeName": "AWS::ACMPCA::Permission",
+    "properties": {
+      "actions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The actions that the specified AWS service principal can use. Actions IssueCertificate, GetCertificate and ListPermissions must be provided."
+      },
+      "certificateAuthorityArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Private Certificate Authority that grants the permission."
+      },
+      "principal": {
+        "type": "string",
+        "description": "The AWS service or identity that receives the permission. At this time, the only valid principal is acm.amazonaws.com."
+      },
+      "sourceAccount": {
+        "type": "string",
+        "description": "The ID of the calling account."
+      }
+    }
+  },
+  "aws-native:apigateway:Account": {
+    "cfTypeName": "AWS::ApiGateway::Account",
+    "properties": {
+      "cloudWatchRoleArn": {
+        "type": "string",
+        "description": "The ARN of an Amazon CloudWatch role for the current Account."
+      }
+    }
+  },
+  "aws-native:apigateway:BasePathMapping": {
+    "cfTypeName": "AWS::ApiGateway::BasePathMapping",
+    "properties": {
+      "basePath": {
+        "type": "string",
+        "description": "The base path name that callers of the API must provide as part of the URL after the domain name."
+      },
+      "domainName": {
+        "type": "string",
+        "description": "The domain name of the BasePathMapping resource to be described."
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      },
+      "stage": {
+        "type": "string",
+        "description": "The name of the associated stage."
+      }
+    }
+  },
+  "aws-native:apigateway:ClientCertificate": {
+    "cfTypeName": "AWS::ApiGateway::ClientCertificate",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the client certificate."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The collection of tags. Each tag element is associated with a given resource."
+      }
+    }
+  },
+  "aws-native:apigateway:Deployment": {
+    "cfTypeName": "AWS::ApiGateway::Deployment",
+    "properties": {
+      "deploymentCanarySettings": {
+        "$ref": "#/types/aws-native:apigateway:DeploymentCanarySettings",
+        "description": "The input configuration for a canary deployment."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description for the Deployment resource to create."
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      },
+      "stageDescription": {
+        "$ref": "#/types/aws-native:apigateway:DeploymentStageDescription",
+        "description": "The description of the Stage resource for the Deployment resource to create. To specify a stage description, you must also provide a stage name."
+      },
+      "stageName": {
+        "type": "string",
+        "description": "The name of the Stage resource for the Deployment resource to create."
+      }
+    }
+  },
+  "aws-native:apigateway:DocumentationPart": {
+    "cfTypeName": "AWS::ApiGateway::DocumentationPart",
+    "properties": {
+      "location": {
+        "$ref": "#/types/aws-native:apigateway:DocumentationPartLocation",
+        "description": "The location of the targeted API entity of the to-be-created documentation part."
+      },
+      "properties": {
+        "type": "string",
+        "description": "The new documentation content map of the targeted API entity. Enclosed key-value pairs are API-specific, but only OpenAPI-compliant key-value pairs can be exported and, hence, published."
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      }
+    }
+  },
+  "aws-native:apigateway:DocumentationVersion": {
+    "cfTypeName": "AWS::ApiGateway::DocumentationVersion",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description about the new documentation snapshot."
+      },
+      "documentationVersion": {
+        "type": "string",
+        "description": "The version identifier of the to-be-updated documentation version.",
+        "language": {
+          "csharp": {
+            "name": "DocumentationVersionValue"
+          }
+        }
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      }
+    }
+  },
+  "aws-native:apigateway:DomainName": {
+    "cfTypeName": "AWS::ApiGateway::DomainName",
+    "properties": {
+      "certificateArn": {
+        "type": "string"
+      },
+      "domainName": {
+        "type": "string",
+        "language": {
+          "csharp": {
+            "name": "DomainNameValue"
+          }
+        }
+      },
+      "endpointConfiguration": {
+        "$ref": "#/types/aws-native:apigateway:DomainNameEndpointConfiguration"
+      },
+      "mutualTlsAuthentication": {
+        "$ref": "#/types/aws-native:apigateway:DomainNameMutualTlsAuthentication"
+      },
+      "ownershipVerificationCertificateArn": {
+        "type": "string"
+      },
+      "regionalCertificateArn": {
+        "type": "string"
+      },
+      "securityPolicy": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:apigateway:Method": {
+    "cfTypeName": "AWS::ApiGateway::Method",
+    "properties": {
+      "apiKeyRequired": {
+        "type": "boolean",
+        "description": "A boolean flag specifying whether a valid ApiKey is required to invoke this method."
+      },
+      "authorizationScopes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of authorization scopes configured on the method. The scopes are used with a ``COGNITO_USER_POOLS`` authorizer to authorize the method invocation. The authorization works by matching the method scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any method scopes matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the method scope is configured, the client must provide an access token instead of an identity token for authorization purposes."
+      },
+      "authorizationType": {
+        "$ref": "#/types/aws-native:apigateway:MethodAuthorizationType",
+        "description": "The method's authorization type. This parameter is required. For valid values, see [Method](https://docs.aws.amazon.com/apigateway/latest/api/API_Method.html) in the *API Gateway API Reference*.\n  If you specify the ``AuthorizerId`` property, specify ``CUSTOM`` or ``COGNITO_USER_POOLS`` for this property."
+      },
+      "authorizerId": {
+        "type": "string",
+        "description": "The identifier of an authorizer to use on this method. The method's authorization type must be ``CUSTOM`` or ``COGNITO_USER_POOLS``."
+      },
+      "httpMethod": {
+        "type": "string",
+        "description": "The method's HTTP verb."
+      },
+      "integration": {
+        "$ref": "#/types/aws-native:apigateway:MethodIntegration",
+        "description": "Represents an ``HTTP``, ``HTTP_PROXY``, ``AWS``, ``AWS_PROXY``, or Mock integration."
+      },
+      "methodResponses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:apigateway:MethodResponse"
+        },
+        "description": "Gets a method response associated with a given HTTP status code."
+      },
+      "operationName": {
+        "type": "string",
+        "description": "A human-friendly operation identifier for the method. For example, you can assign the ``operationName`` of ``ListPets`` for the ``GET /pets`` method in the ``PetStore`` example."
+      },
+      "requestModels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A key-value map specifying data schemas, represented by Model resources, (as the mapped value) of the request payloads of given content types (as the mapping key)."
+      },
+      "requestParameters": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "description": "A key-value map defining required or optional method request parameters that can be accepted by API Gateway. A key is a method request parameter name matching the pattern of ``method.request.{location}.{name}``, where ``location`` is ``querystring``, ``path``, or ``header`` and ``name`` is a valid and unique parameter name. The value associated with the key is a Boolean flag indicating whether the parameter is required (``true``) or optional (``false``). The method request parameter names defined here are available in Integration to be mapped to integration request parameters or templates."
+      },
+      "requestValidatorId": {
+        "type": "string",
+        "description": "The identifier of a RequestValidator for request validation."
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "The Resource identifier for the MethodResponse resource."
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      }
+    }
+  },
+  "aws-native:apigateway:Resource": {
+    "cfTypeName": "AWS::ApiGateway::Resource",
+    "properties": {
+      "parentId": {
+        "type": "string",
+        "description": "The parent resource's identifier."
+      },
+      "pathPart": {
+        "type": "string",
+        "description": "The last path segment for this resource."
+      },
+      "restApiId": {
+        "type": "string",
+        "description": "The string identifier of the associated RestApi."
+      }
+    }
+  },
+  "aws-native:apigateway:UsagePlanKey": {
+    "cfTypeName": "AWS::ApiGateway::UsagePlanKey",
+    "properties": {
+      "keyId": {
+        "type": "string",
+        "description": "The Id of the UsagePlanKey resource."
+      },
+      "keyType": {
+        "$ref": "#/types/aws-native:apigateway:UsagePlanKeyKeyType",
+        "description": "The type of a UsagePlanKey resource for a plan customer."
+      },
+      "usagePlanId": {
+        "type": "string",
+        "description": "The Id of the UsagePlan resource representing the usage plan containing the UsagePlanKey resource representing a plan customer."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:ApiMapping": {
+    "cfTypeName": "AWS::ApiGatewayV2::ApiMapping",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The identifier of the API."
+      },
+      "apiMappingKey": {
+        "type": "string",
+        "description": "The API mapping key."
+      },
+      "domainName": {
+        "type": "string",
+        "description": "The domain name."
+      },
+      "stage": {
+        "type": "string",
+        "description": "The API stage."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:Deployment": {
+    "cfTypeName": "AWS::ApiGatewayV2::Deployment",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The API identifier."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description for the deployment resource."
+      },
+      "stageName": {
+        "type": "string",
+        "description": "The name of an existing stage to associate with the deployment."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:DomainName": {
+    "cfTypeName": "AWS::ApiGatewayV2::DomainName",
+    "properties": {
+      "domainName": {
+        "type": "string",
+        "description": "The custom domain name for your API in Amazon API Gateway. Uppercase letters are not supported.",
+        "language": {
+          "csharp": {
+            "name": "DomainNameValue"
+          }
+        }
+      },
+      "domainNameConfigurations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:apigatewayv2:DomainNameConfiguration"
+        },
+        "description": "The domain name configurations."
+      },
+      "mutualTlsAuthentication": {
+        "$ref": "#/types/aws-native:apigatewayv2:DomainNameMutualTlsAuthentication",
+        "description": "The mutual TLS authentication configuration for a custom domain name."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "The collection of tags associated with a domain name."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:IntegrationResponse": {
+    "cfTypeName": "AWS::ApiGatewayV2::IntegrationResponse",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The API identifier."
+      },
+      "contentHandlingStrategy": {
+        "type": "string",
+        "description": "Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are ``CONVERT_TO_BINARY`` and ``CONVERT_TO_TEXT``, with the following behaviors:\n  ``CONVERT_TO_BINARY``: Converts a response payload from a Base64-encoded string to the corresponding binary blob.\n  ``CONVERT_TO_TEXT``: Converts a response payload from a binary blob to a Base64-encoded string.\n If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification."
+      },
+      "integrationId": {
+        "type": "string",
+        "description": "The integration ID."
+      },
+      "integrationResponseKey": {
+        "type": "string",
+        "description": "The integration response key."
+      },
+      "responseParameters": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of ``method.response.header.{name}``, where name is a valid and unique header name. The mapped non-static value must match the pattern of ``integration.response.header.{name}`` or ``integration.response.body.{JSON-expression}``, where ``{name}`` is a valid and unique response header name and ``{JSON-expression}`` is a valid JSON expression without the ``$`` prefix.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ApiGatewayV2::IntegrationResponse` for more information about the expected schema for this property."
+      },
+      "responseTemplates": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ApiGatewayV2::IntegrationResponse` for more information about the expected schema for this property."
+      },
+      "templateSelectionExpression": {
+        "type": "string",
+        "description": "The template selection expression for the integration response. Supported only for WebSocket APIs."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:Route": {
+    "cfTypeName": "AWS::ApiGatewayV2::Route",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The API identifier."
+      },
+      "apiKeyRequired": {
+        "type": "boolean",
+        "description": "Specifies whether an API key is required for the route. Supported only for WebSocket APIs."
+      },
+      "authorizationScopes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The authorization scopes supported by this route."
+      },
+      "authorizationType": {
+        "type": "string",
+        "description": "The authorization type for the route. For WebSocket APIs, valid values are ``NONE`` for open access, ``AWS_IAM`` for using AWS IAM permissions, and ``CUSTOM`` for using a Lambda authorizer. For HTTP APIs, valid values are ``NONE`` for open access, ``JWT`` for using JSON Web Tokens, ``AWS_IAM`` for using AWS IAM permissions, and ``CUSTOM`` for using a Lambda authorizer."
+      },
+      "authorizerId": {
+        "type": "string",
+        "description": "The identifier of the ``Authorizer`` resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer."
+      },
+      "modelSelectionExpression": {
+        "type": "string",
+        "description": "The model selection expression for the route. Supported only for WebSocket APIs."
+      },
+      "operationName": {
+        "type": "string",
+        "description": "The operation name for the route."
+      },
+      "requestModels": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The request models for the route. Supported only for WebSocket APIs.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ApiGatewayV2::Route` for more information about the expected schema for this property."
+      },
+      "requestParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:apigatewayv2:RouteParameterConstraints"
+        },
+        "description": "The request parameters for the route. Supported only for WebSocket APIs."
+      },
+      "routeKey": {
+        "type": "string",
+        "description": "The route key for the route. For HTTP APIs, the route key can be either ``$default``, or a combination of an HTTP method and resource path, for example, ``GET /pets``."
+      },
+      "routeResponseSelectionExpression": {
+        "type": "string",
+        "description": "The route response selection expression for the route. Supported only for WebSocket APIs."
+      },
+      "target": {
+        "type": "string",
+        "description": "The target for the route."
+      }
+    }
+  },
+  "aws-native:apigatewayv2:RouteResponse": {
+    "cfTypeName": "AWS::ApiGatewayV2::RouteResponse",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The API identifier."
+      },
+      "modelSelectionExpression": {
+        "type": "string",
+        "description": "The model selection expression for the route response. Supported only for WebSocket APIs."
+      },
+      "responseModels": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The response models for the route response.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ApiGatewayV2::RouteResponse` for more information about the expected schema for this property."
+      },
+      "responseParameters": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:apigatewayv2:RouteResponseParameterConstraints"
+        },
+        "description": "The route response parameters."
+      },
+      "routeId": {
+        "type": "string",
+        "description": "The route ID."
+      },
+      "routeResponseKey": {
+        "type": "string",
+        "description": "The route response key."
+      }
+    }
+  },
+  "aws-native:appconfig:ExtensionAssociation": {
+    "cfTypeName": "AWS::AppConfig::ExtensionAssociation",
+    "properties": {
+      "extensionIdentifier": {
+        "type": "string"
+      },
+      "extensionVersionNumber": {
+        "type": "integer"
+      },
+      "parameters": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "resourceIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:appconfig:HostedConfigurationVersion": {
+    "cfTypeName": "AWS::AppConfig::HostedConfigurationVersion",
+    "properties": {
+      "applicationId": {
+        "type": "string",
+        "description": "The application ID."
+      },
+      "configurationProfileId": {
+        "type": "string",
+        "description": "The configuration profile ID."
+      },
+      "content": {
+        "type": "string",
+        "description": "The content of the configuration or the configuration data."
+      },
+      "contentType": {
+        "type": "string",
+        "description": "A standard MIME type describing the format of the configuration content."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description of the hosted configuration version."
+      },
+      "latestVersionNumber": {
+        "type": "integer",
+        "description": "An optional locking token used to prevent race conditions from overwriting configuration updates when creating a new version. To ensure your data is not overwritten when creating multiple hosted configuration versions in rapid succession, specify the version number of the latest hosted configuration version."
+      },
+      "versionLabel": {
+        "type": "string",
+        "description": "A user-defined label for an AWS AppConfig hosted configuration version."
+      }
+    }
+  },
+  "aws-native:appflow:Connector": {
+    "cfTypeName": "AWS::AppFlow::Connector",
+    "properties": {
+      "connectorLabel": {
+        "type": "string",
+        "description": " The name of the connector. The name is unique for each ConnectorRegistration in your AWS account."
+      },
+      "connectorProvisioningConfig": {
+        "$ref": "#/types/aws-native:appflow:ConnectorProvisioningConfig",
+        "description": "Contains information about the configuration of the connector being registered."
+      },
+      "connectorProvisioningType": {
+        "type": "string",
+        "description": "The provisioning type of the connector. Currently the only supported value is LAMBDA. "
+      },
+      "description": {
+        "type": "string",
+        "description": "A description about the connector that's being registered."
+      }
+    }
+  },
+  "aws-native:applicationautoscaling:ScalableTarget": {
+    "cfTypeName": "AWS::ApplicationAutoScaling::ScalableTarget",
+    "properties": {
+      "maxCapacity": {
+        "type": "integer",
+        "description": "The maximum value that you plan to scale in to. When a scaling policy is in effect, Application Auto Scaling can scale in (contract) as needed to the minimum capacity limit in response to changing demand"
+      },
+      "minCapacity": {
+        "type": "integer",
+        "description": "The minimum value that you plan to scale in to. When a scaling policy is in effect, Application Auto Scaling can scale in (contract) as needed to the minimum capacity limit in response to changing demand"
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "The identifier of the resource associated with the scalable target"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "Specify the Amazon Resource Name (ARN) of an Identity and Access Management (IAM) role that allows Application Auto Scaling to modify the scalable target on your behalf. "
+      },
+      "scalableDimension": {
+        "type": "string",
+        "description": "The scalable dimension associated with the scalable target. This string consists of the service namespace, resource type, and scaling property"
+      },
+      "scheduledActions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:applicationautoscaling:ScalableTargetScheduledAction"
+        },
+        "description": "The scheduled actions for the scalable target. Duplicates aren't allowed."
+      },
+      "serviceNamespace": {
+        "type": "string",
+        "description": "The namespace of the AWS service that provides the resource, or a custom-resource"
+      },
+      "suspendedState": {
+        "$ref": "#/types/aws-native:applicationautoscaling:ScalableTargetSuspendedState",
+        "description": "An embedded object that contains attributes and attribute values that are used to suspend and resume automatic scaling. Setting the value of an attribute to true suspends the specified scaling activities. Setting it to false (default) resumes the specified scaling activities."
+      }
+    }
+  },
+  "aws-native:applicationautoscaling:ScalingPolicy": {
+    "cfTypeName": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    "properties": {
+      "policyName": {
+        "type": "string",
+        "description": "The name of the scaling policy.\n\nUpdates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name."
+      },
+      "policyType": {
+        "type": "string",
+        "description": "The scaling policy type.\n\nThe following policy types are supported:\n\nTargetTrackingScaling Not supported for Amazon EMR\n\nStepScaling Not supported for DynamoDB, Amazon Comprehend, Lambda, Amazon Keyspaces, Amazon MSK, Amazon ElastiCache, or Neptune."
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "The identifier of the resource associated with the scaling policy. This string consists of the resource type and unique identifier."
+      },
+      "scalableDimension": {
+        "type": "string",
+        "description": "The scalable dimension. This string consists of the service namespace, resource type, and scaling property."
+      },
+      "scalingTargetId": {
+        "type": "string",
+        "description": "The CloudFormation-generated ID of an Application Auto Scaling scalable target. For more information about the ID, see the Return Value section of the AWS::ApplicationAutoScaling::ScalableTarget resource."
+      },
+      "serviceNamespace": {
+        "type": "string",
+        "description": "The namespace of the AWS service that provides the resource, or a custom-resource."
+      },
+      "stepScalingPolicyConfiguration": {
+        "$ref": "#/types/aws-native:applicationautoscaling:ScalingPolicyStepScalingPolicyConfiguration",
+        "description": "A step scaling policy."
+      },
+      "targetTrackingScalingPolicyConfiguration": {
+        "$ref": "#/types/aws-native:applicationautoscaling:ScalingPolicyTargetTrackingScalingPolicyConfiguration",
+        "description": "A target tracking scaling policy."
+      }
+    }
+  },
+  "aws-native:applicationinsights:Application": {
+    "cfTypeName": "AWS::ApplicationInsights::Application",
+    "properties": {
+      "attachMissingPermission": {
+        "type": "boolean",
+        "description": "If set to true, the managed policies for SSM and CW will be attached to the instance roles if they are missing"
+      },
+      "autoConfigurationEnabled": {
+        "type": "boolean",
+        "description": "If set to true, application will be configured with recommended monitoring configuration."
+      },
+      "componentMonitoringSettings": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:applicationinsights:ApplicationComponentMonitoringSetting"
+        },
+        "description": "The monitoring settings of the components."
+      },
+      "customComponents": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:applicationinsights:ApplicationCustomComponent"
+        },
+        "description": "The custom grouped components."
+      },
+      "cweMonitorEnabled": {
+        "type": "boolean",
+        "description": "Indicates whether Application Insights can listen to CloudWatch events for the application resources."
+      },
+      "groupingType": {
+        "$ref": "#/types/aws-native:applicationinsights:ApplicationGroupingType",
+        "description": "The grouping type of the application"
+      },
+      "logPatternSets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:applicationinsights:ApplicationLogPatternSet"
+        },
+        "description": "The log pattern sets."
+      },
+      "opsCenterEnabled": {
+        "type": "boolean",
+        "description": "When set to true, creates opsItems for any problems detected on an application."
+      },
+      "opsItemSnsTopicArn": {
+        "type": "string",
+        "description": "The SNS topic provided to Application Insights that is associated to the created opsItem."
+      },
+      "resourceGroupName": {
+        "type": "string",
+        "description": "The name of the resource group."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags of Application Insights application."
+      }
+    }
+  },
+  "aws-native:appstream:ApplicationEntitlementAssociation": {
+    "cfTypeName": "AWS::AppStream::ApplicationEntitlementAssociation",
+    "properties": {
+      "applicationIdentifier": {
+        "type": "string"
+      },
+      "entitlementName": {
+        "type": "string"
+      },
+      "stackName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:appstream:ApplicationFleetAssociation": {
+    "cfTypeName": "AWS::AppStream::ApplicationFleetAssociation",
+    "properties": {
+      "applicationArn": {
+        "type": "string"
+      },
+      "fleetName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:appstream:DirectoryConfig": {
+    "cfTypeName": "AWS::AppStream::DirectoryConfig",
+    "properties": {
+      "certificateBasedAuthProperties": {
+        "$ref": "#/types/aws-native:appstream:DirectoryConfigCertificateBasedAuthProperties"
+      },
+      "directoryName": {
+        "type": "string"
+      },
+      "organizationalUnitDistinguishedNames": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "serviceAccountCredentials": {
+        "$ref": "#/types/aws-native:appstream:DirectoryConfigServiceAccountCredentials"
+      }
+    }
+  },
+  "aws-native:appsync:DomainName": {
+    "cfTypeName": "AWS::AppSync::DomainName",
+    "properties": {
+      "certificateArn": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "domainName": {
+        "type": "string",
+        "language": {
+          "csharp": {
+            "name": "DomainNameValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:appsync:DomainNameApiAssociation": {
+    "cfTypeName": "AWS::AppSync::DomainNameApiAssociation",
+    "properties": {
+      "apiId": {
+        "type": "string"
+      },
+      "domainName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:appsync:Resolver": {
+    "cfTypeName": "AWS::AppSync::Resolver",
+    "properties": {
+      "apiId": {
+        "type": "string",
+        "description": "The APSYlong GraphQL API to which you want to attach this resolver."
+      },
+      "cachingConfig": {
+        "$ref": "#/types/aws-native:appsync:ResolverCachingConfig",
+        "description": "The caching configuration for the resolver."
+      },
+      "code": {
+        "type": "string",
+        "description": "The ``resolver`` code that contains the request and response functions. When code is used, the ``runtime`` is required. The runtime value must be ``APPSYNC_JS``."
+      },
+      "codeS3Location": {
+        "type": "string",
+        "description": "The Amazon S3 endpoint."
+      },
+      "dataSourceName": {
+        "type": "string",
+        "description": "The resolver data source name."
+      },
+      "fieldName": {
+        "type": "string",
+        "description": "The GraphQL field on a type that invokes the resolver."
+      },
+      "kind": {
+        "type": "string",
+        "description": "The resolver type.\n  +   *UNIT*: A UNIT resolver type. A UNIT resolver is the default resolver type. You can use a UNIT resolver to run a GraphQL query against a single data source.\n  +   *PIPELINE*: A PIPELINE resolver type. You can use a PIPELINE resolver to invoke a series of ``Function`` objects in a serial manner. You can use a pipeline resolver to run a GraphQL query against multiple data sources."
+      },
+      "maxBatchSize": {
+        "type": "integer",
+        "description": "The maximum number of resolver request inputs that will be sent to a single LAMlong function in a ``BatchInvoke`` operation."
+      },
+      "metricsConfig": {
+        "$ref": "#/types/aws-native:appsync:ResolverMetricsConfig"
+      },
+      "pipelineConfig": {
+        "$ref": "#/types/aws-native:appsync:ResolverPipelineConfig",
+        "description": "Functions linked with the pipeline resolver."
+      },
+      "requestMappingTemplate": {
+        "type": "string",
+        "description": "The request mapping template.\n Request mapping templates are optional when using a Lambda data source. For all other data sources, a request mapping template is required."
+      },
+      "requestMappingTemplateS3Location": {
+        "type": "string",
+        "description": "The location of a request mapping template in an S3 bucket. Use this if you want to provision with a template file in S3 rather than embedding it in your CFNshort template."
+      },
+      "responseMappingTemplate": {
+        "type": "string",
+        "description": "The response mapping template."
+      },
+      "responseMappingTemplateS3Location": {
+        "type": "string",
+        "description": "The location of a response mapping template in an S3 bucket. Use this if you want to provision with a template file in S3 rather than embedding it in your CFNshort template."
+      },
+      "runtime": {
+        "$ref": "#/types/aws-native:appsync:ResolverAppSyncRuntime",
+        "description": "Describes a runtime used by an APSYlong resolver or APSYlong function. Specifies the name and version of the runtime to use. Note that if a runtime is specified, code must also be specified."
+      },
+      "syncConfig": {
+        "$ref": "#/types/aws-native:appsync:ResolverSyncConfig",
+        "description": "The ``SyncConfig`` for a resolver attached to a versioned data source."
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The GraphQL type that invokes this resolver."
+      }
+    }
+  },
+  "aws-native:appsync:SourceApiAssociation": {
+    "cfTypeName": "AWS::AppSync::SourceApiAssociation",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "Description of the SourceApiAssociation."
+      },
+      "mergedApiIdentifier": {
+        "type": "string",
+        "description": "Identifier of the Merged GraphQLApi to associate. It could be either GraphQLApi ApiId or ARN"
+      },
+      "sourceApiAssociationConfig": {
+        "$ref": "#/types/aws-native:appsync:SourceApiAssociationConfig",
+        "description": "Customized configuration for SourceApiAssociation."
+      },
+      "sourceApiIdentifier": {
+        "type": "string",
+        "description": "Identifier of the Source GraphQLApi to associate. It could be either GraphQLApi ApiId or ARN"
+      }
+    }
+  },
+  "aws-native:aps:Workspace": {
+    "cfTypeName": "AWS::APS::Workspace",
+    "properties": {
+      "alertManagerDefinition": {
+        "type": "string",
+        "description": "The AMP Workspace alert manager definition data"
+      },
+      "alias": {
+        "type": "string",
+        "description": "AMP Workspace alias."
+      },
+      "kmsKeyArn": {
+        "type": "string",
+        "description": "KMS Key ARN used to encrypt and decrypt AMP workspace data."
+      },
+      "loggingConfiguration": {
+        "$ref": "#/types/aws-native:aps:WorkspaceLoggingConfiguration"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:arczonalshift:ZonalAutoshiftConfiguration": {
+    "cfTypeName": "AWS::ARCZonalShift::ZonalAutoshiftConfiguration",
+    "properties": {
+      "practiceRunConfiguration": {
+        "$ref": "#/types/aws-native:arczonalshift:ZonalAutoshiftConfigurationPracticeRunConfiguration"
+      },
+      "resourceIdentifier": {
+        "type": "string"
+      },
+      "zonalAutoshiftStatus": {
+        "$ref": "#/types/aws-native:arczonalshift:ZonalAutoshiftConfigurationZonalAutoshiftStatus"
+      }
+    }
+  },
+  "aws-native:athena:PreparedStatement": {
+    "cfTypeName": "AWS::Athena::PreparedStatement",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the prepared statement."
+      },
+      "queryStatement": {
+        "type": "string",
+        "description": "The query string for the prepared statement."
+      },
+      "statementName": {
+        "type": "string",
+        "description": "The name of the prepared statement."
+      },
+      "workGroup": {
+        "type": "string",
+        "description": "The name of the workgroup to which the prepared statement belongs."
+      }
+    }
+  },
+  "aws-native:autoscaling:ScalingPolicy": {
+    "cfTypeName": "AWS::AutoScaling::ScalingPolicy",
+    "properties": {
+      "adjustmentType": {
+        "type": "string",
+        "description": "Specifies how the scaling adjustment is interpreted. The valid values are ChangeInCapacity, ExactCapacity, and PercentChangeInCapacity."
+      },
+      "autoScalingGroupName": {
+        "type": "string",
+        "description": "The name of the Auto Scaling group."
+      },
+      "cooldown": {
+        "type": "string",
+        "description": "The duration of the policy's cooldown period, in seconds. When a cooldown period is specified here, it overrides the default cooldown period defined for the Auto Scaling group."
+      },
+      "estimatedInstanceWarmup": {
+        "type": "integer",
+        "description": "The estimated time, in seconds, until a newly launched instance can contribute to the CloudWatch metrics. If not provided, the default is to use the value from the default cooldown period for the Auto Scaling group. Valid only if the policy type is TargetTrackingScaling or StepScaling."
+      },
+      "metricAggregationType": {
+        "type": "string",
+        "description": "The aggregation type for the CloudWatch metrics. The valid values are Minimum, Maximum, and Average. If the aggregation type is null, the value is treated as Average. Valid only if the policy type is StepScaling."
+      },
+      "minAdjustmentMagnitude": {
+        "type": "integer",
+        "description": "The minimum value to scale by when the adjustment type is PercentChangeInCapacity. For example, suppose that you create a step scaling policy to scale out an Auto Scaling group by 25 percent and you specify a MinAdjustmentMagnitude of 2. If the group has 4 instances and the scaling policy is performed, 25 percent of 4 is 1. However, because you specified a MinAdjustmentMagnitude of 2, Amazon EC2 Auto Scaling scales out the group by 2 instances."
+      },
+      "policyType": {
+        "type": "string",
+        "description": "One of the following policy types: TargetTrackingScaling, StepScaling, SimpleScaling (default), PredictiveScaling"
+      },
+      "predictiveScalingConfiguration": {
+        "$ref": "#/types/aws-native:autoscaling:ScalingPolicyPredictiveScalingConfiguration",
+        "description": "A predictive scaling policy. Includes support for predefined metrics only."
+      },
+      "scalingAdjustment": {
+        "type": "integer",
+        "description": "The amount by which to scale, based on the specified adjustment type. A positive value adds to the current capacity while a negative number removes from the current capacity. For exact capacity, you must specify a positive value. Required if the policy type is SimpleScaling. (Not used with any other policy type.)"
+      },
+      "stepAdjustments": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:autoscaling:ScalingPolicyStepAdjustment"
+        },
+        "description": "A set of adjustments that enable you to scale based on the size of the alarm breach. Required if the policy type is StepScaling. (Not used with any other policy type.)"
+      },
+      "targetTrackingConfiguration": {
+        "$ref": "#/types/aws-native:autoscaling:ScalingPolicyTargetTrackingConfiguration",
+        "description": "A target tracking scaling policy. Includes support for predefined or customized metrics."
+      }
+    }
+  },
+  "aws-native:autoscaling:ScheduledAction": {
+    "cfTypeName": "AWS::AutoScaling::ScheduledAction",
+    "properties": {
+      "autoScalingGroupName": {
+        "type": "string",
+        "description": "The name of the Auto Scaling group."
+      },
+      "desiredCapacity": {
+        "type": "integer",
+        "description": "The desired capacity is the initial capacity of the Auto Scaling group after the scheduled action runs and the capacity it attempts to maintain."
+      },
+      "endTime": {
+        "type": "string",
+        "description": "The latest scheduled start time to return. If scheduled action names are provided, this parameter is ignored."
+      },
+      "maxSize": {
+        "type": "integer",
+        "description": "The minimum size of the Auto Scaling group."
+      },
+      "minSize": {
+        "type": "integer",
+        "description": "The minimum size of the Auto Scaling group."
+      },
+      "recurrence": {
+        "type": "string",
+        "description": "The recurring schedule for the action, in Unix cron syntax format. When StartTime and EndTime are specified with Recurrence , they form the boundaries of when the recurring action starts and stops."
+      },
+      "startTime": {
+        "type": "string",
+        "description": "The earliest scheduled start time to return. If scheduled action names are provided, this parameter is ignored."
+      },
+      "timeZone": {
+        "type": "string",
+        "description": "The time zone for the cron expression."
+      }
+    }
+  },
+  "aws-native:autoscaling:WarmPool": {
+    "cfTypeName": "AWS::AutoScaling::WarmPool",
+    "properties": {
+      "autoScalingGroupName": {
+        "type": "string"
+      },
+      "instanceReusePolicy": {
+        "$ref": "#/types/aws-native:autoscaling:WarmPoolInstanceReusePolicy"
+      },
+      "maxGroupPreparedCapacity": {
+        "type": "integer"
+      },
+      "minSize": {
+        "type": "integer"
+      },
+      "poolState": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:backup:BackupPlan": {
+    "cfTypeName": "AWS::Backup::BackupPlan",
+    "properties": {
+      "backupPlan": {
+        "$ref": "#/types/aws-native:backup:BackupPlanResourceType",
+        "language": {
+          "csharp": {
+            "name": "BackupPlanValue"
+          }
+        }
+      },
+      "backupPlanTags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:backup:BackupSelection": {
+    "cfTypeName": "AWS::Backup::BackupSelection",
+    "properties": {
+      "backupPlanId": {
+        "type": "string"
+      },
+      "backupSelection": {
+        "$ref": "#/types/aws-native:backup:BackupSelectionResourceType",
+        "language": {
+          "csharp": {
+            "name": "BackupSelectionValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:budgets:BudgetsAction": {
+    "cfTypeName": "AWS::Budgets::BudgetsAction",
+    "properties": {
+      "actionThreshold": {
+        "$ref": "#/types/aws-native:budgets:BudgetsActionActionThreshold"
+      },
+      "actionType": {
+        "$ref": "#/types/aws-native:budgets:BudgetsActionActionType"
+      },
+      "approvalModel": {
+        "$ref": "#/types/aws-native:budgets:BudgetsActionApprovalModel"
+      },
+      "budgetName": {
+        "type": "string"
+      },
+      "definition": {
+        "$ref": "#/types/aws-native:budgets:BudgetsActionDefinition"
+      },
+      "executionRoleArn": {
+        "type": "string"
+      },
+      "notificationType": {
+        "$ref": "#/types/aws-native:budgets:BudgetsActionNotificationType"
+      },
+      "subscribers": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:budgets:BudgetsActionSubscriber"
+        }
+      }
+    }
+  },
+  "aws-native:ce:AnomalyMonitor": {
+    "cfTypeName": "AWS::CE::AnomalyMonitor",
+    "properties": {
+      "monitorDimension": {
+        "$ref": "#/types/aws-native:ce:AnomalyMonitorMonitorDimension",
+        "description": "The dimensions to evaluate"
+      },
+      "monitorName": {
+        "type": "string",
+        "description": "The name of the monitor."
+      },
+      "monitorSpecification": {
+        "type": "string"
+      },
+      "monitorType": {
+        "$ref": "#/types/aws-native:ce:AnomalyMonitorMonitorType"
+      },
+      "resourceTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ce:AnomalyMonitorResourceTag"
+        },
+        "description": "Tags to assign to monitor."
+      }
+    }
+  },
+  "aws-native:ce:AnomalySubscription": {
+    "cfTypeName": "AWS::CE::AnomalySubscription",
+    "properties": {
+      "frequency": {
+        "$ref": "#/types/aws-native:ce:AnomalySubscriptionFrequency",
+        "description": "The frequency at which anomaly reports are sent over email. "
+      },
+      "monitorArnList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of cost anomaly monitors."
+      },
+      "resourceTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ce:AnomalySubscriptionResourceTag"
+        },
+        "description": "Tags to assign to subscription."
+      },
+      "subscribers": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ce:AnomalySubscriptionSubscriber"
+        },
+        "description": "A list of subscriber"
+      },
+      "subscriptionName": {
+        "type": "string",
+        "description": "The name of the subscription."
+      },
+      "threshold": {
+        "type": "number",
+        "description": "The dollar value that triggers a notification if the threshold is exceeded. "
+      },
+      "thresholdExpression": {
+        "type": "string",
+        "description": "An Expression object in JSON String format used to specify the anomalies that you want to generate alerts for."
+      }
+    }
+  },
+  "aws-native:certificatemanager:Account": {
+    "cfTypeName": "AWS::CertificateManager::Account",
+    "properties": {
+      "expiryEventsConfiguration": {
+        "$ref": "#/types/aws-native:certificatemanager:AccountExpiryEventsConfiguration"
+      }
+    }
+  },
+  "aws-native:chatbot:MicrosoftTeamsChannelConfiguration": {
+    "cfTypeName": "AWS::Chatbot::MicrosoftTeamsChannelConfiguration",
+    "properties": {
+      "configurationName": {
+        "type": "string",
+        "description": "The name of the configuration"
+      },
+      "guardrailPolicies": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set."
+      },
+      "iamRoleArn": {
+        "type": "string",
+        "description": "The ARN of the IAM role that defines the permissions for AWS Chatbot"
+      },
+      "loggingLevel": {
+        "type": "string",
+        "description": "Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs"
+      },
+      "snsTopicArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications."
+      },
+      "teamId": {
+        "type": "string",
+        "description": "The id of the Microsoft Teams team"
+      },
+      "teamsChannelId": {
+        "type": "string",
+        "description": "The id of the Microsoft Teams channel"
+      },
+      "teamsTenantId": {
+        "type": "string",
+        "description": "The id of the Microsoft Teams tenant"
+      },
+      "userRoleRequired": {
+        "type": "boolean",
+        "description": "Enables use of a user role requirement in your chat configuration"
+      }
+    }
+  },
+  "aws-native:chatbot:SlackChannelConfiguration": {
+    "cfTypeName": "AWS::Chatbot::SlackChannelConfiguration",
+    "properties": {
+      "configurationName": {
+        "type": "string",
+        "description": "The name of the configuration"
+      },
+      "guardrailPolicies": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set."
+      },
+      "iamRoleArn": {
+        "type": "string",
+        "description": "The ARN of the IAM role that defines the permissions for AWS Chatbot"
+      },
+      "loggingLevel": {
+        "type": "string",
+        "description": "Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs"
+      },
+      "slackChannelId": {
+        "type": "string",
+        "description": "The id of the Slack channel"
+      },
+      "slackWorkspaceId": {
+        "type": "string",
+        "description": "The id of the Slack workspace"
+      },
+      "snsTopicArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications."
+      },
+      "userRoleRequired": {
+        "type": "boolean",
+        "description": "Enables use of a user role requirement in your chat configuration"
+      }
+    }
+  },
+  "aws-native:cleanrooms:Membership": {
+    "cfTypeName": "AWS::CleanRooms::Membership",
+    "properties": {
+      "collaborationIdentifier": {
+        "type": "string"
+      },
+      "defaultResultConfiguration": {
+        "$ref": "#/types/aws-native:cleanrooms:MembershipProtectedQueryResultConfiguration"
+      },
+      "paymentConfiguration": {
+        "$ref": "#/types/aws-native:cleanrooms:MembershipPaymentConfiguration"
+      },
+      "queryLogStatus": {
+        "$ref": "#/types/aws-native:cleanrooms:MembershipQueryLogStatus"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An arbitrary set of tags (key-value pairs) for this cleanrooms membership."
+      }
+    }
+  },
+  "aws-native:cloudformation:HookDefaultVersion": {
+    "cfTypeName": "AWS::CloudFormation::HookDefaultVersion",
+    "properties": {
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      },
+      "typeVersionArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the type version."
+      },
+      "versionId": {
+        "type": "string",
+        "description": "The ID of an existing version of the hook to set as the default."
+      }
+    }
+  },
+  "aws-native:cloudformation:HookTypeConfig": {
+    "cfTypeName": "AWS::CloudFormation::HookTypeConfig",
+    "properties": {
+      "configuration": {
+        "type": "string",
+        "description": "The configuration data for the extension, in this account and region."
+      },
+      "configurationAlias": {
+        "$ref": "#/types/aws-native:cloudformation:HookTypeConfigConfigurationAlias",
+        "description": "An alias by which to refer to this extension configuration data."
+      },
+      "typeArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the type without version number."
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      }
+    }
+  },
+  "aws-native:cloudformation:HookVersion": {
+    "cfTypeName": "AWS::CloudFormation::HookVersion",
+    "properties": {
+      "executionRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM execution role to use to register the type. If your resource type calls AWS APIs in any of its handlers, you must create an IAM execution role that includes the necessary permissions to call those AWS APIs, and provision that execution role in your account. CloudFormation then assumes that execution role to provide your resource type with the appropriate credentials."
+      },
+      "loggingConfig": {
+        "$ref": "#/types/aws-native:cloudformation:HookVersionLoggingConfig",
+        "description": "Specifies logging configuration information for a type."
+      },
+      "schemaHandlerPackage": {
+        "type": "string",
+        "description": "A url to the S3 bucket containing the schema handler package that contains the schema, event handlers, and associated files for the type you want to register.\n\nFor information on generating a schema handler package for the type you want to register, see submit in the CloudFormation CLI User Guide."
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      }
+    }
+  },
+  "aws-native:cloudformation:ModuleDefaultVersion": {
+    "cfTypeName": "AWS::CloudFormation::ModuleDefaultVersion",
+    "properties": {
+      "arn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the module version to set as the default version."
+      },
+      "moduleName": {
+        "type": "string",
+        "description": "The name of a module existing in the registry."
+      },
+      "versionId": {
+        "type": "string",
+        "description": "The ID of an existing version of the named module to set as the default."
+      }
+    }
+  },
+  "aws-native:cloudformation:ModuleVersion": {
+    "cfTypeName": "AWS::CloudFormation::ModuleVersion",
+    "properties": {
+      "moduleName": {
+        "type": "string",
+        "description": "The name of the module being registered.\n\nRecommended module naming pattern: company_or_organization::service::type::MODULE."
+      },
+      "modulePackage": {
+        "type": "string",
+        "description": "The url to the S3 bucket containing the schema and template fragment for the module you want to register."
+      }
+    }
+  },
+  "aws-native:cloudformation:PublicTypeVersion": {
+    "cfTypeName": "AWS::CloudFormation::PublicTypeVersion",
+    "properties": {
+      "arn": {
+        "type": "string",
+        "description": "The Amazon Resource Number (ARN) of the extension."
+      },
+      "logDeliveryBucket": {
+        "type": "string",
+        "description": "A url to the S3 bucket where logs for the testType run will be available"
+      },
+      "publicVersionNumber": {
+        "type": "string",
+        "description": "The version number of a public third-party extension"
+      },
+      "type": {
+        "$ref": "#/types/aws-native:cloudformation:PublicTypeVersionType",
+        "description": "The kind of extension"
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      }
+    }
+  },
+  "aws-native:cloudformation:Publisher": {
+    "cfTypeName": "AWS::CloudFormation::Publisher",
+    "properties": {
+      "acceptTermsAndConditions": {
+        "type": "boolean",
+        "description": "Whether you accept the terms and conditions for publishing extensions in the CloudFormation registry. You must accept the terms and conditions in order to publish public extensions to the CloudFormation registry. The terms and conditions can be found at https://cloudformation-registry-documents.s3.amazonaws.com/Terms_and_Conditions_for_AWS_CloudFormation_Registry_Publishers.pdf"
+      },
+      "connectionArn": {
+        "type": "string",
+        "description": "If you are using a Bitbucket or GitHub account for identity verification, the Amazon Resource Name (ARN) for your connection to that account."
+      }
+    }
+  },
+  "aws-native:cloudformation:ResourceDefaultVersion": {
+    "cfTypeName": "AWS::CloudFormation::ResourceDefaultVersion",
+    "properties": {
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      },
+      "typeVersionArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the type version."
+      },
+      "versionId": {
+        "type": "string",
+        "description": "The ID of an existing version of the resource to set as the default."
+      }
+    }
+  },
+  "aws-native:cloudformation:ResourceVersion": {
+    "cfTypeName": "AWS::CloudFormation::ResourceVersion",
+    "properties": {
+      "executionRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM execution role to use to register the type. If your resource type calls AWS APIs in any of its handlers, you must create an IAM execution role that includes the necessary permissions to call those AWS APIs, and provision that execution role in your account. CloudFormation then assumes that execution role to provide your resource type with the appropriate credentials."
+      },
+      "loggingConfig": {
+        "$ref": "#/types/aws-native:cloudformation:ResourceVersionLoggingConfig",
+        "description": "Specifies logging configuration information for a type."
+      },
+      "schemaHandlerPackage": {
+        "type": "string",
+        "description": "A url to the S3 bucket containing the schema handler package that contains the schema, event handlers, and associated files for the type you want to register.\n\nFor information on generating a schema handler package for the type you want to register, see submit in the CloudFormation CLI User Guide."
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      }
+    }
+  },
+  "aws-native:cloudformation:TypeActivation": {
+    "cfTypeName": "AWS::CloudFormation::TypeActivation",
+    "properties": {
+      "autoUpdate": {
+        "type": "boolean",
+        "description": "Whether to automatically update the extension in this account and region when a new minor version is published by the extension publisher. Major versions released by the publisher must be manually updated."
+      },
+      "executionRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM execution role to use to register the type. If your resource type calls AWS APIs in any of its handlers, you must create an IAM execution role that includes the necessary permissions to call those AWS APIs, and provision that execution role in your account. CloudFormation then assumes that execution role to provide your resource type with the appropriate credentials."
+      },
+      "loggingConfig": {
+        "$ref": "#/types/aws-native:cloudformation:TypeActivationLoggingConfig",
+        "description": "Specifies logging configuration information for a type."
+      },
+      "majorVersion": {
+        "type": "string",
+        "description": "The Major Version of the type you want to enable"
+      },
+      "publicTypeArn": {
+        "type": "string",
+        "description": "The Amazon Resource Number (ARN) assigned to the public extension upon publication"
+      },
+      "publisherId": {
+        "type": "string",
+        "description": "The publisher id assigned by CloudFormation for publishing in this region."
+      },
+      "type": {
+        "$ref": "#/types/aws-native:cloudformation:TypeActivationType",
+        "description": "The kind of extension"
+      },
+      "typeName": {
+        "type": "string",
+        "description": "The name of the type being registered.\n\nWe recommend that type names adhere to the following pattern: company_or_organization::service::type."
+      },
+      "typeNameAlias": {
+        "type": "string",
+        "description": "An alias to assign to the public extension in this account and region. If you specify an alias for the extension, you must then use the alias to refer to the extension in your templates."
+      },
+      "versionBump": {
+        "$ref": "#/types/aws-native:cloudformation:TypeActivationVersionBump",
+        "description": "Manually updates a previously-enabled type to a new major or minor version, if available. You can also use this parameter to update the value of AutoUpdateEnabled"
+      }
+    }
+  },
+  "aws-native:cloudfront:CachePolicy": {
+    "cfTypeName": "AWS::CloudFront::CachePolicy",
+    "properties": {
+      "cachePolicyConfig": {
+        "$ref": "#/types/aws-native:cloudfront:CachePolicyConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:CloudFrontOriginAccessIdentity": {
+    "cfTypeName": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    "properties": {
+      "cloudFrontOriginAccessIdentityConfig": {
+        "$ref": "#/types/aws-native:cloudfront:CloudFrontOriginAccessIdentityConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:ContinuousDeploymentPolicy": {
+    "cfTypeName": "AWS::CloudFront::ContinuousDeploymentPolicy",
+    "properties": {
+      "continuousDeploymentPolicyConfig": {
+        "$ref": "#/types/aws-native:cloudfront:ContinuousDeploymentPolicyConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:Distribution": {
+    "cfTypeName": "AWS::CloudFront::Distribution",
+    "properties": {
+      "distributionConfig": {
+        "$ref": "#/types/aws-native:cloudfront:DistributionConfig",
+        "description": "The distribution's configuration."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A complex type that contains zero or more ``Tag`` elements."
+      }
+    }
+  },
+  "aws-native:cloudfront:KeyGroup": {
+    "cfTypeName": "AWS::CloudFront::KeyGroup",
+    "properties": {
+      "keyGroupConfig": {
+        "$ref": "#/types/aws-native:cloudfront:KeyGroupConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:MonitoringSubscription": {
+    "cfTypeName": "AWS::CloudFront::MonitoringSubscription",
+    "properties": {
+      "distributionId": {
+        "type": "string"
+      },
+      "monitoringSubscription": {
+        "$ref": "#/types/aws-native:cloudfront:MonitoringSubscription",
+        "language": {
+          "csharp": {
+            "name": "MonitoringSubscriptionValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:cloudfront:OriginAccessControl": {
+    "cfTypeName": "AWS::CloudFront::OriginAccessControl",
+    "properties": {
+      "originAccessControlConfig": {
+        "$ref": "#/types/aws-native:cloudfront:OriginAccessControlConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:OriginRequestPolicy": {
+    "cfTypeName": "AWS::CloudFront::OriginRequestPolicy",
+    "properties": {
+      "originRequestPolicyConfig": {
+        "$ref": "#/types/aws-native:cloudfront:OriginRequestPolicyConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:PublicKey": {
+    "cfTypeName": "AWS::CloudFront::PublicKey",
+    "properties": {
+      "publicKeyConfig": {
+        "$ref": "#/types/aws-native:cloudfront:PublicKeyConfig"
+      }
+    }
+  },
+  "aws-native:cloudfront:ResponseHeadersPolicy": {
+    "cfTypeName": "AWS::CloudFront::ResponseHeadersPolicy",
+    "properties": {
+      "responseHeadersPolicyConfig": {
+        "$ref": "#/types/aws-native:cloudfront:ResponseHeadersPolicyConfig"
+      }
+    }
+  },
+  "aws-native:cloudtrail:ResourcePolicy": {
+    "cfTypeName": "AWS::CloudTrail::ResourcePolicy",
+    "properties": {
+      "resourceArn": {
+        "type": "string",
+        "description": "The ARN of the AWS CloudTrail resource to which the policy applies."
+      },
+      "resourcePolicy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified resource. In IAM, you must provide policy documents in JSON format. However, in CloudFormation you can provide the policy in JSON or YAML format because CloudFormation converts YAML to JSON before submitting it to IAM.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::CloudTrail::ResourcePolicy` for more information about the expected schema for this property.",
+        "language": {
+          "csharp": {
+            "name": "ResourcePolicyValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:cloudwatch:CompositeAlarm": {
+    "cfTypeName": "AWS::CloudWatch::CompositeAlarm",
+    "properties": {
+      "actionsEnabled": {
+        "type": "boolean",
+        "description": "Indicates whether actions should be executed during any changes to the alarm state. The default is TRUE."
+      },
+      "actionsSuppressor": {
+        "type": "string",
+        "description": "Actions will be suppressed if the suppressor alarm is in the ALARM state. ActionsSuppressor can be an AlarmName or an Amazon Resource Name (ARN) from an existing alarm. "
+      },
+      "actionsSuppressorExtensionPeriod": {
+        "type": "integer",
+        "description": "Actions will be suppressed if WaitPeriod is active. The length of time that actions are suppressed is in seconds."
+      },
+      "actionsSuppressorWaitPeriod": {
+        "type": "integer",
+        "description": "Actions will be suppressed if ExtensionPeriod is active. The length of time that actions are suppressed is in seconds."
+      },
+      "alarmActions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Specify each action as an Amazon Resource Name (ARN)."
+      },
+      "alarmDescription": {
+        "type": "string",
+        "description": "The description of the alarm"
+      },
+      "alarmName": {
+        "type": "string",
+        "description": "The name of the Composite Alarm"
+      },
+      "alarmRule": {
+        "type": "string",
+        "description": "Expression which aggregates the state of other Alarms (Metric or Composite Alarms)"
+      },
+      "insufficientDataActions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The actions to execute when this alarm transitions to the INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+      },
+      "okActions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The actions to execute when this alarm transitions to the OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
+      }
+    }
+  },
+  "aws-native:codepipeline:CustomActionType": {
+    "cfTypeName": "AWS::CodePipeline::CustomActionType",
+    "properties": {
+      "category": {
+        "type": "string",
+        "description": "The category of the custom action, such as a build action or a test action."
+      },
+      "configurationProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:codepipeline:CustomActionTypeConfigurationProperties"
+        },
+        "description": "The configuration properties for the custom action."
+      },
+      "inputArtifactDetails": {
+        "$ref": "#/types/aws-native:codepipeline:CustomActionTypeArtifactDetails",
+        "description": "The details of the input artifact for the action, such as its commit ID."
+      },
+      "outputArtifactDetails": {
+        "$ref": "#/types/aws-native:codepipeline:CustomActionTypeArtifactDetails",
+        "description": "The details of the output artifact of the action, such as its commit ID."
+      },
+      "provider": {
+        "type": "string",
+        "description": "The provider of the service used in the custom action, such as AWS CodeDeploy."
+      },
+      "settings": {
+        "$ref": "#/types/aws-native:codepipeline:CustomActionTypeSettings",
+        "description": "URLs that provide users information about this custom action."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the custom action."
+      },
+      "version": {
+        "type": "string",
+        "description": "The version identifier of the custom action."
+      }
+    }
+  },
+  "aws-native:codestarconnections:RepositoryLink": {
+    "cfTypeName": "AWS::CodeStarConnections::RepositoryLink",
+    "properties": {
+      "connectionArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the CodeStarConnection. The ARN is used as the connection reference when the connection is shared between AWS services."
+      },
+      "encryptionKeyArn": {
+        "type": "string",
+        "description": "The ARN of the KMS key that the customer can optionally specify to use to encrypt RepositoryLink properties. If not specified, a default key will be used."
+      },
+      "ownerId": {
+        "type": "string",
+        "description": "the ID of the entity that owns the repository."
+      },
+      "repositoryName": {
+        "type": "string",
+        "description": "The repository for which the link is being created."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Specifies the tags applied to a RepositoryLink."
+      }
+    }
+  },
+  "aws-native:codestarconnections:SyncConfiguration": {
+    "cfTypeName": "AWS::CodeStarConnections::SyncConfiguration",
+    "properties": {
+      "branch": {
+        "type": "string",
+        "description": "The name of the branch of the repository from which resources are to be synchronized,"
+      },
+      "configFile": {
+        "type": "string",
+        "description": "The source provider repository path of the sync configuration file of the respective SyncType."
+      },
+      "repositoryLinkId": {
+        "type": "string",
+        "description": "A UUID that uniquely identifies the RepositoryLink that the SyncConfig is associated with."
+      },
+      "resourceName": {
+        "type": "string",
+        "description": "The name of the resource that is being synchronized to the repository."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The IAM Role that allows AWS to update CloudFormation stacks based on content in the specified repository."
+      },
+      "syncType": {
+        "type": "string",
+        "description": "The type of resource synchronization service that is to be configured, for example, CFN_STACK_SYNC."
+      }
+    }
+  },
+  "aws-native:cognito:IdentityPoolPrincipalTag": {
+    "cfTypeName": "AWS::Cognito::IdentityPoolPrincipalTag",
+    "properties": {
+      "identityPoolId": {
+        "type": "string"
+      },
+      "identityProviderName": {
+        "type": "string"
+      },
+      "principalTags": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::IdentityPoolPrincipalTag` for more information about the expected schema for this property."
+      },
+      "useDefaults": {
+        "type": "boolean"
+      }
+    }
+  },
+  "aws-native:cognito:IdentityPoolRoleAttachment": {
+    "cfTypeName": "AWS::Cognito::IdentityPoolRoleAttachment",
+    "properties": {
+      "identityPoolId": {
+        "type": "string"
+      },
+      "roleMappings": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:cognito:IdentityPoolRoleAttachmentRoleMapping"
+        }
+      },
+      "roles": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:cognito:LogDeliveryConfiguration": {
+    "cfTypeName": "AWS::Cognito::LogDeliveryConfiguration",
+    "properties": {
+      "logConfigurations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:cognito:LogDeliveryConfigurationLogConfiguration"
+        }
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolClient": {
+    "cfTypeName": "AWS::Cognito::UserPoolClient",
+    "properties": {
+      "accessTokenValidity": {
+        "type": "integer"
+      },
+      "allowedOAuthFlows": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "allowedOAuthFlowsUserPoolClient": {
+        "type": "boolean"
+      },
+      "allowedOAuthScopes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "analyticsConfiguration": {
+        "$ref": "#/types/aws-native:cognito:UserPoolClientAnalyticsConfiguration"
+      },
+      "authSessionValidity": {
+        "type": "integer"
+      },
+      "callbackUrls": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "clientName": {
+        "type": "string"
+      },
+      "defaultRedirectUri": {
+        "type": "string"
+      },
+      "enablePropagateAdditionalUserContextData": {
+        "type": "boolean"
+      },
+      "enableTokenRevocation": {
+        "type": "boolean"
+      },
+      "explicitAuthFlows": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "generateSecret": {
+        "type": "boolean"
+      },
+      "idTokenValidity": {
+        "type": "integer"
+      },
+      "logoutUrls": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "preventUserExistenceErrors": {
+        "type": "string"
+      },
+      "readAttributes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "refreshTokenValidity": {
+        "type": "integer"
+      },
+      "supportedIdentityProviders": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tokenValidityUnits": {
+        "$ref": "#/types/aws-native:cognito:UserPoolClientTokenValidityUnits"
+      },
+      "userPoolId": {
+        "type": "string"
+      },
+      "writeAttributes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolDomain": {
+    "cfTypeName": "AWS::Cognito::UserPoolDomain",
+    "properties": {
+      "customDomainConfig": {
+        "$ref": "#/types/aws-native:cognito:UserPoolDomainCustomDomainConfigType"
+      },
+      "domain": {
+        "type": "string"
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolGroup": {
+    "cfTypeName": "AWS::Cognito::UserPoolGroup",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "groupName": {
+        "type": "string"
+      },
+      "precedence": {
+        "type": "integer"
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolIdentityProvider": {
+    "cfTypeName": "AWS::Cognito::UserPoolIdentityProvider",
+    "properties": {
+      "attributeMapping": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property."
+      },
+      "idpIdentifiers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "providerDetails": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property."
+      },
+      "providerName": {
+        "type": "string"
+      },
+      "providerType": {
+        "type": "string"
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolRiskConfigurationAttachment": {
+    "cfTypeName": "AWS::Cognito::UserPoolRiskConfigurationAttachment",
+    "properties": {
+      "accountTakeoverRiskConfiguration": {
+        "$ref": "#/types/aws-native:cognito:UserPoolRiskConfigurationAttachmentAccountTakeoverRiskConfigurationType"
+      },
+      "clientId": {
+        "type": "string"
+      },
+      "compromisedCredentialsRiskConfiguration": {
+        "$ref": "#/types/aws-native:cognito:UserPoolRiskConfigurationAttachmentCompromisedCredentialsRiskConfigurationType"
+      },
+      "riskExceptionConfiguration": {
+        "$ref": "#/types/aws-native:cognito:UserPoolRiskConfigurationAttachmentRiskExceptionConfigurationType"
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolUiCustomizationAttachment": {
+    "cfTypeName": "AWS::Cognito::UserPoolUICustomizationAttachment",
+    "properties": {
+      "clientId": {
+        "type": "string"
+      },
+      "css": {
+        "type": "string"
+      },
+      "userPoolId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolUser": {
+    "cfTypeName": "AWS::Cognito::UserPoolUser",
+    "properties": {
+      "clientMetadata": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "desiredDeliveryMediums": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "forceAliasCreation": {
+        "type": "boolean"
+      },
+      "messageAction": {
+        "type": "string"
+      },
+      "userAttributes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:cognito:UserPoolUserAttributeType"
+        }
+      },
+      "userPoolId": {
+        "type": "string"
+      },
+      "username": {
+        "type": "string"
+      },
+      "validationData": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:cognito:UserPoolUserAttributeType"
+        }
+      }
+    }
+  },
+  "aws-native:cognito:UserPoolUserToGroupAttachment": {
+    "cfTypeName": "AWS::Cognito::UserPoolUserToGroupAttachment",
+    "properties": {
+      "groupName": {
+        "type": "string"
+      },
+      "userPoolId": {
+        "type": "string"
+      },
+      "username": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:configuration:AggregationAuthorization": {
+    "cfTypeName": "AWS::Config::AggregationAuthorization",
+    "properties": {
+      "authorizedAccountId": {
+        "type": "string",
+        "description": "The 12-digit account ID of the account authorized to aggregate data."
+      },
+      "authorizedAwsRegion": {
+        "type": "string",
+        "description": "The region authorized to collect aggregated data."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the AggregationAuthorization."
+      }
+    }
+  },
+  "aws-native:configuration:StoredQuery": {
+    "cfTypeName": "AWS::Config::StoredQuery",
+    "properties": {
+      "queryDescription": {
+        "type": "string"
+      },
+      "queryExpression": {
+        "type": "string"
+      },
+      "queryName": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the stored query."
+      }
+    }
+  },
+  "aws-native:connect:ApprovedOrigin": {
+    "cfTypeName": "AWS::Connect::ApprovedOrigin",
+    "properties": {
+      "instanceId": {
+        "type": "string"
+      },
+      "origin": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:connect:EvaluationForm": {
+    "cfTypeName": "AWS::Connect::EvaluationForm",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the evaluation form."
+      },
+      "instanceArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the instance."
+      },
+      "items": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:connect:EvaluationFormBaseItem"
+        },
+        "description": "The list of evaluation form items."
+      },
+      "scoringStrategy": {
+        "$ref": "#/types/aws-native:connect:EvaluationFormScoringStrategy",
+        "description": "The scoring strategy."
+      },
+      "status": {
+        "$ref": "#/types/aws-native:connect:EvaluationFormStatus",
+        "description": "The status of the evaluation form."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "One or more tags."
+      },
+      "title": {
+        "type": "string",
+        "description": "The title of the evaluation form."
+      }
+    }
+  },
+  "aws-native:connect:Instance": {
+    "cfTypeName": "AWS::Connect::Instance",
+    "properties": {
+      "attributes": {
+        "$ref": "#/types/aws-native:connect:InstanceAttributes",
+        "description": "The attributes for the instance."
+      },
+      "directoryId": {
+        "type": "string",
+        "description": "Existing directoryId user wants to map to the new Connect instance."
+      },
+      "identityManagementType": {
+        "$ref": "#/types/aws-native:connect:InstanceIdentityManagementType",
+        "description": "Specifies the type of directory integration for new instance."
+      },
+      "instanceAlias": {
+        "type": "string",
+        "description": "Alias of the new directory created as part of new instance creation."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:connect:InstanceStorageConfig": {
+    "cfTypeName": "AWS::Connect::InstanceStorageConfig",
+    "properties": {
+      "instanceArn": {
+        "type": "string",
+        "description": "Connect Instance ID with which the storage config will be associated"
+      },
+      "kinesisFirehoseConfig": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigKinesisFirehoseConfig"
+      },
+      "kinesisStreamConfig": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigKinesisStreamConfig"
+      },
+      "kinesisVideoStreamConfig": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigKinesisVideoStreamConfig"
+      },
+      "resourceType": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigInstanceStorageResourceType"
+      },
+      "s3Config": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigS3Config"
+      },
+      "storageType": {
+        "$ref": "#/types/aws-native:connect:InstanceStorageConfigStorageType"
+      }
+    }
+  },
+  "aws-native:connect:IntegrationAssociation": {
+    "cfTypeName": "AWS::Connect::IntegrationAssociation",
+    "properties": {
+      "instanceId": {
+        "type": "string"
+      },
+      "integrationArn": {
+        "type": "string"
+      },
+      "integrationType": {
+        "$ref": "#/types/aws-native:connect:IntegrationAssociationIntegrationType"
+      }
+    }
+  },
+  "aws-native:connect:PhoneNumber": {
+    "cfTypeName": "AWS::Connect::PhoneNumber",
+    "properties": {
+      "countryCode": {
+        "type": "string",
+        "description": "The phone number country code."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the phone number."
+      },
+      "prefix": {
+        "type": "string",
+        "description": "The phone number prefix."
+      },
+      "sourcePhoneNumberArn": {
+        "type": "string",
+        "description": "The source phone number arn."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "One or more tags."
+      },
+      "targetArn": {
+        "type": "string",
+        "description": "The ARN of the target the phone number is claimed to."
+      },
+      "type": {
+        "type": "string",
+        "description": "The phone number type"
+      }
+    }
+  },
+  "aws-native:connect:SecurityKey": {
+    "cfTypeName": "AWS::Connect::SecurityKey",
+    "properties": {
+      "instanceId": {
+        "type": "string"
+      },
+      "key": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:connect:User": {
+    "cfTypeName": "AWS::Connect::User",
+    "properties": {
+      "directoryUserId": {
+        "type": "string",
+        "description": "The identifier of the user account in the directory used for identity management."
+      },
+      "hierarchyGroupArn": {
+        "type": "string",
+        "description": "The identifier of the hierarchy group for the user."
+      },
+      "identityInfo": {
+        "$ref": "#/types/aws-native:connect:UserIdentityInfo",
+        "description": "The information about the identity of the user."
+      },
+      "instanceArn": {
+        "type": "string",
+        "description": "The identifier of the Amazon Connect instance."
+      },
+      "password": {
+        "type": "string",
+        "description": "The password for the user account. A password is required if you are using Amazon Connect for identity management. Otherwise, it is an error to include a password."
+      },
+      "phoneConfig": {
+        "$ref": "#/types/aws-native:connect:UserPhoneConfig",
+        "description": "The phone settings for the user."
+      },
+      "routingProfileArn": {
+        "type": "string",
+        "description": "The identifier of the routing profile for the user."
+      },
+      "securityProfileArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "One or more security profile arns for the user"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "One or more tags."
+      },
+      "userProficiencies": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:connect:UserProficiency"
+        },
+        "description": "One or more predefined attributes assigned to a user, with a level that indicates how skilled they are."
+      },
+      "username": {
+        "type": "string",
+        "description": "The user name for the account."
+      }
+    }
+  },
+  "aws-native:connect:ViewVersion": {
+    "cfTypeName": "AWS::Connect::ViewVersion",
+    "properties": {
+      "versionDescription": {
+        "type": "string",
+        "description": "The description for the view version."
+      },
+      "viewArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the view for which a version is being created."
+      },
+      "viewContentSha256": {
+        "type": "string",
+        "description": "The view content hash to be checked."
+      }
+    }
+  },
+  "aws-native:controltower:EnabledBaseline": {
+    "cfTypeName": "AWS::ControlTower::EnabledBaseline",
+    "properties": {
+      "baselineIdentifier": {
+        "type": "string"
+      },
+      "baselineVersion": {
+        "type": "string"
+      },
+      "parameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:controltower:EnabledBaselineParameter"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "targetIdentifier": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:controltower:EnabledControl": {
+    "cfTypeName": "AWS::ControlTower::EnabledControl",
+    "properties": {
+      "controlIdentifier": {
+        "type": "string",
+        "description": "Arn of the control."
+      },
+      "parameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:controltower:EnabledControlParameter"
+        },
+        "description": "Parameters to configure the enabled control behavior."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A set of tags to assign to the enabled control."
+      },
+      "targetIdentifier": {
+        "type": "string",
+        "description": "Arn for Organizational unit to which the control needs to be applied"
+      }
+    }
+  },
+  "aws-native:controltower:LandingZone": {
+    "cfTypeName": "AWS::ControlTower::LandingZone",
+    "properties": {
+      "manifest": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ControlTower::LandingZone` for more information about the expected schema for this property."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "version": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:customerprofiles:CalculatedAttributeDefinition": {
+    "cfTypeName": "AWS::CustomerProfiles::CalculatedAttributeDefinition",
+    "properties": {
+      "attributeDetails": {
+        "$ref": "#/types/aws-native:customerprofiles:CalculatedAttributeDefinitionAttributeDetails"
+      },
+      "calculatedAttributeName": {
+        "type": "string"
+      },
+      "conditions": {
+        "$ref": "#/types/aws-native:customerprofiles:CalculatedAttributeDefinitionConditions"
+      },
+      "description": {
+        "type": "string"
+      },
+      "displayName": {
+        "type": "string"
+      },
+      "domainName": {
+        "type": "string"
+      },
+      "statistic": {
+        "$ref": "#/types/aws-native:customerprofiles:CalculatedAttributeDefinitionStatistic"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:customerprofiles:Integration": {
+    "cfTypeName": "AWS::CustomerProfiles::Integration",
+    "properties": {
+      "domainName": {
+        "type": "string",
+        "description": "The unique name of the domain."
+      },
+      "flowDefinition": {
+        "$ref": "#/types/aws-native:customerprofiles:IntegrationFlowDefinition"
+      },
+      "objectTypeName": {
+        "type": "string",
+        "description": "The name of the ObjectType defined for the 3rd party data in Profile Service"
+      },
+      "objectTypeNames": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:customerprofiles:IntegrationObjectTypeMapping"
+        },
+        "description": "The mapping between 3rd party event types and ObjectType names"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags (keys and values) associated with the integration"
+      },
+      "uri": {
+        "type": "string",
+        "description": "The URI of the S3 bucket or any other type of data source."
+      }
+    }
+  },
+  "aws-native:datasync:LocationAzureBlob": {
+    "cfTypeName": "AWS::DataSync::LocationAzureBlob",
+    "properties": {
+      "agentArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Names (ARNs) of agents to use for an Azure Blob Location."
+      },
+      "azureAccessTier": {
+        "$ref": "#/types/aws-native:datasync:LocationAzureBlobAzureAccessTier",
+        "description": "Specifies an access tier for the objects you're transferring into your Azure Blob Storage container."
+      },
+      "azureBlobAuthenticationType": {
+        "$ref": "#/types/aws-native:datasync:LocationAzureBlobAzureBlobAuthenticationType",
+        "description": "The specific authentication type that you want DataSync to use to access your Azure Blob Container."
+      },
+      "azureBlobContainerUrl": {
+        "type": "string",
+        "description": "The URL of the Azure Blob container that was described."
+      },
+      "azureBlobSasConfiguration": {
+        "$ref": "#/types/aws-native:datasync:LocationAzureBlobAzureBlobSasConfiguration"
+      },
+      "azureBlobType": {
+        "$ref": "#/types/aws-native:datasync:LocationAzureBlobAzureBlobType",
+        "description": "Specifies a blob type for the objects you're transferring into your Azure Blob Storage container."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "The subdirectory in the Azure Blob Container that is used to read data from the Azure Blob Source Location."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationEfs": {
+    "cfTypeName": "AWS::DataSync::LocationEFS",
+    "properties": {
+      "accessPointArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the Amazon EFS Access point that DataSync uses when accessing the EFS file system."
+      },
+      "ec2Config": {
+        "$ref": "#/types/aws-native:datasync:LocationEfsEc2Config"
+      },
+      "efsFilesystemArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the Amazon EFS file system."
+      },
+      "fileSystemAccessRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the AWS IAM role that the DataSync will assume when mounting the EFS file system."
+      },
+      "inTransitEncryption": {
+        "$ref": "#/types/aws-native:datasync:LocationEfsInTransitEncryption",
+        "description": "Protocol that is used for encrypting the traffic exchanged between the DataSync Agent and the EFS file system."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the location's path. This subdirectory in the EFS file system is used to read data from the EFS source location or write data to the EFS destination."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationFSxLustre": {
+    "cfTypeName": "AWS::DataSync::LocationFSxLustre",
+    "properties": {
+      "fsxFilesystemArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the FSx for Lustre file system."
+      },
+      "securityGroupArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The ARNs of the security groups that are to use to configure the FSx for Lustre file system."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the location's path."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationFSxOntap": {
+    "cfTypeName": "AWS::DataSync::LocationFSxONTAP",
+    "properties": {
+      "protocol": {
+        "$ref": "#/types/aws-native:datasync:LocationFSxOntapProtocol"
+      },
+      "securityGroupArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The ARNs of the security groups that are to use to configure the FSx ONTAP file system."
+      },
+      "storageVirtualMachineArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the FSx ONTAP SVM."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the location's path."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationFSxOpenZfs": {
+    "cfTypeName": "AWS::DataSync::LocationFSxOpenZFS",
+    "properties": {
+      "fsxFilesystemArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the FSx OpenZFS file system."
+      },
+      "protocol": {
+        "$ref": "#/types/aws-native:datasync:LocationFSxOpenZfsProtocol"
+      },
+      "securityGroupArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The ARNs of the security groups that are to use to configure the FSx OpenZFS file system."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the location's path."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationFSxWindows": {
+    "cfTypeName": "AWS::DataSync::LocationFSxWindows",
+    "properties": {
+      "domain": {
+        "type": "string",
+        "description": "The name of the Windows domain that the FSx for Windows server belongs to."
+      },
+      "fsxFilesystemArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the FSx for Windows file system."
+      },
+      "password": {
+        "type": "string",
+        "description": "The password of the user who has the permissions to access files and folders in the FSx for Windows file system."
+      },
+      "securityGroupArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The ARNs of the security groups that are to use to configure the FSx for Windows file system."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the location's path."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "user": {
+        "type": "string",
+        "description": "The user who has the permissions to access files and folders in the FSx for Windows file system."
+      }
+    }
+  },
+  "aws-native:datasync:LocationHdfs": {
+    "cfTypeName": "AWS::DataSync::LocationHDFS",
+    "properties": {
+      "agentArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "ARN(s) of the agent(s) to use for an HDFS location."
+      },
+      "authenticationType": {
+        "$ref": "#/types/aws-native:datasync:LocationHdfsAuthenticationType",
+        "description": "The authentication mode used to determine identity of user."
+      },
+      "blockSize": {
+        "type": "integer",
+        "description": "Size of chunks (blocks) in bytes that the data is divided into when stored in the HDFS cluster."
+      },
+      "kerberosKeytab": {
+        "type": "string",
+        "description": "The Base64 string representation of the Keytab file."
+      },
+      "kerberosKrb5Conf": {
+        "type": "string",
+        "description": "The string representation of the Krb5Conf file, or the presigned URL to access the Krb5.conf file within an S3 bucket."
+      },
+      "kerberosPrincipal": {
+        "type": "string",
+        "description": "The unique identity, or principal, to which Kerberos can assign tickets."
+      },
+      "kmsKeyProviderUri": {
+        "type": "string",
+        "description": "The identifier for the Key Management Server where the encryption keys that encrypt data inside HDFS clusters are stored."
+      },
+      "nameNodes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:datasync:LocationHdfsNameNode"
+        },
+        "description": "An array of Name Node(s) of the HDFS location."
+      },
+      "qopConfiguration": {
+        "$ref": "#/types/aws-native:datasync:LocationHdfsQopConfiguration"
+      },
+      "replicationFactor": {
+        "type": "integer",
+        "description": "Number of copies of each block that exists inside the HDFS cluster."
+      },
+      "simpleUser": {
+        "type": "string",
+        "description": "The user name that has read and write permissions on the specified HDFS cluster."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "The subdirectory in HDFS that is used to read data from the HDFS source location or write data to the HDFS destination."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationNfs": {
+    "cfTypeName": "AWS::DataSync::LocationNFS",
+    "properties": {
+      "mountOptions": {
+        "$ref": "#/types/aws-native:datasync:LocationNfsMountOptions"
+      },
+      "onPremConfig": {
+        "$ref": "#/types/aws-native:datasync:LocationNfsOnPremConfig"
+      },
+      "serverHostname": {
+        "type": "string",
+        "description": "The name of the NFS server. This value is the IP address or DNS name of the NFS server."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "The subdirectory in the NFS file system that is used to read data from the NFS source location or write data to the NFS destination."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationObjectStorage": {
+    "cfTypeName": "AWS::DataSync::LocationObjectStorage",
+    "properties": {
+      "accessKey": {
+        "type": "string",
+        "description": "Optional. The access key is used if credentials are required to access the self-managed object storage server."
+      },
+      "agentArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Name (ARN) of the agents associated with the self-managed object storage server location."
+      },
+      "bucketName": {
+        "type": "string",
+        "description": "The name of the bucket on the self-managed object storage server."
+      },
+      "secretKey": {
+        "type": "string",
+        "description": "Optional. The secret key is used if credentials are required to access the self-managed object storage server."
+      },
+      "serverCertificate": {
+        "type": "string",
+        "description": "X.509 PEM content containing a certificate authority or chain to trust."
+      },
+      "serverHostname": {
+        "type": "string",
+        "description": "The name of the self-managed object storage server. This value is the IP address or Domain Name Service (DNS) name of the object storage server."
+      },
+      "serverPort": {
+        "type": "integer",
+        "description": "The port that your self-managed server accepts inbound network traffic on."
+      },
+      "serverProtocol": {
+        "$ref": "#/types/aws-native:datasync:LocationObjectStorageServerProtocol",
+        "description": "The protocol that the object storage server uses to communicate."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "The subdirectory in the self-managed object storage server that is used to read data from."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationS3": {
+    "cfTypeName": "AWS::DataSync::LocationS3",
+    "properties": {
+      "s3BucketArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Amazon S3 bucket."
+      },
+      "s3Config": {
+        "$ref": "#/types/aws-native:datasync:LocationS3s3Config"
+      },
+      "s3StorageClass": {
+        "$ref": "#/types/aws-native:datasync:LocationS3S3StorageClass",
+        "description": "The Amazon S3 storage class you want to store your files in when this location is used as a task destination."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "A subdirectory in the Amazon S3 bucket. This subdirectory in Amazon S3 is used to read data from the S3 source location or write data to the S3 destination."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:datasync:LocationSmb": {
+    "cfTypeName": "AWS::DataSync::LocationSMB",
+    "properties": {
+      "agentArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Names (ARNs) of agents to use for a Simple Message Block (SMB) location."
+      },
+      "domain": {
+        "type": "string",
+        "description": "The name of the Windows domain that the SMB server belongs to."
+      },
+      "mountOptions": {
+        "$ref": "#/types/aws-native:datasync:LocationSmbMountOptions"
+      },
+      "password": {
+        "type": "string",
+        "description": "The password of the user who can mount the share and has the permissions to access files and folders in the SMB share."
+      },
+      "serverHostname": {
+        "type": "string",
+        "description": "The name of the SMB server. This value is the IP address or Domain Name Service (DNS) name of the SMB server."
+      },
+      "subdirectory": {
+        "type": "string",
+        "description": "The subdirectory in the SMB file system that is used to read data from the SMB source location or write data to the SMB destination"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "user": {
+        "type": "string",
+        "description": "The user who can mount the share, has the permissions to access files and folders in the SMB share."
+      }
+    }
+  },
+  "aws-native:datazone:EnvironmentBlueprintConfiguration": {
+    "cfTypeName": "AWS::DataZone::EnvironmentBlueprintConfiguration",
+    "properties": {
+      "domainIdentifier": {
+        "type": "string"
+      },
+      "enabledRegions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "environmentBlueprintIdentifier": {
+        "type": "string"
+      },
+      "manageAccessRoleArn": {
+        "type": "string"
+      },
+      "provisioningRoleArn": {
+        "type": "string"
+      },
+      "regionalParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:datazone:EnvironmentBlueprintConfigurationRegionalParameter"
+        }
+      }
+    }
+  },
+  "aws-native:detective:Graph": {
+    "cfTypeName": "AWS::Detective::Graph",
+    "properties": {
+      "autoEnableMembers": {
+        "type": "boolean",
+        "description": "Indicates whether to automatically enable new organization accounts as member accounts in the organization behavior graph."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:detective:MemberInvitation": {
+    "cfTypeName": "AWS::Detective::MemberInvitation",
+    "properties": {
+      "disableEmailNotification": {
+        "type": "boolean",
+        "description": "When set to true, invitation emails are not sent to the member accounts. Member accounts must still accept the invitation before they are added to the behavior graph. Updating this field has no effect."
+      },
+      "graphArn": {
+        "type": "string",
+        "description": "The ARN of the graph to which the member account will be invited"
+      },
+      "memberEmailAddress": {
+        "type": "string",
+        "description": "The root email address for the account to be invited, for validation. Updating this field has no effect."
+      },
+      "memberId": {
+        "type": "string",
+        "description": "The AWS account ID to be invited to join the graph as a member"
+      },
+      "message": {
+        "type": "string",
+        "description": "A message to be included in the email invitation sent to the invited account. Updating this field has no effect."
+      }
+    }
+  },
+  "aws-native:detective:OrganizationAdmin": {
+    "cfTypeName": "AWS::Detective::OrganizationAdmin",
+    "properties": {
+      "accountId": {
+        "type": "string",
+        "description": "The account ID of the account that should be registered as your Organization's delegated administrator for Detective"
+      }
+    }
+  },
+  "aws-native:devopsguru:LogAnomalyDetectionIntegration": {
+    "cfTypeName": "AWS::DevOpsGuru::LogAnomalyDetectionIntegration",
+    "properties": {}
+  },
+  "aws-native:devopsguru:NotificationChannel": {
+    "cfTypeName": "AWS::DevOpsGuru::NotificationChannel",
+    "properties": {
+      "config": {
+        "$ref": "#/types/aws-native:devopsguru:NotificationChannelConfig"
+      }
+    }
+  },
+  "aws-native:devopsguru:ResourceCollection": {
+    "cfTypeName": "AWS::DevOpsGuru::ResourceCollection",
+    "properties": {
+      "resourceCollectionFilter": {
+        "$ref": "#/types/aws-native:devopsguru:ResourceCollectionFilter"
+      }
+    }
+  },
+  "aws-native:dms:ReplicationConfig": {
+    "cfTypeName": "AWS::DMS::ReplicationConfig",
+    "properties": {
+      "computeConfig": {
+        "$ref": "#/types/aws-native:dms:ReplicationConfigComputeConfig"
+      },
+      "replicationConfigArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Replication Config"
+      },
+      "replicationConfigIdentifier": {
+        "type": "string",
+        "description": "A unique identifier of replication configuration"
+      },
+      "replicationSettings": {
+        "$ref": "pulumi.json#/Any",
+        "description": "JSON settings for Servereless replications that are provisioned using this replication configuration\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::DMS::ReplicationConfig` for more information about the expected schema for this property."
+      },
+      "replicationType": {
+        "$ref": "#/types/aws-native:dms:ReplicationConfigReplicationType",
+        "description": "The type of AWS DMS Serverless replication to provision using this replication configuration"
+      },
+      "resourceIdentifier": {
+        "type": "string",
+        "description": "A unique value or name that you get set for a given resource that can be used to construct an Amazon Resource Name (ARN) for that resource"
+      },
+      "sourceEndpointArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the source endpoint for this AWS DMS Serverless replication configuration"
+      },
+      "supplementalSettings": {
+        "$ref": "pulumi.json#/Any",
+        "description": "JSON settings for specifying supplemental data\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::DMS::ReplicationConfig` for more information about the expected schema for this property."
+      },
+      "tableMappings": {
+        "$ref": "pulumi.json#/Any",
+        "description": "JSON table mappings for AWS DMS Serverless replications that are provisioned using this replication configuration\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::DMS::ReplicationConfig` for more information about the expected schema for this property."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "\u003cp\u003eContains a map of the key-value pairs for the resource tag or tags assigned to the dataset.\u003c/p\u003e"
+      },
+      "targetEndpointArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the target endpoint for this AWS DMS Serverless replication configuration"
+      }
+    }
+  },
+  "aws-native:dynamodb:GlobalTable": {
+    "cfTypeName": "AWS::DynamoDB::GlobalTable",
+    "properties": {
+      "attributeDefinitions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:dynamodb:GlobalTableAttributeDefinition"
+        }
+      },
+      "billingMode": {
+        "type": "string"
+      },
+      "globalSecondaryIndexes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:dynamodb:GlobalTableGlobalSecondaryIndex"
+        }
+      },
+      "keySchema": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:dynamodb:GlobalTableKeySchema"
+        }
+      },
+      "localSecondaryIndexes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:dynamodb:GlobalTableLocalSecondaryIndex"
+        }
+      },
+      "replicas": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:dynamodb:GlobalTableReplicaSpecification"
+        }
+      },
+      "sseSpecification": {
+        "$ref": "#/types/aws-native:dynamodb:GlobalTableSseSpecification"
+      },
+      "streamSpecification": {
+        "$ref": "#/types/aws-native:dynamodb:GlobalTableStreamSpecification"
+      },
+      "tableName": {
+        "type": "string"
+      },
+      "timeToLiveSpecification": {
+        "$ref": "#/types/aws-native:dynamodb:GlobalTableTimeToLiveSpecification"
+      },
+      "writeProvisionedThroughputSettings": {
+        "$ref": "#/types/aws-native:dynamodb:GlobalTableWriteProvisionedThroughputSettings"
+      }
+    }
+  },
+  "aws-native:ec2:CapacityReservation": {
+    "cfTypeName": "AWS::EC2::CapacityReservation",
+    "properties": {
+      "availabilityZone": {
+        "type": "string"
+      },
+      "ebsOptimized": {
+        "type": "boolean"
+      },
+      "endDate": {
+        "type": "string"
+      },
+      "endDateType": {
+        "type": "string"
+      },
+      "ephemeralStorage": {
+        "type": "boolean"
+      },
+      "instanceCount": {
+        "type": "integer"
+      },
+      "instanceMatchCriteria": {
+        "type": "string"
+      },
+      "instancePlatform": {
+        "type": "string"
+      },
+      "instanceType": {
+        "type": "string"
+      },
+      "outPostArn": {
+        "type": "string"
+      },
+      "placementGroupArn": {
+        "type": "string"
+      },
+      "tagSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:CapacityReservationTagSpecification"
+        }
+      },
+      "tenancy": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:CapacityReservationFleet": {
+    "cfTypeName": "AWS::EC2::CapacityReservationFleet",
+    "properties": {
+      "allocationStrategy": {
+        "type": "string"
+      },
+      "endDate": {
+        "type": "string"
+      },
+      "instanceMatchCriteria": {
+        "$ref": "#/types/aws-native:ec2:CapacityReservationFleetInstanceMatchCriteria"
+      },
+      "instanceTypeSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:CapacityReservationFleetInstanceTypeSpecification"
+        }
+      },
+      "noRemoveEndDate": {
+        "type": "boolean"
+      },
+      "removeEndDate": {
+        "type": "boolean"
+      },
+      "tagSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:CapacityReservationFleetTagSpecification"
+        }
+      },
+      "tenancy": {
+        "$ref": "#/types/aws-native:ec2:CapacityReservationFleetTenancy"
+      },
+      "totalTargetCapacity": {
+        "type": "integer"
+      }
+    }
+  },
+  "aws-native:ec2:CarrierGateway": {
+    "cfTypeName": "AWS::EC2::CarrierGateway",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the carrier gateway."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:CustomerGateway": {
+    "cfTypeName": "AWS::EC2::CustomerGateway",
+    "properties": {
+      "bgpAsn": {
+        "type": "integer",
+        "description": "For devices that support BGP, the customer gateway's BGP ASN."
+      },
+      "deviceName": {
+        "type": "string",
+        "description": "A name for the customer gateway device."
+      },
+      "ipAddress": {
+        "type": "string",
+        "description": "The internet-routable IP address for the customer gateway's outside interface. The address must be static."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "One or more tags for the customer gateway."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of VPN connection that this customer gateway supports."
+      }
+    }
+  },
+  "aws-native:ec2:DhcpOptions": {
+    "cfTypeName": "AWS::EC2::DHCPOptions",
+    "properties": {
+      "domainName": {
+        "type": "string",
+        "description": "This value is used to complete unqualified DNS hostnames."
+      },
+      "domainNameServers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IPv4 addresses of up to four domain name servers, or AmazonProvidedDNS."
+      },
+      "ipv6AddressPreferredLeaseTime": {
+        "type": "integer",
+        "description": "The preferred Lease Time for ipV6 address in seconds."
+      },
+      "netbiosNameServers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IPv4 addresses of up to four NetBIOS name servers."
+      },
+      "netbiosNodeType": {
+        "type": "integer",
+        "description": "The NetBIOS node type (1, 2, 4, or 8)."
+      },
+      "ntpServers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IPv4 addresses of up to four Network Time Protocol (NTP) servers."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the DHCP options set."
+      }
+    }
+  },
+  "aws-native:ec2:Ec2Fleet": {
+    "cfTypeName": "AWS::EC2::EC2Fleet",
+    "properties": {
+      "context": {
+        "type": "string"
+      },
+      "excessCapacityTerminationPolicy": {
+        "$ref": "#/types/aws-native:ec2:Ec2FleetExcessCapacityTerminationPolicy"
+      },
+      "launchTemplateConfigs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:Ec2FleetFleetLaunchTemplateConfigRequest"
+        }
+      },
+      "onDemandOptions": {
+        "$ref": "#/types/aws-native:ec2:Ec2FleetOnDemandOptionsRequest"
+      },
+      "replaceUnhealthyInstances": {
+        "type": "boolean"
+      },
+      "spotOptions": {
+        "$ref": "#/types/aws-native:ec2:Ec2FleetSpotOptionsRequest"
+      },
+      "tagSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:Ec2FleetTagSpecification"
+        }
+      },
+      "targetCapacitySpecification": {
+        "$ref": "#/types/aws-native:ec2:Ec2FleetTargetCapacitySpecificationRequest"
+      },
+      "terminateInstancesWithExpiration": {
+        "type": "boolean"
+      },
+      "type": {
+        "$ref": "#/types/aws-native:ec2:Ec2FleetType"
+      },
+      "validFrom": {
+        "type": "string"
+      },
+      "validUntil": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:EgressOnlyInternetGateway": {
+    "cfTypeName": "AWS::EC2::EgressOnlyInternetGateway",
+    "properties": {
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC for which to create the egress-only internet gateway."
+      }
+    }
+  },
+  "aws-native:ec2:Eip": {
+    "cfTypeName": "AWS::EC2::EIP",
+    "properties": {
+      "domain": {
+        "type": "string",
+        "description": "The network (``vpc``).\n If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a dependency on the VPC-gateway attachment by using the [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) on this resource."
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "The ID of the instance.\n  Updates to the ``InstanceId`` property may require *some interruptions*. Updates on an EIP reassociates the address on its associated resource."
+      },
+      "networkBorderGroup": {
+        "type": "string",
+        "description": "A unique set of Availability Zones, Local Zones, or Wavelength Zones from which AWS advertises IP addresses. Use this parameter to limit the IP address to this location. IP addresses cannot move between network border groups.\n Use [DescribeAvailabilityZones](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html) to view the network border groups."
+      },
+      "publicIpv4Pool": {
+        "type": "string",
+        "description": "The ID of an address pool that you own. Use this parameter to let Amazon EC2 select an address from the address pool.\n  Updates to the ``PublicIpv4Pool`` property may require *some interruptions*. Updates on an EIP reassociates the address on its associated resource."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the Elastic IP address.\n  Updates to the ``Tags`` property may require *some interruptions*. Updates on an EIP reassociates the address on its associated resource."
+      },
+      "transferAddress": {
+        "type": "string",
+        "description": "The Elastic IP address you are accepting for transfer. You can only accept one transferred address. For more information on Elastic IP address transfers, see [Transfer Elastic IP addresses](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#transfer-EIPs-intro) in the *Amazon Virtual Private Cloud User Guide*."
+      }
+    }
+  },
+  "aws-native:ec2:EipAssociation": {
+    "cfTypeName": "AWS::EC2::EIPAssociation",
+    "properties": {
+      "allocationId": {
+        "type": "string",
+        "description": "The allocation ID. This is required for EC2-VPC."
+      },
+      "eip": {
+        "type": "string",
+        "description": "The Elastic IP address to associate with the instance."
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "The ID of the instance."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of the network interface."
+      },
+      "privateIpAddress": {
+        "type": "string",
+        "description": "The primary or secondary private IP address to associate with the Elastic IP address."
+      }
+    }
+  },
+  "aws-native:ec2:EnclaveCertificateIamRoleAssociation": {
+    "cfTypeName": "AWS::EC2::EnclaveCertificateIamRoleAssociation",
+    "properties": {
+      "certificateArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the ACM certificate with which to associate the IAM role."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM role to associate with the ACM certificate. You can associate up to 16 IAM roles with an ACM certificate."
+      }
+    }
+  },
+  "aws-native:ec2:FlowLog": {
+    "cfTypeName": "AWS::EC2::FlowLog",
+    "properties": {
+      "deliverCrossAccountRole": {
+        "type": "string",
+        "description": "The ARN of the IAM role that allows Amazon EC2 to publish flow logs across accounts."
+      },
+      "deliverLogsPermissionArn": {
+        "type": "string",
+        "description": "The ARN for the IAM role that permits Amazon EC2 to publish flow logs to a CloudWatch Logs log group in your account. If you specify LogDestinationType as s3 or kinesis-data-firehose, do not specify DeliverLogsPermissionArn or LogGroupName."
+      },
+      "destinationOptions": {
+        "$ref": "#/types/aws-native:ec2:DestinationOptionsProperties"
+      },
+      "logDestination": {
+        "type": "string",
+        "description": "Specifies the destination to which the flow log data is to be published. Flow log data can be published to a CloudWatch Logs log group, an Amazon S3 bucket, or a Kinesis Firehose stream. The value specified for this parameter depends on the value specified for LogDestinationType."
+      },
+      "logDestinationType": {
+        "$ref": "#/types/aws-native:ec2:FlowLogLogDestinationType",
+        "description": "Specifies the type of destination to which the flow log data is to be published. Flow log data can be published to CloudWatch Logs or Amazon S3."
+      },
+      "logFormat": {
+        "type": "string",
+        "description": "The fields to include in the flow log record, in the order in which they should appear."
+      },
+      "logGroupName": {
+        "type": "string",
+        "description": "The name of a new or existing CloudWatch Logs log group where Amazon EC2 publishes your flow logs. If you specify LogDestinationType as s3 or kinesis-data-firehose, do not specify DeliverLogsPermissionArn or LogGroupName."
+      },
+      "maxAggregationInterval": {
+        "type": "integer",
+        "description": "The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. You can specify 60 seconds (1 minute) or 600 seconds (10 minutes)."
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "The ID of the subnet, network interface, or VPC for which you want to create a flow log."
+      },
+      "resourceType": {
+        "$ref": "#/types/aws-native:ec2:FlowLogResourceType",
+        "description": "The type of resource for which to create the flow log. For example, if you specified a VPC ID for the ResourceId property, specify VPC for this property."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags to apply to the flow logs."
+      },
+      "trafficType": {
+        "$ref": "#/types/aws-native:ec2:FlowLogTrafficType",
+        "description": "The type of traffic to log. You can log traffic that the resource accepts or rejects, or all traffic."
+      }
+    }
+  },
+  "aws-native:ec2:GatewayRouteTableAssociation": {
+    "cfTypeName": "AWS::EC2::GatewayRouteTableAssociation",
+    "properties": {
+      "gatewayId": {
+        "type": "string",
+        "description": "The ID of the gateway."
+      },
+      "routeTableId": {
+        "type": "string",
+        "description": "The ID of the route table."
+      }
+    }
+  },
+  "aws-native:ec2:Host": {
+    "cfTypeName": "AWS::EC2::Host",
+    "properties": {
+      "assetId": {
+        "type": "string",
+        "description": "The ID of the Outpost hardware asset."
+      },
+      "autoPlacement": {
+        "type": "string",
+        "description": "Indicates whether the host accepts any untargeted instance launches that match its instance type configuration, or if it only accepts Host tenancy instance launches that specify its unique host ID."
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The Availability Zone in which to allocate the Dedicated Host."
+      },
+      "hostMaintenance": {
+        "type": "string",
+        "description": "Automatically allocates a new dedicated host and moves your instances on to it if a degradation is detected on your current host."
+      },
+      "hostRecovery": {
+        "type": "string",
+        "description": "Indicates whether to enable or disable host recovery for the Dedicated Host. Host recovery is disabled by default."
+      },
+      "instanceFamily": {
+        "type": "string",
+        "description": "Specifies the instance family to be supported by the Dedicated Hosts. If you specify an instance family, the Dedicated Hosts support multiple instance types within that instance family."
+      },
+      "instanceType": {
+        "type": "string",
+        "description": "Specifies the instance type to be supported by the Dedicated Hosts. If you specify an instance type, the Dedicated Hosts support instances of the specified instance type only."
+      },
+      "outpostArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Amazon Web Services Outpost on which to allocate the Dedicated Host."
+      }
+    }
+  },
+  "aws-native:ec2:Instance": {
+    "cfTypeName": "AWS::EC2::Instance",
+    "properties": {
+      "additionalInfo": {
+        "type": "string",
+        "description": "This property is reserved for internal use. If you use it, the stack fails with this error: Bad property set: [Testing this property] (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: 0XXXXXX-49c7-4b40-8bcc-76885dcXXXXX)."
+      },
+      "affinity": {
+        "$ref": "#/types/aws-native:ec2:InstanceAffinity",
+        "description": "Indicates whether the instance is associated with a dedicated host. If you want the instance to always restart on the same host on which it was launched, specify host. If you want the instance to restart on any available host, but try to launch onto the last host it ran on (on a best-effort basis), specify default."
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The Availability Zone of the instance."
+      },
+      "blockDeviceMappings": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceBlockDeviceMapping"
+        },
+        "description": "The block device mapping entries that defines the block devices to attach to the instance at launch."
+      },
+      "cpuOptions": {
+        "$ref": "#/types/aws-native:ec2:CpuOptionsProperties",
+        "description": "The CPU options for the instance."
+      },
+      "creditSpecification": {
+        "$ref": "#/types/aws-native:ec2:CreditSpecificationProperties",
+        "description": "The credit option for CPU usage of the burstable performance instance. Valid values are standard and unlimited."
+      },
+      "disableApiTermination": {
+        "type": "boolean",
+        "description": "If you set this parameter to true, you can't terminate the instance using the Amazon EC2 console, CLI, or API; otherwise, you can."
+      },
+      "ebsOptimized": {
+        "type": "boolean",
+        "description": "Indicates whether the instance is optimized for Amazon EBS I/O."
+      },
+      "elasticGpuSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceElasticGpuSpecification"
+        },
+        "description": "An elastic GPU to associate with the instance."
+      },
+      "elasticInferenceAccelerators": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceElasticInferenceAccelerator"
+        },
+        "description": "An elastic inference accelerator to associate with the instance."
+      },
+      "enclaveOptions": {
+        "$ref": "#/types/aws-native:ec2:EnclaveOptionsProperties",
+        "description": "Indicates whether the instance is enabled for AWS Nitro Enclaves."
+      },
+      "hibernationOptions": {
+        "$ref": "#/types/aws-native:ec2:HibernationOptionsProperties",
+        "description": "Indicates whether an instance is enabled for hibernation."
+      },
+      "hostId": {
+        "type": "string",
+        "description": "If you specify host for the Affinity property, the ID of a dedicated host that the instance is associated with. If you don't specify an ID, Amazon EC2 launches the instance onto any available, compatible dedicated host in your account."
+      },
+      "hostResourceGroupArn": {
+        "type": "string",
+        "description": "The ARN of the host resource group in which to launch the instances. If you specify a host resource group ARN, omit the Tenancy parameter or set it to host."
+      },
+      "iamInstanceProfile": {
+        "type": "string",
+        "description": "The IAM instance profile."
+      },
+      "imageId": {
+        "type": "string",
+        "description": "The ID of the AMI. An AMI ID is required to launch an instance and must be specified here or in a launch template."
+      },
+      "instanceInitiatedShutdownBehavior": {
+        "type": "string",
+        "description": "Indicates whether an instance stops or terminates when you initiate shutdown from the instance (using the operating system command for system shutdown)."
+      },
+      "instanceType": {
+        "type": "string",
+        "description": "The instance type."
+      },
+      "ipv6AddressCount": {
+        "type": "integer",
+        "description": "[EC2-VPC] The number of IPv6 addresses to associate with the primary network interface. Amazon EC2 chooses the IPv6 addresses from the range of your subnet."
+      },
+      "ipv6Addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceIpv6Address"
+        },
+        "description": "[EC2-VPC] The IPv6 addresses from the range of the subnet to associate with the primary network interface."
+      },
+      "kernelId": {
+        "type": "string",
+        "description": "The ID of the kernel."
+      },
+      "keyName": {
+        "type": "string",
+        "description": "The name of the key pair."
+      },
+      "launchTemplate": {
+        "$ref": "#/types/aws-native:ec2:InstanceLaunchTemplateSpecification",
+        "description": "The launch template to use to launch the instances."
+      },
+      "licenseSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceLicenseSpecification"
+        },
+        "description": "The license configurations."
+      },
+      "monitoring": {
+        "type": "boolean",
+        "description": "Specifies whether detailed monitoring is enabled for the instance."
+      },
+      "networkInterfaces": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceNetworkInterface"
+        },
+        "description": "The network interfaces to associate with the instance."
+      },
+      "placementGroupName": {
+        "type": "string",
+        "description": "The name of an existing placement group that you want to launch the instance into (cluster | partition | spread)."
+      },
+      "privateDnsNameOptions": {
+        "$ref": "#/types/aws-native:ec2:InstancePrivateDnsNameOptions",
+        "description": "The options for the instance hostname."
+      },
+      "privateIpAddress": {
+        "type": "string",
+        "description": "[EC2-VPC] The primary IPv4 address. You must specify a value from the IPv4 address range of the subnet."
+      },
+      "propagateTagsToVolumeOnCreation": {
+        "type": "boolean",
+        "description": "Indicates whether to assign the tags from the instance to all of the volumes attached to the instance at launch. If you specify true and you assign tags to the instance, those tags are automatically assigned to all of the volumes that you attach to the instance at launch. If you specify false, those tags are not assigned to the attached volumes."
+      },
+      "ramdiskId": {
+        "type": "string",
+        "description": "The ID of the RAM disk to select."
+      },
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the security groups."
+      },
+      "securityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "the names of the security groups. For a nondefault VPC, you must use security group IDs instead."
+      },
+      "sourceDestCheck": {
+        "type": "boolean",
+        "description": "Specifies whether to enable an instance launched in a VPC to perform NAT."
+      },
+      "ssmAssociations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceSsmAssociation"
+        },
+        "description": "The SSM document and parameter values in AWS Systems Manager to associate with this instance."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "[EC2-VPC] The ID of the subnet to launch the instance into.\n\n"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags to add to the instance."
+      },
+      "tenancy": {
+        "type": "string",
+        "description": "The tenancy of the instance (if the instance is running in a VPC). An instance with a tenancy of dedicated runs on single-tenant hardware."
+      },
+      "userData": {
+        "type": "string",
+        "description": "The user data to make available to the instance."
+      },
+      "volumes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:InstanceVolume"
+        },
+        "description": "The volumes to attach to the instance."
+      }
+    }
+  },
+  "aws-native:ec2:InstanceConnectEndpoint": {
+    "cfTypeName": "AWS::EC2::InstanceConnectEndpoint",
+    "properties": {
+      "clientToken": {
+        "type": "string",
+        "description": "The client token of the instance connect endpoint."
+      },
+      "preserveClientIp": {
+        "type": "boolean",
+        "description": "If true, the address of the instance connect endpoint client is preserved when connecting to the end resource"
+      },
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The security group IDs of the instance connect endpoint."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The subnet id of the instance connect endpoint"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags of the instance connect endpoint."
+      }
+    }
+  },
+  "aws-native:ec2:InternetGateway": {
+    "cfTypeName": "AWS::EC2::InternetGateway",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags to assign to the internet gateway."
+      }
+    }
+  },
+  "aws-native:ec2:Ipam": {
+    "cfTypeName": "AWS::EC2::IPAM",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "operatingRegions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:IpamOperatingRegion"
+        },
+        "description": "The regions IPAM is enabled for. Allows pools to be created in these regions, as well as enabling monitoring"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "tier": {
+        "$ref": "#/types/aws-native:ec2:IpamTier",
+        "description": "The tier of the IPAM."
+      }
+    }
+  },
+  "aws-native:ec2:IpamAllocation": {
+    "cfTypeName": "AWS::EC2::IPAMAllocation",
+    "properties": {
+      "cidr": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "ipamPoolId": {
+        "type": "string",
+        "description": "Id of the IPAM Pool."
+      },
+      "netmaskLength": {
+        "type": "integer",
+        "description": "The desired netmask length of the allocation. If set, IPAM will choose a block of free space with this size and return the CIDR representing it."
+      }
+    }
+  },
+  "aws-native:ec2:IpamPool": {
+    "cfTypeName": "AWS::EC2::IPAMPool",
+    "properties": {
+      "addressFamily": {
+        "type": "string",
+        "description": "The address family of the address space in this pool. Either IPv4 or IPv6."
+      },
+      "allocationDefaultNetmaskLength": {
+        "type": "integer",
+        "description": "The default netmask length for allocations made from this pool. This value is used when the netmask length of an allocation isn't specified."
+      },
+      "allocationMaxNetmaskLength": {
+        "type": "integer",
+        "description": "The maximum allowed netmask length for allocations made from this pool."
+      },
+      "allocationMinNetmaskLength": {
+        "type": "integer",
+        "description": "The minimum allowed netmask length for allocations made from this pool."
+      },
+      "allocationResourceTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:IpamPoolTag"
+        },
+        "description": "When specified, an allocation will not be allowed unless a resource has a matching set of tags."
+      },
+      "autoImport": {
+        "type": "boolean",
+        "description": "Determines what to do if IPAM discovers resources that haven't been assigned an allocation. If set to true, an allocation will be made automatically."
+      },
+      "awsService": {
+        "$ref": "#/types/aws-native:ec2:IpamPoolAwsService",
+        "description": "Limits which service in Amazon Web Services that the pool can be used in."
+      },
+      "description": {
+        "type": "string"
+      },
+      "ipamScopeId": {
+        "type": "string",
+        "description": "The Id of the scope this pool is a part of."
+      },
+      "locale": {
+        "type": "string",
+        "description": "The region of this pool. If not set, this will default to \"None\" which will disable non-custom allocations. If the locale has been specified for the source pool, this value must match."
+      },
+      "provisionedCidrs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:IpamPoolProvisionedCidr"
+        },
+        "description": "A list of cidrs representing the address space available for allocation in this pool."
+      },
+      "publicIpSource": {
+        "$ref": "#/types/aws-native:ec2:IpamPoolPublicIpSource",
+        "description": "The IP address source for pools in the public scope. Only used for provisioning IP address CIDRs to pools in the public scope. Default is `byoip`."
+      },
+      "publiclyAdvertisable": {
+        "type": "boolean",
+        "description": "Determines whether or not address space from this pool is publicly advertised. Must be set if and only if the pool is IPv6."
+      },
+      "sourceIpamPoolId": {
+        "type": "string",
+        "description": "The Id of this pool's source. If set, all space provisioned in this pool must be free space provisioned in the parent pool."
+      },
+      "sourceResource": {
+        "$ref": "#/types/aws-native:ec2:IpamPoolSourceResource"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:IpamPoolCidr": {
+    "cfTypeName": "AWS::EC2::IPAMPoolCidr",
+    "properties": {
+      "cidr": {
+        "type": "string",
+        "description": "Represents a single IPv4 or IPv6 CIDR"
+      },
+      "ipamPoolId": {
+        "type": "string",
+        "description": "Id of the IPAM Pool."
+      },
+      "netmaskLength": {
+        "type": "integer",
+        "description": "The desired netmask length of the provision. If set, IPAM will choose a block of free space with this size and return the CIDR representing it."
+      }
+    }
+  },
+  "aws-native:ec2:IpamResourceDiscovery": {
+    "cfTypeName": "AWS::EC2::IPAMResourceDiscovery",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "operatingRegions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:IpamResourceDiscoveryIpamOperatingRegion"
+        },
+        "description": "The regions Resource Discovery is enabled for. Allows resource discoveries to be created in these regions, as well as enabling monitoring"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:IpamResourceDiscoveryAssociation": {
+    "cfTypeName": "AWS::EC2::IPAMResourceDiscoveryAssociation",
+    "properties": {
+      "ipamId": {
+        "type": "string",
+        "description": "The Id of the IPAM this Resource Discovery is associated to."
+      },
+      "ipamResourceDiscoveryId": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IPAM Resource Discovery Association."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:IpamScope": {
+    "cfTypeName": "AWS::EC2::IPAMScope",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "ipamId": {
+        "type": "string",
+        "description": "The Id of the IPAM this scope is a part of."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:KeyPair": {
+    "cfTypeName": "AWS::EC2::KeyPair",
+    "properties": {
+      "keyFormat": {
+        "$ref": "#/types/aws-native:ec2:KeyPairKeyFormat",
+        "description": "The format of the private key"
+      },
+      "keyName": {
+        "type": "string",
+        "description": "The name of the SSH key pair"
+      },
+      "keyType": {
+        "$ref": "#/types/aws-native:ec2:KeyPairKeyType",
+        "description": "The crypto-system used to generate a key pair."
+      },
+      "publicKeyMaterial": {
+        "type": "string",
+        "description": "Plain text public key to import"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:LocalGatewayRoute": {
+    "cfTypeName": "AWS::EC2::LocalGatewayRoute",
+    "properties": {
+      "destinationCidrBlock": {
+        "type": "string",
+        "description": "The CIDR block used for destination matches."
+      },
+      "localGatewayRouteTableId": {
+        "type": "string",
+        "description": "The ID of the local gateway route table."
+      },
+      "localGatewayVirtualInterfaceGroupId": {
+        "type": "string",
+        "description": "The ID of the virtual interface group."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of the network interface."
+      }
+    }
+  },
+  "aws-native:ec2:LocalGatewayRouteTable": {
+    "cfTypeName": "AWS::EC2::LocalGatewayRouteTable",
+    "properties": {
+      "localGatewayId": {
+        "type": "string",
+        "description": "The ID of the local gateway."
+      },
+      "mode": {
+        "type": "string",
+        "description": "The mode of the local gateway route table."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the local gateway route table."
+      }
+    }
+  },
+  "aws-native:ec2:LocalGatewayRouteTableVirtualInterfaceGroupAssociation": {
+    "cfTypeName": "AWS::EC2::LocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+    "properties": {
+      "localGatewayRouteTableId": {
+        "type": "string",
+        "description": "The ID of the local gateway route table."
+      },
+      "localGatewayVirtualInterfaceGroupId": {
+        "type": "string",
+        "description": "The ID of the local gateway route table virtual interface group."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the local gateway route table virtual interface group association."
+      }
+    }
+  },
+  "aws-native:ec2:LocalGatewayRouteTableVpcAssociation": {
+    "cfTypeName": "AWS::EC2::LocalGatewayRouteTableVPCAssociation",
+    "properties": {
+      "localGatewayRouteTableId": {
+        "type": "string",
+        "description": "The ID of the local gateway route table."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the association."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:NatGateway": {
+    "cfTypeName": "AWS::EC2::NatGateway",
+    "properties": {
+      "allocationId": {
+        "type": "string",
+        "description": "[Public NAT gateway only] The allocation ID of the Elastic IP address that's associated with the NAT gateway. This property is required for a public NAT gateway and cannot be specified with a private NAT gateway."
+      },
+      "connectivityType": {
+        "type": "string",
+        "description": "Indicates whether the NAT gateway supports public or private connectivity. The default is public connectivity."
+      },
+      "maxDrainDurationSeconds": {
+        "type": "integer",
+        "description": "The maximum amount of time to wait (in seconds) before forcibly releasing the IP addresses if connections are still in progress. Default value is 350 seconds."
+      },
+      "privateIpAddress": {
+        "type": "string",
+        "description": "The private IPv4 address to assign to the NAT gateway. If you don't provide an address, a private IPv4 address will be automatically assigned."
+      },
+      "secondaryAllocationIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Secondary EIP allocation IDs. For more information, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-creating) in the *Amazon VPC User Guide*."
+      },
+      "secondaryPrivateIpAddressCount": {
+        "type": "integer",
+        "description": "[Private NAT gateway only] The number of secondary private IPv4 addresses you want to assign to the NAT gateway. For more information about secondary addresses, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-creating) in the *Amazon Virtual Private Cloud User Guide*.\n ``SecondaryPrivateIpAddressCount`` and ``SecondaryPrivateIpAddresses`` cannot be set at the same time."
+      },
+      "secondaryPrivateIpAddresses": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Secondary private IPv4 addresses. For more information about secondary addresses, see [Create a NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-creating) in the *Amazon Virtual Private Cloud User Guide*.\n ``SecondaryPrivateIpAddressCount`` and ``SecondaryPrivateIpAddresses`` cannot be set at the same time."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet in which the NAT gateway is located."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the NAT gateway."
+      }
+    }
+  },
+  "aws-native:ec2:NetworkAcl": {
+    "cfTypeName": "AWS::EC2::NetworkAcl",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the network ACL."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC for the network ACL."
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInsightsAccessScope": {
+    "cfTypeName": "AWS::EC2::NetworkInsightsAccessScope",
+    "properties": {
+      "excludePaths": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInsightsAccessScopeAccessScopePathRequest"
+        }
+      },
+      "matchPaths": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInsightsAccessScopeAccessScopePathRequest"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInsightsAccessScopeAnalysis": {
+    "cfTypeName": "AWS::EC2::NetworkInsightsAccessScopeAnalysis",
+    "properties": {
+      "networkInsightsAccessScopeId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInsightsAnalysis": {
+    "cfTypeName": "AWS::EC2::NetworkInsightsAnalysis",
+    "properties": {
+      "additionalAccounts": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "filterInArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "networkInsightsPathId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInsightsPath": {
+    "cfTypeName": "AWS::EC2::NetworkInsightsPath",
+    "properties": {
+      "destination": {
+        "type": "string"
+      },
+      "destinationIp": {
+        "type": "string"
+      },
+      "destinationPort": {
+        "type": "integer"
+      },
+      "filterAtDestination": {
+        "$ref": "#/types/aws-native:ec2:NetworkInsightsPathPathFilter"
+      },
+      "filterAtSource": {
+        "$ref": "#/types/aws-native:ec2:NetworkInsightsPathPathFilter"
+      },
+      "protocol": {
+        "$ref": "#/types/aws-native:ec2:NetworkInsightsPathProtocol"
+      },
+      "source": {
+        "type": "string"
+      },
+      "sourceIp": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInterface": {
+    "cfTypeName": "AWS::EC2::NetworkInterface",
+    "properties": {
+      "connectionTrackingSpecification": {
+        "$ref": "#/types/aws-native:ec2:NetworkInterfaceConnectionTrackingSpecification"
+      },
+      "description": {
+        "type": "string",
+        "description": "A description for the network interface."
+      },
+      "enablePrimaryIpv6": {
+        "type": "boolean",
+        "description": "If you have instances or ENIs that rely on the IPv6 address not changing, to avoid disrupting traffic to instances or ENIs, you can enable a primary IPv6 address. Enable this option to automatically assign an IPv6 associated with the ENI attached to your instance to be the primary IPv6 address. When you enable an IPv6 address to be a primary IPv6, you cannot disable it. Traffic will be routed to the primary IPv6 address until the instance is terminated or the ENI is detached. If you have multiple IPv6 addresses associated with an ENI and you enable a primary IPv6 address, the first IPv6 address associated with the ENI becomes the primary IPv6 address."
+      },
+      "groupSet": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of security group IDs associated with this network interface."
+      },
+      "interfaceType": {
+        "type": "string",
+        "description": "Indicates the type of network interface."
+      },
+      "ipv4PrefixCount": {
+        "type": "integer",
+        "description": "The number of IPv4 prefixes to assign to a network interface. When you specify a number of IPv4 prefixes, Amazon EC2 selects these prefixes from your existing subnet CIDR reservations, if available, or from free spaces in the subnet. By default, these will be /28 prefixes. You can't specify a count of IPv4 prefixes if you've specified one of the following: specific IPv4 prefixes, specific private IPv4 addresses, or a count of private IPv4 addresses."
+      },
+      "ipv4Prefixes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInterfaceIpv4PrefixSpecification"
+        },
+        "description": "Assigns a list of IPv4 prefixes to the network interface. If you want EC2 to automatically assign IPv4 prefixes, use the Ipv4PrefixCount property and do not specify this property. Presently, only /28 prefixes are supported. You can't specify IPv4 prefixes if you've specified one of the following: a count of IPv4 prefixes, specific private IPv4 addresses, or a count of private IPv4 addresses."
+      },
+      "ipv6AddressCount": {
+        "type": "integer",
+        "description": "The number of IPv6 addresses to assign to a network interface. Amazon EC2 automatically selects the IPv6 addresses from the subnet range. To specify specific IPv6 addresses, use the Ipv6Addresses property and don't specify this property."
+      },
+      "ipv6Addresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInterfaceInstanceIpv6Address"
+        },
+        "description": "One or more specific IPv6 addresses from the IPv6 CIDR block range of your subnet to associate with the network interface. If you're specifying a number of IPv6 addresses, use the Ipv6AddressCount property and don't specify this property."
+      },
+      "ipv6PrefixCount": {
+        "type": "integer",
+        "description": "The number of IPv6 prefixes to assign to a network interface. When you specify a number of IPv6 prefixes, Amazon EC2 selects these prefixes from your existing subnet CIDR reservations, if available, or from free spaces in the subnet. By default, these will be /80 prefixes. You can't specify a count of IPv6 prefixes if you've specified one of the following: specific IPv6 prefixes, specific IPv6 addresses, or a count of IPv6 addresses."
+      },
+      "ipv6Prefixes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInterfaceIpv6PrefixSpecification"
+        },
+        "description": "Assigns a list of IPv6 prefixes to the network interface. If you want EC2 to automatically assign IPv6 prefixes, use the Ipv6PrefixCount property and do not specify this property. Presently, only /80 prefixes are supported. You can't specify IPv6 prefixes if you've specified one of the following: a count of IPv6 prefixes, specific IPv6 addresses, or a count of IPv6 addresses."
+      },
+      "privateIpAddress": {
+        "type": "string",
+        "description": "Assigns a single private IP address to the network interface, which is used as the primary private IP address. If you want to specify multiple private IP address, use the PrivateIpAddresses property. "
+      },
+      "privateIpAddresses": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:NetworkInterfacePrivateIpAddressSpecification"
+        },
+        "description": "Assigns a list of private IP addresses to the network interface. You can specify a primary private IP address by setting the value of the Primary property to true in the PrivateIpAddressSpecification property. If you want EC2 to automatically assign private IP addresses, use the SecondaryPrivateIpAddressCount property and do not specify this property."
+      },
+      "secondaryPrivateIpAddressCount": {
+        "type": "integer",
+        "description": "The number of secondary private IPv4 addresses to assign to a network interface. When you specify a number of secondary IPv4 addresses, Amazon EC2 selects these IP addresses within the subnet's IPv4 CIDR range. You can't specify this option and specify more than one private IP address using privateIpAddresses"
+      },
+      "sourceDestCheck": {
+        "type": "boolean",
+        "description": "Indicates whether traffic to or from the instance is validated."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet to associate with the network interface."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An arbitrary set of tags (key-value pairs) for this network interface."
+      }
+    }
+  },
+  "aws-native:ec2:NetworkInterfaceAttachment": {
+    "cfTypeName": "AWS::EC2::NetworkInterfaceAttachment",
+    "properties": {
+      "deleteOnTermination": {
+        "type": "boolean",
+        "description": "Whether to delete the network interface when the instance terminates. By default, this value is set to true."
+      },
+      "deviceIndex": {
+        "type": "string",
+        "description": "The network interface's position in the attachment order. For example, the first attached network interface has a DeviceIndex of 0."
+      },
+      "enaSrdSpecification": {
+        "$ref": "#/types/aws-native:ec2:NetworkInterfaceAttachmentEnaSrdSpecification"
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "The ID of the instance to which you will attach the ENI."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of the ENI that you want to attach."
+      }
+    }
+  },
+  "aws-native:ec2:NetworkPerformanceMetricSubscription": {
+    "cfTypeName": "AWS::EC2::NetworkPerformanceMetricSubscription",
+    "properties": {
+      "destination": {
+        "type": "string",
+        "description": "The target Region or Availability Zone for the metric to subscribe to."
+      },
+      "metric": {
+        "type": "string",
+        "description": "The metric type to subscribe to."
+      },
+      "source": {
+        "type": "string",
+        "description": "The starting Region or Availability Zone for metric to subscribe to."
+      },
+      "statistic": {
+        "type": "string",
+        "description": "The statistic to subscribe to."
+      }
+    }
+  },
+  "aws-native:ec2:PlacementGroup": {
+    "cfTypeName": "AWS::EC2::PlacementGroup",
+    "properties": {
+      "partitionCount": {
+        "type": "integer",
+        "description": "The number of partitions. Valid only when **Strategy** is set to `partition`"
+      },
+      "spreadLevel": {
+        "type": "string",
+        "description": "The Spread Level of Placement Group is an enum where it accepts either host or rack when strategy is spread"
+      },
+      "strategy": {
+        "type": "string",
+        "description": "The placement strategy."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:ec2:Route": {
+    "cfTypeName": "AWS::EC2::Route",
+    "properties": {
+      "carrierGatewayId": {
+        "type": "string",
+        "description": "The ID of the carrier gateway.\n You can only use this option when the VPC contains a subnet which is associated with a Wavelength Zone."
+      },
+      "coreNetworkArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the core network."
+      },
+      "destinationCidrBlock": {
+        "type": "string",
+        "description": "The IPv4 CIDR address block used for the destination match. Routing decisions are based on the most specific match. We modify the specified CIDR block to its canonical form; for example, if you specify ``100.68.0.18/18``, we modify it to ``100.68.0.0/18``."
+      },
+      "destinationIpv6CidrBlock": {
+        "type": "string",
+        "description": "The IPv6 CIDR block used for the destination match. Routing decisions are based on the most specific match."
+      },
+      "destinationPrefixListId": {
+        "type": "string",
+        "description": "The ID of a prefix list used for the destination match."
+      },
+      "egressOnlyInternetGatewayId": {
+        "type": "string",
+        "description": "[IPv6 traffic only] The ID of an egress-only internet gateway."
+      },
+      "gatewayId": {
+        "type": "string",
+        "description": "The ID of an internet gateway or virtual private gateway attached to your VPC."
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "The ID of a NAT instance in your VPC. The operation fails if you specify an instance ID unless exactly one network interface is attached."
+      },
+      "localGatewayId": {
+        "type": "string",
+        "description": "The ID of the local gateway."
+      },
+      "natGatewayId": {
+        "type": "string",
+        "description": "[IPv4 traffic only] The ID of a NAT gateway."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of a network interface."
+      },
+      "routeTableId": {
+        "type": "string",
+        "description": "The ID of the route table for the route."
+      },
+      "transitGatewayId": {
+        "type": "string",
+        "description": "The ID of a transit gateway."
+      },
+      "vpcEndpointId": {
+        "type": "string",
+        "description": "The ID of a VPC endpoint. Supported for Gateway Load Balancer endpoints only."
+      },
+      "vpcPeeringConnectionId": {
+        "type": "string",
+        "description": "The ID of a VPC peering connection."
+      }
+    }
+  },
+  "aws-native:ec2:RouteTable": {
+    "cfTypeName": "AWS::EC2::RouteTable",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the route table."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:SecurityGroup": {
+    "cfTypeName": "AWS::EC2::SecurityGroup",
+    "properties": {
+      "groupDescription": {
+        "type": "string",
+        "description": "A description for the security group."
+      },
+      "groupName": {
+        "type": "string",
+        "description": "The name of the security group."
+      },
+      "securityGroupEgress": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:SecurityGroupEgress"
+        },
+        "description": "[VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group."
+      },
+      "securityGroupIngress": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:SecurityGroupIngress"
+        },
+        "description": "The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the security group."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC for the security group."
+      }
+    }
+  },
+  "aws-native:ec2:SecurityGroupEgress": {
+    "cfTypeName": "AWS::EC2::SecurityGroupEgress",
+    "properties": {
+      "cidrIp": {
+        "type": "string",
+        "description": "The IPv4 address range, in CIDR format.\n You must specify a destination security group (``DestinationPrefixListId`` or ``DestinationSecurityGroupId``) or a CIDR range (``CidrIp`` or ``CidrIpv6``).\n For examples of rules that you can add to security groups for specific access scenarios, see [Security group rules for different use cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html) in the *User Guide*."
+      },
+      "cidrIpv6": {
+        "type": "string",
+        "description": "The IPv6 address range, in CIDR format.\n You must specify a destination security group (``DestinationPrefixListId`` or ``DestinationSecurityGroupId``) or a CIDR range (``CidrIp`` or ``CidrIpv6``).\n For examples of rules that you can add to security groups for specific access scenarios, see [Security group rules for different use cases](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/security-group-rules-reference.html) in the *User Guide*."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of an egress (outbound) security group rule.\n Constraints: Up to 255 characters in length. Allowed characters are a-z, A-Z, 0-9, spaces, and ._-:/()#,@[]+=;{}!$*"
+      },
+      "destinationPrefixListId": {
+        "type": "string",
+        "description": "The prefix list IDs for an AWS service. This is the AWS service that you want to access through a VPC endpoint from instances associated with the security group.\n You must specify a destination security group (``DestinationPrefixListId`` or ``DestinationSecurityGroupId``) or a CIDR range (``CidrIp`` or ``CidrIpv6``)."
+      },
+      "destinationSecurityGroupId": {
+        "type": "string",
+        "description": "The ID of the security group.\n You must specify a destination security group (``DestinationPrefixListId`` or ``DestinationSecurityGroupId``) or a CIDR range (``CidrIp`` or ``CidrIpv6``)."
+      },
+      "fromPort": {
+        "type": "integer",
+        "description": "If the protocol is TCP or UDP, this is the start of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP type or -1 (all ICMP types)."
+      },
+      "groupId": {
+        "type": "string",
+        "description": "The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID."
+      },
+      "ipProtocol": {
+        "type": "string",
+        "description": "The IP protocol name (``tcp``, ``udp``, ``icmp``, ``icmpv6``) or number (see [Protocol Numbers](https://docs.aws.amazon.com/http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).\n Use ``-1`` to specify all protocols. When authorizing security group rules, specifying ``-1`` or a protocol number other than ``tcp``, ``udp``, ``icmp``, or ``icmpv6`` allows traffic on all ports, regardless of any port range you specify. For ``tcp``, ``udp``, and ``icmp``, you must specify a port range. For ``icmpv6``, the port range is optional; if you omit the port range, traffic for all types and codes is allowed."
+      },
+      "toPort": {
+        "type": "integer",
+        "description": "If the protocol is TCP or UDP, this is the end of the port range. If the protocol is ICMP or ICMPv6, this is the ICMP code or -1 (all ICMP codes). If the start port is -1 (all ICMP types), then the end port must be -1 (all ICMP codes)."
+      }
+    }
+  },
+  "aws-native:ec2:SecurityGroupIngress": {
+    "cfTypeName": "AWS::EC2::SecurityGroupIngress",
+    "properties": {
+      "cidrIp": {
+        "type": "string",
+        "description": "The IPv4 ranges"
+      },
+      "cidrIpv6": {
+        "type": "string",
+        "description": "[VPC only] The IPv6 ranges"
+      },
+      "description": {
+        "type": "string",
+        "description": "Updates the description of an ingress (inbound) security group rule. You can replace an existing description, or add a description to a rule that did not have one previously"
+      },
+      "fromPort": {
+        "type": "integer",
+        "description": "The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number. A value of -1 indicates all ICMP/ICMPv6 types. If you specify all ICMP/ICMPv6 types, you must specify all codes.\n\nUse this for ICMP and any protocol that uses ports."
+      },
+      "groupId": {
+        "type": "string",
+        "description": "The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID.\n\nYou must specify the GroupName property or the GroupId property. For security groups that are in a VPC, you must use the GroupId property."
+      },
+      "groupName": {
+        "type": "string",
+        "description": "The name of the security group."
+      },
+      "ipProtocol": {
+        "type": "string",
+        "description": "The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers).\n\n[VPC only] Use -1 to specify all protocols. When authorizing security group rules, specifying -1 or a protocol number other than tcp, udp, icmp, or icmpv6 allows traffic on all ports, regardless of any port range you specify. For tcp, udp, and icmp, you must specify a port range. For icmpv6, the port range is optional; if you omit the port range, traffic for all types and codes is allowed."
+      },
+      "sourcePrefixListId": {
+        "type": "string",
+        "description": "[EC2-VPC only] The ID of a prefix list.\n\n"
+      },
+      "sourceSecurityGroupId": {
+        "type": "string",
+        "description": "The ID of the security group. You must specify either the security group ID or the security group name. For security groups in a nondefault VPC, you must specify the security group ID."
+      },
+      "sourceSecurityGroupName": {
+        "type": "string",
+        "description": "[EC2-Classic, default VPC] The name of the source security group.\n\nYou must specify the GroupName property or the GroupId property. For security groups that are in a VPC, you must use the GroupId property."
+      },
+      "sourceSecurityGroupOwnerId": {
+        "type": "string",
+        "description": "[nondefault VPC] The AWS account ID that owns the source security group. You can't specify this property with an IP address range.\n\nIf you specify SourceSecurityGroupName or SourceSecurityGroupId and that security group is owned by a different account than the account creating the stack, you must specify the SourceSecurityGroupOwnerId; otherwise, this property is optional."
+      },
+      "toPort": {
+        "type": "integer",
+        "description": "The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A value of -1 indicates all ICMP/ICMPv6 codes for the specified ICMP type. If you specify all ICMP/ICMPv6 types, you must specify all codes.\n\nUse this for ICMP and any protocol that uses ports."
+      }
+    }
+  },
+  "aws-native:ec2:SnapshotBlockPublicAccess": {
+    "cfTypeName": "AWS::EC2::SnapshotBlockPublicAccess",
+    "properties": {
+      "state": {
+        "$ref": "#/types/aws-native:ec2:SnapshotBlockPublicAccessState",
+        "description": "The state of EBS Snapshot Block Public Access."
+      }
+    }
+  },
+  "aws-native:ec2:SpotFleet": {
+    "cfTypeName": "AWS::EC2::SpotFleet",
+    "properties": {
+      "spotFleetRequestConfigData": {
+        "$ref": "#/types/aws-native:ec2:SpotFleetRequestConfigData"
+      }
+    }
+  },
+  "aws-native:ec2:Subnet": {
+    "cfTypeName": "AWS::EC2::Subnet",
+    "properties": {
+      "assignIpv6AddressOnCreation": {
+        "type": "boolean",
+        "description": "Indicates whether a network interface created in this subnet receives an IPv6 address. The default value is ``false``.\n If you specify ``AssignIpv6AddressOnCreation``, you must also specify an IPv6 CIDR block."
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The Availability Zone of the subnet.\n If you update this property, you must also update the ``CidrBlock`` property."
+      },
+      "availabilityZoneId": {
+        "type": "string",
+        "description": "The AZ ID of the subnet."
+      },
+      "cidrBlock": {
+        "type": "string",
+        "description": "The IPv4 CIDR block assigned to the subnet.\n If you update this property, we create a new subnet, and then delete the existing one."
+      },
+      "enableDns64": {
+        "type": "boolean",
+        "description": "Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations. For more information, see [DNS64 and NAT64](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html#nat-gateway-nat64-dns64) in the *User Guide*."
+      },
+      "ipv4IpamPoolId": {
+        "type": "string",
+        "description": "An IPv4 IPAM pool ID for the subnet."
+      },
+      "ipv4NetmaskLength": {
+        "type": "integer",
+        "description": "An IPv4 netmask length for the subnet."
+      },
+      "ipv6CidrBlock": {
+        "type": "string",
+        "description": "The IPv6 CIDR block.\n If you specify ``AssignIpv6AddressOnCreation``, you must also specify an IPv6 CIDR block."
+      },
+      "ipv6CidrBlocks": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IPv6 network ranges for the subnet, in CIDR notation."
+      },
+      "ipv6IpamPoolId": {
+        "type": "string",
+        "description": "An IPv6 IPAM pool ID for the subnet."
+      },
+      "ipv6Native": {
+        "type": "boolean",
+        "description": "Indicates whether this is an IPv6 only subnet. For more information, see [Subnet basics](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#subnet-basics) in the *User Guide*."
+      },
+      "ipv6NetmaskLength": {
+        "type": "integer",
+        "description": "An IPv6 netmask length for the subnet."
+      },
+      "mapPublicIpOnLaunch": {
+        "type": "boolean",
+        "description": "Indicates whether instances launched in this subnet receive a public IPv4 address. The default value is ``false``.\n AWS charges for all public IPv4 addresses, including public IPv4 addresses associated with running instances and Elastic IP addresses. For more information, see the *Public IPv4 Address* tab on the [VPC pricing page](https://docs.aws.amazon.com/vpc/pricing/)."
+      },
+      "outpostArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Outpost."
+      },
+      "privateDnsNameOptionsOnLaunch": {
+        "$ref": "#/types/aws-native:ec2:PrivateDnsNameOptionsOnLaunchProperties",
+        "description": "The hostname type for EC2 instances launched into this subnet and how DNS A and AAAA record queries to the instances should be handled. For more information, see [Amazon EC2 instance hostname types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-naming.html) in the *User Guide*.\n Available options:\n  + EnableResourceNameDnsAAAARecord (true | false)\n + EnableResourceNameDnsARecord (true | false)\n + HostnameType (ip-name | resource-name)"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the subnet."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC the subnet is in.\n If you update this property, you must also update the ``CidrBlock`` property."
+      }
+    }
+  },
+  "aws-native:ec2:SubnetCidrBlock": {
+    "cfTypeName": "AWS::EC2::SubnetCidrBlock",
+    "properties": {
+      "ipv6CidrBlock": {
+        "type": "string",
+        "description": "The IPv6 network range for the subnet, in CIDR notation. The subnet size must use a /64 prefix length"
+      },
+      "ipv6IpamPoolId": {
+        "type": "string",
+        "description": "The ID of an IPv6 Amazon VPC IP Address Manager (IPAM) pool from which to allocate, to get the subnet's CIDR"
+      },
+      "ipv6NetmaskLength": {
+        "type": "integer",
+        "description": "The netmask length of the IPv6 CIDR to allocate to the subnet from an IPAM pool"
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet"
+      }
+    }
+  },
+  "aws-native:ec2:SubnetNetworkAclAssociation": {
+    "cfTypeName": "AWS::EC2::SubnetNetworkAclAssociation",
+    "properties": {
+      "networkAclId": {
+        "type": "string",
+        "description": "The ID of the network ACL"
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet"
+      }
+    }
+  },
+  "aws-native:ec2:SubnetRouteTableAssociation": {
+    "cfTypeName": "AWS::EC2::SubnetRouteTableAssociation",
+    "properties": {
+      "routeTableId": {
+        "type": "string",
+        "description": "The ID of the route table.\n The physical ID changes when the route table ID is changed."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGateway": {
+    "cfTypeName": "AWS::EC2::TransitGateway",
+    "properties": {
+      "amazonSideAsn": {
+        "type": "integer"
+      },
+      "associationDefaultRouteTableId": {
+        "type": "string"
+      },
+      "autoAcceptSharedAttachments": {
+        "type": "string"
+      },
+      "defaultRouteTableAssociation": {
+        "type": "string"
+      },
+      "defaultRouteTablePropagation": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "dnsSupport": {
+        "type": "string"
+      },
+      "multicastSupport": {
+        "type": "string"
+      },
+      "propagationDefaultRouteTableId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "transitGatewayCidrBlocks": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "vpnEcmpSupport": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayAttachment": {
+    "cfTypeName": "AWS::EC2::TransitGatewayAttachment",
+    "properties": {
+      "options": {
+        "$ref": "#/types/aws-native:ec2:OptionsProperties",
+        "description": "The options for the transit gateway vpc attachment."
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "transitGatewayId": {
+        "type": "string"
+      },
+      "vpcId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayConnect": {
+    "cfTypeName": "AWS::EC2::TransitGatewayConnect",
+    "properties": {
+      "options": {
+        "$ref": "#/types/aws-native:ec2:TransitGatewayConnectOptions",
+        "description": "The Connect attachment options."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the attachment."
+      },
+      "transportTransitGatewayAttachmentId": {
+        "type": "string",
+        "description": "The ID of the attachment from which the Connect attachment was created."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayMulticastDomain": {
+    "cfTypeName": "AWS::EC2::TransitGatewayMulticastDomain",
+    "properties": {
+      "options": {
+        "$ref": "#/types/aws-native:ec2:OptionsProperties",
+        "description": "The options for the transit gateway multicast domain."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the transit gateway multicast domain."
+      },
+      "transitGatewayId": {
+        "type": "string",
+        "description": "The ID of the transit gateway."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayMulticastDomainAssociation": {
+    "cfTypeName": "AWS::EC2::TransitGatewayMulticastDomainAssociation",
+    "properties": {
+      "subnetId": {
+        "type": "string",
+        "description": "The IDs of the subnets to associate with the transit gateway multicast domain."
+      },
+      "transitGatewayAttachmentId": {
+        "type": "string",
+        "description": "The ID of the transit gateway attachment."
+      },
+      "transitGatewayMulticastDomainId": {
+        "type": "string",
+        "description": "The ID of the transit gateway multicast domain."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayMulticastGroupMember": {
+    "cfTypeName": "AWS::EC2::TransitGatewayMulticastGroupMember",
+    "properties": {
+      "groupIpAddress": {
+        "type": "string",
+        "description": "The IP address assigned to the transit gateway multicast group."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of the transit gateway attachment."
+      },
+      "transitGatewayMulticastDomainId": {
+        "type": "string",
+        "description": "The ID of the transit gateway multicast domain."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayMulticastGroupSource": {
+    "cfTypeName": "AWS::EC2::TransitGatewayMulticastGroupSource",
+    "properties": {
+      "groupIpAddress": {
+        "type": "string",
+        "description": "The IP address assigned to the transit gateway multicast group."
+      },
+      "networkInterfaceId": {
+        "type": "string",
+        "description": "The ID of the transit gateway attachment."
+      },
+      "transitGatewayMulticastDomainId": {
+        "type": "string",
+        "description": "The ID of the transit gateway multicast domain."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayPeeringAttachment": {
+    "cfTypeName": "AWS::EC2::TransitGatewayPeeringAttachment",
+    "properties": {
+      "peerAccountId": {
+        "type": "string",
+        "description": "The ID of the peer account"
+      },
+      "peerRegion": {
+        "type": "string",
+        "description": "Peer Region"
+      },
+      "peerTransitGatewayId": {
+        "type": "string",
+        "description": "The ID of the peer transit gateway."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the transit gateway peering attachment."
+      },
+      "transitGatewayId": {
+        "type": "string",
+        "description": "The ID of the transit gateway."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayRouteTable": {
+    "cfTypeName": "AWS::EC2::TransitGatewayRouteTable",
+    "properties": {
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "Tags are composed of a Key/Value pair. You can use tags to categorize and track each parameter group. The tag value null is permitted."
+      },
+      "transitGatewayId": {
+        "type": "string",
+        "description": "The ID of the transit gateway."
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayRouteTableAssociation": {
+    "cfTypeName": "AWS::EC2::TransitGatewayRouteTableAssociation",
+    "properties": {
+      "transitGatewayAttachmentId": {
+        "type": "string"
+      },
+      "transitGatewayRouteTableId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:TransitGatewayVpcAttachment": {
+    "cfTypeName": "AWS::EC2::TransitGatewayVpcAttachment",
+    "properties": {
+      "addSubnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "options": {
+        "$ref": "#/types/aws-native:ec2:OptionsProperties",
+        "description": "The options for the transit gateway vpc attachment."
+      },
+      "removeSubnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "transitGatewayId": {
+        "type": "string"
+      },
+      "vpcId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:VerifiedAccessEndpoint": {
+    "cfTypeName": "AWS::EC2::VerifiedAccessEndpoint",
+    "properties": {
+      "applicationDomain": {
+        "type": "string",
+        "description": "The DNS name for users to reach your application."
+      },
+      "attachmentType": {
+        "type": "string",
+        "description": "The type of attachment used to provide connectivity between the AWS Verified Access endpoint and the application."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description for the AWS Verified Access endpoint."
+      },
+      "domainCertificateArn": {
+        "type": "string",
+        "description": "The ARN of a public TLS/SSL certificate imported into or created with ACM."
+      },
+      "endpointDomainPrefix": {
+        "type": "string",
+        "description": "A custom identifier that gets prepended to a DNS name that is generated for the endpoint."
+      },
+      "endpointType": {
+        "type": "string",
+        "description": "The type of AWS Verified Access endpoint. Incoming application requests will be sent to an IP address, load balancer or a network interface depending on the endpoint type specified.The type of AWS Verified Access endpoint. Incoming application requests will be sent to an IP address, load balancer or a network interface depending on the endpoint type specified."
+      },
+      "loadBalancerOptions": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessEndpointLoadBalancerOptions",
+        "description": "The load balancer details if creating the AWS Verified Access endpoint as load-balancer type."
+      },
+      "networkInterfaceOptions": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessEndpointNetworkInterfaceOptions",
+        "description": "The options for network-interface type endpoint."
+      },
+      "policyDocument": {
+        "type": "string",
+        "description": "The AWS Verified Access policy document."
+      },
+      "policyEnabled": {
+        "type": "boolean",
+        "description": "The status of the Verified Access policy."
+      },
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the security groups for the endpoint."
+      },
+      "sseSpecification": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessEndpointSseSpecification",
+        "description": "The configuration options for customer provided KMS encryption."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "verifiedAccessGroupId": {
+        "type": "string",
+        "description": "The ID of the AWS Verified Access group."
+      }
+    }
+  },
+  "aws-native:ec2:VerifiedAccessGroup": {
+    "cfTypeName": "AWS::EC2::VerifiedAccessGroup",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description for the AWS Verified Access group."
+      },
+      "policyDocument": {
+        "type": "string",
+        "description": "The AWS Verified Access policy document."
+      },
+      "policyEnabled": {
+        "type": "boolean",
+        "description": "The status of the Verified Access policy."
+      },
+      "sseSpecification": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessGroupSseSpecification",
+        "description": "The configuration options for customer provided KMS encryption."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "verifiedAccessInstanceId": {
+        "type": "string",
+        "description": "The ID of the AWS Verified Access instance."
+      }
+    }
+  },
+  "aws-native:ec2:VerifiedAccessInstance": {
+    "cfTypeName": "AWS::EC2::VerifiedAccessInstance",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description for the AWS Verified Access instance."
+      },
+      "fipsEnabled": {
+        "type": "boolean",
+        "description": "Indicates whether FIPS is enabled"
+      },
+      "loggingConfigurations": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessInstanceVerifiedAccessLogs",
+        "description": "The configuration options for AWS Verified Access instances."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "verifiedAccessTrustProviderIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the AWS Verified Access trust providers."
+      },
+      "verifiedAccessTrustProviders": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:VerifiedAccessInstanceVerifiedAccessTrustProvider"
+        },
+        "description": "AWS Verified Access trust providers."
+      }
+    }
+  },
+  "aws-native:ec2:VerifiedAccessTrustProvider": {
+    "cfTypeName": "AWS::EC2::VerifiedAccessTrustProvider",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description for the Amazon Web Services Verified Access trust provider."
+      },
+      "deviceOptions": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessTrustProviderDeviceOptions"
+      },
+      "deviceTrustProviderType": {
+        "type": "string",
+        "description": "The type of device-based trust provider. Possible values: jamf|crowdstrike"
+      },
+      "oidcOptions": {
+        "$ref": "#/types/aws-native:ec2:VerifiedAccessTrustProviderOidcOptions"
+      },
+      "policyReferenceName": {
+        "type": "string",
+        "description": "The identifier to be used when working with policy rules."
+      },
+      "sseSpecification": {
+        "$ref": "#/types/aws-native:ec2:SseSpecificationProperties",
+        "description": "The configuration options for customer provided KMS encryption."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "trustProviderType": {
+        "type": "string",
+        "description": "Type of trust provider. Possible values: user|device"
+      },
+      "userTrustProviderType": {
+        "type": "string",
+        "description": "The type of device-based trust provider. Possible values: oidc|iam-identity-center"
+      }
+    }
+  },
+  "aws-native:ec2:Volume": {
+    "cfTypeName": "AWS::EC2::Volume",
+    "properties": {
+      "autoEnableIo": {
+        "type": "boolean",
+        "description": "Indicates whether the volume is auto-enabled for I/O operations. By default, Amazon EBS disables I/O to the volume from attached EC2 instances when it determines that a volume's data is potentially inconsistent. If the consistency of the volume is not a concern, and you prefer that the volume be made available immediately if it's impaired, you can configure the volume to automatically enable I/O."
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The ID of the Availability Zone in which to create the volume. For example, ``us-east-1a``."
+      },
+      "encrypted": {
+        "type": "boolean",
+        "description": "Indicates whether the volume should be encrypted. The effect of setting the encryption state to ``true`` depends on the volume origin (new or from a snapshot), starting encryption state, ownership, and whether encryption by default is enabled. For more information, see [Encryption by default](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default) in the *Amazon Elastic Compute Cloud User Guide*.\n Encrypted Amazon EBS volumes must be attached to instances that support Amazon EBS encryption. For more information, see [Supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances)."
+      },
+      "iops": {
+        "type": "integer",
+        "description": "The number of I/O operations per second (IOPS). For ``gp3``, ``io1``, and ``io2`` volumes, this represents the number of IOPS that are provisioned for the volume. For ``gp2`` volumes, this represents the baseline performance of the volume and the rate at which the volume accumulates I/O credits for bursting.\n The following are the supported values for each volume type:\n  +   ``gp3``: 3,000 - 16,000 IOPS\n  +   ``io1``: 100 - 64,000 IOPS\n  +   ``io2``: 100 - 256,000 IOPS\n  \n For ``io2`` volumes, you can achieve up to 256,000 IOPS on [instances built on the Nitro System](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances). On other instances, you can achieve performance up to 32,000 IOPS.\n This parameter is required for ``io1`` and ``io2`` volumes. The default for ``gp3`` volumes is 3,000 IOPS. This parameter is not supported for ``gp2``, ``st1``, ``sc1``, or ``standard`` volumes."
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The identifier of the kms-key-long to use for Amazon EBS encryption. If ``KmsKeyId`` is specified, the encrypted state must be ``true``.\n If you omit this property and your account is enabled for encryption by default, or *Encrypted* is set to ``true``, then the volume is encrypted using the default key specified for your account. If your account does not have a default key, then the volume is encrypted using the aws-managed-key.\n Alternatively, if you want to specify a different key, you can specify one of the following:\n  +  Key ID. For example, 1234abcd-12ab-34cd-56ef-1234567890ab.\n  +  Key alias. Specify the alias for the key, prefixed with ``alias/``. For example, for a key with the alias ``my_cmk``, use ``alias/my_cmk``. Or to specify the aws-managed-key, use ``alias/aws/ebs``.\n  +  Key ARN. For example, arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab.\n  +  Alias ARN. For example, arn:aws:kms:us-east-1:012345678910:alias/ExampleAlias."
+      },
+      "multiAttachEnabled": {
+        "type": "boolean",
+        "description": "Indicates whether Amazon EBS Multi-Attach is enabled.\n CFNlong does not currently support updating a single-attach volume to be multi-attach enabled, updating a multi-attach enabled volume to be single-attach, or updating the size or number of I/O operations per second (IOPS) of a multi-attach enabled volume."
+      },
+      "outpostArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Outpost."
+      },
+      "size": {
+        "type": "integer",
+        "description": "The size of the volume, in GiBs. You must specify either a snapshot ID or a volume size. If you specify a snapshot, the default is the snapshot size. You can specify a volume size that is equal to or larger than the snapshot size.\n The following are the supported volumes sizes for each volume type:\n  +   ``gp2`` and ``gp3``: 1 - 16,384 GiB\n  +   ``io1``: 4 - 16,384 GiB\n  +   ``io2``: 4 - 65,536 GiB\n  +   ``st1`` and ``sc1``: 125 - 16,384 GiB\n  +   ``standard``: 1 - 1024 GiB"
+      },
+      "snapshotId": {
+        "type": "string",
+        "description": "The snapshot from which to create the volume. You must specify either a snapshot ID or a volume size."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags to apply to the volume during creation."
+      },
+      "throughput": {
+        "type": "integer",
+        "description": "The throughput to provision for a volume, with a maximum of 1,000 MiB/s.\n This parameter is valid only for ``gp3`` volumes. The default value is 125.\n Valid Range: Minimum value of 125. Maximum value of 1000."
+      },
+      "volumeType": {
+        "type": "string",
+        "description": "The volume type. This parameter can be one of the following values:\n  +  General Purpose SSD: ``gp2`` | ``gp3`` \n  +  Provisioned IOPS SSD: ``io1`` | ``io2`` \n  +  Throughput Optimized HDD: ``st1`` \n  +  Cold HDD: ``sc1`` \n  +  Magnetic: ``standard`` \n  \n For more information, see [Amazon EBS volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html) in the *Amazon Elastic Compute Cloud User Guide*.\n Default: ``gp2``"
+      }
+    }
+  },
+  "aws-native:ec2:VolumeAttachment": {
+    "cfTypeName": "AWS::EC2::VolumeAttachment",
+    "properties": {
+      "device": {
+        "type": "string",
+        "description": "The device name (for example, ``/dev/sdh`` or ``xvdh``)."
+      },
+      "instanceId": {
+        "type": "string",
+        "description": "The ID of the instance to which the volume attaches. This value can be a reference to an [AWS::EC2::Instance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html) resource, or it can be the physical ID of an existing EC2 instance."
+      },
+      "volumeId": {
+        "type": "string",
+        "description": "The ID of the Amazon EBS volume. The volume and instance must be within the same Availability Zone. This value can be a reference to an [AWS::EC2::Volume](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html) resource, or it can be the volume ID of an existing Amazon EBS volume."
+      }
+    }
+  },
+  "aws-native:ec2:Vpc": {
+    "cfTypeName": "AWS::EC2::VPC",
+    "properties": {
+      "cidrBlock": {
+        "type": "string",
+        "description": "The IPv4 network range for the VPC, in CIDR notation. For example, ``10.0.0.0/16``. We modify the specified CIDR block to its canonical form; for example, if you specify ``100.68.0.18/18``, we modify it to ``100.68.0.0/18``.\n You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``."
+      },
+      "enableDnsHostnames": {
+        "type": "boolean",
+        "description": "Indicates whether the instances launched in the VPC get DNS hostnames. If enabled, instances in the VPC get DNS hostnames; otherwise, they do not. Disabled by default for nondefault VPCs. For more information, see [DNS attributes in your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support).\n You can only enable DNS hostnames if you've enabled DNS support."
+      },
+      "enableDnsSupport": {
+        "type": "boolean",
+        "description": "Indicates whether the DNS resolution is supported for the VPC. If enabled, queries to the Amazon provided DNS server at the 169.254.169.253 IP address, or the reserved IP address at the base of the VPC network range \"plus two\" succeed. If disabled, the Amazon provided DNS service in the VPC that resolves public DNS hostnames to IP addresses is not enabled. Enabled by default. For more information, see [DNS attributes in your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support)."
+      },
+      "instanceTenancy": {
+        "type": "string",
+        "description": "The allowed tenancy of instances launched into the VPC.\n  +  ``default``: An instance launched into the VPC runs on shared hardware by default, unless you explicitly specify a different tenancy during instance launch.\n  +  ``dedicated``: An instance launched into the VPC runs on dedicated hardware by default, unless you explicitly specify a tenancy of ``host`` during instance launch. You cannot specify a tenancy of ``default`` during instance launch.\n  \n Updating ``InstanceTenancy`` requires no replacement only if you are updating its value from ``dedicated`` to ``default``. Updating ``InstanceTenancy`` from ``default`` to ``dedicated`` requires replacement."
+      },
+      "ipv4IpamPoolId": {
+        "type": "string",
+        "description": "The ID of an IPv4 IPAM pool you want to use for allocating this VPC's CIDR. For more information, see [What is IPAM?](https://docs.aws.amazon.com//vpc/latest/ipam/what-is-it-ipam.html) in the *Amazon VPC IPAM User Guide*.\n You must specify either``CidrBlock`` or ``Ipv4IpamPoolId``."
+      },
+      "ipv4NetmaskLength": {
+        "type": "integer",
+        "description": "The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Amazon VPC IP Address Manager (IPAM) pool. For more information about IPAM, see [What is IPAM?](https://docs.aws.amazon.com//vpc/latest/ipam/what-is-it-ipam.html) in the *Amazon VPC IPAM User Guide*."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:VpcCidrBlock": {
+    "cfTypeName": "AWS::EC2::VPCCidrBlock",
+    "properties": {
+      "amazonProvidedIpv6CidrBlock": {
+        "type": "boolean",
+        "description": "Requests an Amazon-provided IPv6 CIDR block with a /56 prefix length for the VPC. You cannot specify the range of IPv6 addresses, or the size of the CIDR block."
+      },
+      "cidrBlock": {
+        "type": "string",
+        "description": "An IPv4 CIDR block to associate with the VPC."
+      },
+      "ipv4IpamPoolId": {
+        "type": "string",
+        "description": "The ID of the IPv4 IPAM pool to Associate a CIDR from to a VPC."
+      },
+      "ipv4NetmaskLength": {
+        "type": "integer",
+        "description": "The netmask length of the IPv4 CIDR you would like to associate from an Amazon VPC IP Address Manager (IPAM) pool."
+      },
+      "ipv6CidrBlock": {
+        "type": "string",
+        "description": "An IPv6 CIDR block from the IPv6 address pool."
+      },
+      "ipv6IpamPoolId": {
+        "type": "string",
+        "description": "The ID of the IPv6 IPAM pool to Associate a CIDR from to a VPC."
+      },
+      "ipv6NetmaskLength": {
+        "type": "integer",
+        "description": "The netmask length of the IPv6 CIDR you would like to associate from an Amazon VPC IP Address Manager (IPAM) pool."
+      },
+      "ipv6Pool": {
+        "type": "string",
+        "description": "The ID of an IPv6 address pool from which to allocate the IPv6 CIDR block."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:VpcEndpoint": {
+    "cfTypeName": "AWS::EC2::VPCEndpoint",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "An endpoint policy, which controls access to the service from the VPC. The default endpoint policy allows full access to the service. Endpoint policies are supported only for gateway and interface endpoints.\n For CloudFormation templates in YAML, you can provide the policy in JSON or YAML format. CFNlong converts YAML policies to JSON format before calling the API to create or modify the VPC endpoint.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::EC2::VPCEndpoint` for more information about the expected schema for this property."
+      },
+      "privateDnsEnabled": {
+        "type": "boolean",
+        "description": "Indicate whether to associate a private hosted zone with the specified VPC. The private hosted zone contains a record set for the default public DNS name for the service for the Region (for example, ``kinesis.us-east-1.amazonaws.com``), which resolves to the private IP addresses of the endpoint network interfaces in the VPC. This enables you to make requests to the default public DNS name for the service instead of the public DNS names that are automatically generated by the VPC endpoint service.\n To use a private hosted zone, you must set the following VPC attributes to ``true``: ``enableDnsHostnames`` and ``enableDnsSupport``.\n This property is supported only for interface endpoints.\n Default: ``false``"
+      },
+      "routeTableIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the route tables. Routing is supported only for gateway endpoints."
+      },
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the security groups to associate with the endpoint network interfaces. If this parameter is not specified, we use the default security group for the VPC. Security groups are supported only for interface endpoints."
+      },
+      "serviceName": {
+        "type": "string",
+        "description": "The name of the endpoint service."
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IDs of the subnets in which to create endpoint network interfaces. You must specify this property for an interface endpoint or a Gateway Load Balancer endpoint. You can't specify this property for a gateway endpoint. For a Gateway Load Balancer endpoint, you can specify only one subnet."
+      },
+      "vpcEndpointType": {
+        "$ref": "#/types/aws-native:ec2:VpcEndpointType",
+        "description": "The type of endpoint.\n Default: Gateway"
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:VpcEndpointConnectionNotification": {
+    "cfTypeName": "AWS::EC2::VPCEndpointConnectionNotification",
+    "properties": {
+      "connectionEvents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The endpoint events for which to receive notifications."
+      },
+      "connectionNotificationArn": {
+        "type": "string",
+        "description": "The ARN of the SNS topic for the notifications."
+      },
+      "serviceId": {
+        "type": "string",
+        "description": "The ID of the endpoint service."
+      },
+      "vpcEndpointId": {
+        "type": "string",
+        "description": "The ID of the endpoint."
+      }
+    }
+  },
+  "aws-native:ec2:VpcEndpointService": {
+    "cfTypeName": "AWS::EC2::VPCEndpointService",
+    "properties": {
+      "acceptanceRequired": {
+        "type": "boolean"
+      },
+      "contributorInsightsEnabled": {
+        "type": "boolean"
+      },
+      "gatewayLoadBalancerArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "networkLoadBalancerArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "payerResponsibility": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:VpcEndpointServicePermissions": {
+    "cfTypeName": "AWS::EC2::VPCEndpointServicePermissions",
+    "properties": {
+      "allowedPrincipals": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "serviceId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ec2:VpcGatewayAttachment": {
+    "cfTypeName": "AWS::EC2::VPCGatewayAttachment",
+    "properties": {
+      "internetGatewayId": {
+        "type": "string",
+        "description": "The ID of the internet gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      },
+      "vpnGatewayId": {
+        "type": "string",
+        "description": "The ID of the virtual private gateway. You must specify either InternetGatewayId or VpnGatewayId, but not both."
+      }
+    }
+  },
+  "aws-native:ec2:VpcPeeringConnection": {
+    "cfTypeName": "AWS::EC2::VPCPeeringConnection",
+    "properties": {
+      "peerOwnerId": {
+        "type": "string",
+        "description": "The AWS account ID of the owner of the accepter VPC."
+      },
+      "peerRegion": {
+        "type": "string",
+        "description": "The Region code for the accepter VPC, if the accepter VPC is located in a Region other than the Region in which you make the request."
+      },
+      "peerRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the VPC peer role for the peering connection in another AWS account."
+      },
+      "peerVpcId": {
+        "type": "string",
+        "description": "The ID of the VPC with which you are creating the VPC peering connection. You must specify this parameter in the request."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:VpcdhcpOptionsAssociation": {
+    "cfTypeName": "AWS::EC2::VPCDHCPOptionsAssociation",
+    "properties": {
+      "dhcpOptionsId": {
+        "type": "string",
+        "description": "The ID of the DHCP options set, or default to associate no DHCP options with the VPC."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The ID of the VPC."
+      }
+    }
+  },
+  "aws-native:ec2:VpnConnection": {
+    "cfTypeName": "AWS::EC2::VPNConnection",
+    "properties": {
+      "customerGatewayId": {
+        "type": "string",
+        "description": "The ID of the customer gateway at your end of the VPN connection."
+      },
+      "staticRoutesOnly": {
+        "type": "boolean",
+        "description": "Indicates whether the VPN connection uses static routes only."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the VPN connection."
+      },
+      "transitGatewayId": {
+        "type": "string",
+        "description": "The ID of the transit gateway associated with the VPN connection."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of VPN connection."
+      },
+      "vpnGatewayId": {
+        "type": "string",
+        "description": "The ID of the virtual private gateway at the AWS side of the VPN connection."
+      },
+      "vpnTunnelOptionsSpecifications": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ec2:VpnConnectionVpnTunnelOptionsSpecification"
+        },
+        "description": "The tunnel options for the VPN connection."
+      }
+    }
+  },
+  "aws-native:ec2:VpnConnectionRoute": {
+    "cfTypeName": "AWS::EC2::VPNConnectionRoute",
+    "properties": {
+      "destinationCidrBlock": {
+        "type": "string",
+        "description": "The CIDR block associated with the local subnet of the customer network."
+      },
+      "vpnConnectionId": {
+        "type": "string",
+        "description": "The ID of the VPN connection."
+      }
+    }
+  },
+  "aws-native:ec2:VpnGateway": {
+    "cfTypeName": "AWS::EC2::VPNGateway",
+    "properties": {
+      "amazonSideAsn": {
+        "type": "integer",
+        "description": "The private Autonomous System Number (ASN) for the Amazon side of a BGP session."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Any tags assigned to the virtual private gateway."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of VPN connection the virtual private gateway supports."
+      }
+    }
+  },
+  "aws-native:ecr:PullThroughCacheRule": {
+    "cfTypeName": "AWS::ECR::PullThroughCacheRule",
+    "properties": {
+      "credentialArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the AWS Secrets Manager secret that identifies the credentials to authenticate to the upstream registry."
+      },
+      "ecrRepositoryPrefix": {
+        "type": "string",
+        "description": "The ECRRepositoryPrefix is a custom alias for upstream registry url."
+      },
+      "upstreamRegistry": {
+        "type": "string",
+        "description": "The name of the upstream registry."
+      },
+      "upstreamRegistryUrl": {
+        "type": "string",
+        "description": "The upstreamRegistryUrl is the endpoint of upstream registry url of the public repository to be cached"
+      }
+    }
+  },
+  "aws-native:ecr:RegistryPolicy": {
+    "cfTypeName": "AWS::ECR::RegistryPolicy",
+    "properties": {
+      "policyText": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The JSON policy text for your registry.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::ECR::RegistryPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:ecr:ReplicationConfiguration": {
+    "cfTypeName": "AWS::ECR::ReplicationConfiguration",
+    "properties": {
+      "replicationConfiguration": {
+        "$ref": "#/types/aws-native:ecr:ReplicationConfiguration",
+        "language": {
+          "csharp": {
+            "name": "ReplicationConfigurationValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:ecs:ClusterCapacityProviderAssociations": {
+    "cfTypeName": "AWS::ECS::ClusterCapacityProviderAssociations",
+    "properties": {
+      "capacityProviders": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/types/aws-native:ecs:ClusterCapacityProviderAssociationsCapacityProvider"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "cluster": {
+        "type": "string"
+      },
+      "defaultCapacityProviderStrategy": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:ClusterCapacityProviderAssociationsCapacityProviderStrategy"
+        }
+      }
+    }
+  },
+  "aws-native:ecs:PrimaryTaskSet": {
+    "cfTypeName": "AWS::ECS::PrimaryTaskSet",
+    "properties": {
+      "cluster": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to create the task set in."
+      },
+      "service": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the service to create the task set in."
+      },
+      "taskSetId": {
+        "type": "string",
+        "description": "The ID or full Amazon Resource Name (ARN) of the task set."
+      }
+    }
+  },
+  "aws-native:ecs:TaskDefinition": {
+    "cfTypeName": "AWS::ECS::TaskDefinition",
+    "properties": {
+      "containerDefinitions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskDefinitionContainerDefinition"
+        },
+        "description": "A list of container definitions in JSON format that describe the different containers that make up your task. For more information about container definition parameters and defaults, see [Amazon ECS Task Definitions](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html) in the *Amazon Elastic Container Service Developer Guide*."
+      },
+      "cpu": {
+        "type": "string",
+        "description": "The number of ``cpu`` units used by the task. If you use the EC2 launch type, this field is optional. Any value can be used. If you use the Fargate launch type, this field is required. You must use one of the following values. The value that you choose determines your range of valid values for the ``memory`` parameter.\n The CPU units cannot be less than 1 vCPU when you use Windows containers on Fargate.\n  +  256 (.25 vCPU) - Available ``memory`` values: 512 (0.5 GB), 1024 (1 GB), 2048 (2 GB)\n  +  512 (.5 vCPU) - Available ``memory`` values: 1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB)\n  +  1024 (1 vCPU) - Available ``memory`` values: 2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB)\n  +  2048 (2 vCPU) - Available ``memory`` values: 4096 (4 GB) and 16384 (16 GB) in increments of 1024 (1 GB)\n  +  4096 (4 vCPU) - Available ``memory`` values: 8192 (8 GB) and 30720 (30 GB) in increments of 1024 (1 GB)\n  +  8192 (8 vCPU) - Available ``memory`` va"
+      },
+      "ephemeralStorage": {
+        "$ref": "#/types/aws-native:ecs:TaskDefinitionEphemeralStorage",
+        "description": "The ephemeral storage settings to use for tasks run with the task definition."
+      },
+      "executionRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the task execution role that grants the Amazon ECS container agent permission to make AWS API calls on your behalf. The task execution IAM role is required depending on the requirements of your task. For more information, see [Amazon ECS task execution IAM role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html) in the *Amazon Elastic Container Service Developer Guide*."
+      },
+      "family": {
+        "type": "string",
+        "description": "The name of a family that this task definition is registered to. Up to 255 letters (uppercase and lowercase), numbers, hyphens, and underscores are allowed.\n A family groups multiple versions of a task definition. Amazon ECS gives the first task definition that you registered to a family a revision number of 1. Amazon ECS gives sequential revision numbers to each task definition that you add.\n  To use revision numbers when you update a task definition, specify this property. If you don't specify a value, CFNlong generates a new task definition each time that you update it."
+      },
+      "inferenceAccelerators": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskDefinitionInferenceAccelerator"
+        },
+        "description": "The Elastic Inference accelerators to use for the containers in the task."
+      },
+      "ipcMode": {
+        "type": "string",
+        "description": "The IPC resource namespace to use for the containers in the task. The valid values are ``host``, ``task``, or ``none``. If ``host`` is specified, then all containers within the tasks that specified the ``host`` IPC mode on the same container instance share the same IPC resources with the host Amazon EC2 instance. If ``task`` is specified, all containers within the specified task share the same IPC resources. If ``none`` is specified, then IPC resources within the containers of a task are private and not shared with other containers in a task or on the container instance. If no value is specified, then the IPC resource namespace sharing depends on the Docker daemon setting on the container instance. For more information, see [IPC settings](https://docs.aws.amazon.com/https://docs.docker.com/engine/reference/run/#ipc-settings---ipc) in the *Docker run reference*.\n If the ``host`` IPC mode is used, be aware that there is a heightened risk of undesired IPC namespace expose. For more inform"
+      },
+      "memory": {
+        "type": "string",
+        "description": "The amount (in MiB) of memory used by the task.\n If your tasks runs on Amazon EC2 instances, you must specify either a task-level memory value or a container-level memory value. This field is optional and any value can be used. If a task-level memory value is specified, the container-level memory value is optional. For more information regarding container-level memory and memory reservation, see [ContainerDefinition](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html).\n If your tasks runs on FARGATElong, this field is required. You must use one of the following values. The value you choose determines your range of valid values for the ``cpu`` parameter.\n  +  512 (0.5 GB), 1024 (1 GB), 2048 (2 GB) - Available ``cpu`` values: 256 (.25 vCPU)\n  +  1024 (1 GB), 2048 (2 GB), 3072 (3 GB), 4096 (4 GB) - Available ``cpu`` values: 512 (.5 vCPU)\n  +  2048 (2 GB), 3072 (3 GB), 4096 (4 GB), 5120 (5 GB), 6144 (6 GB), 7168 (7 GB), 8192 (8 GB) - Available ``cpu`` va"
+      },
+      "networkMode": {
+        "type": "string",
+        "description": "The Docker networking mode to use for the containers in the task. The valid values are ``none``, ``bridge``, ``awsvpc``, and ``host``. If no network mode is specified, the default is ``bridge``.\n For Amazon ECS tasks on Fargate, the ``awsvpc`` network mode is required. For Amazon ECS tasks on Amazon EC2 Linux instances, any network mode can be used. For Amazon ECS tasks on Amazon EC2 Windows instances, ``\u003cdefault\u003e`` or ``awsvpc`` can be used. If the network mode is set to ``none``, you cannot specify port mappings in your container definitions, and the tasks containers do not have external connectivity. The ``host`` and ``awsvpc`` network modes offer the highest networking performance for containers because they use the EC2 network stack instead of the virtualized network stack provided by the ``bridge`` mode.\n With the ``host`` and ``awsvpc`` network modes, exposed container ports are mapped directly to the corresponding host port (for the ``host`` network mode) or the attached elasti"
+      },
+      "pidMode": {
+        "type": "string",
+        "description": "The process namespace to use for the containers in the task. The valid values are ``host`` or ``task``. On Fargate for Linux containers, the only valid value is ``task``. For example, monitoring sidecars might need ``pidMode`` to access information about other containers running in the same task.\n If ``host`` is specified, all containers within the tasks that specified the ``host`` PID mode on the same container instance share the same process namespace with the host Amazon EC2 instance.\n If ``task`` is specified, all containers within the specified task share the same process namespace.\n If no value is specified, the default is a private namespace for each container. For more information, see [PID settings](https://docs.aws.amazon.com/https://docs.docker.com/engine/reference/run/#pid-settings---pid) in the *Docker run reference*.\n If the ``host`` PID mode is used, there's a heightened risk of undesired process namespace exposure. For more information, see [Docker security](https://doc"
+      },
+      "placementConstraints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskDefinitionPlacementConstraint"
+        },
+        "description": "An array of placement constraint objects to use for tasks.\n  This parameter isn't supported for tasks run on FARGATElong."
+      },
+      "proxyConfiguration": {
+        "$ref": "#/types/aws-native:ecs:TaskDefinitionProxyConfiguration",
+        "description": "The configuration details for the App Mesh proxy.\n Your Amazon ECS container instances require at least version 1.26.0 of the container agent and at least version 1.26.0-1 of the ``ecs-init`` package to use a proxy configuration. If your container instances are launched from the Amazon ECS optimized AMI version ``20190301`` or later, they contain the required versions of the container agent and ``ecs-init``. For more information, see [Amazon ECS-optimized Linux AMI](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) in the *Amazon Elastic Container Service Developer Guide*."
+      },
+      "requiresCompatibilities": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The task launch types the task definition was validated against. The valid values are ``EC2``, ``FARGATE``, and ``EXTERNAL``. For more information, see [Amazon ECS launch types](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) in the *Amazon Elastic Container Service Developer Guide*."
+      },
+      "runtimePlatform": {
+        "$ref": "#/types/aws-native:ecs:TaskDefinitionRuntimePlatform",
+        "description": "The operating system that your tasks definitions run on. A platform family is specified only for tasks using the Fargate launch type. \n When you specify a task definition in a service, this value must match the ``runtimePlatform`` value of the service."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The metadata that you apply to the task definition to help you categorize and organize them. Each tag consists of a key and an optional value. You define both of them.\n The following basic restrictions apply to tags:\n  +  Maximum number of tags per resource - 50\n  +  For each resource, each tag key must be unique, and each tag key can have only one value.\n  +  Maximum key length - 128 Unicode characters in UTF-8\n  +  Maximum value length - 256 Unicode characters in UTF-8\n  +  If your tagging schema is used across multiple services and resources, remember that other services may have restrictions on allowed characters. Generally allowed characters are: letters, numbers, and spaces representable in UTF-8, and the following characters: + - = . _ : / @.\n  +  Tag keys and values are case-sensitive.\n  +  Do not use ``aws:``, ``AWS:``, or any upper or lowercase combination of such as a prefix for either keys or values as it is reserved for AWS use. You cannot edit or delete tag keys or values"
+      },
+      "taskRoleArn": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the IAMlong role that grants containers in the task permission to call AWS APIs on your behalf. For more information, see [Amazon ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) in the *Amazon Elastic Container Service Developer Guide*.\n IAM roles for tasks on Windows require that the ``-EnableTaskIAMRole`` option is set when you launch the Amazon ECS-optimized Windows AMI. Your containers must also run some configuration code to use the feature. For more information, see [Windows IAM roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/windows_task_IAM_roles.html) in the *Amazon Elastic Container Service Developer Guide*."
+      },
+      "volumes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskDefinitionVolume"
+        },
+        "description": "The list of data volume definitions for the task. For more information, see [Using data volumes in tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html) in the *Amazon Elastic Container Service Developer Guide*.\n  The ``host`` and ``sourcePath`` parameters aren't supported for tasks run on FARGATElong."
+      }
+    }
+  },
+  "aws-native:ecs:TaskSet": {
+    "cfTypeName": "AWS::ECS::TaskSet",
+    "properties": {
+      "cluster": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the cluster that hosts the service to create the task set in."
+      },
+      "externalId": {
+        "type": "string",
+        "description": "An optional non-unique tag that identifies this task set in external systems. If the task set is associated with a service discovery registry, the tasks in this task set will have the ECS_TASK_SET_EXTERNAL_ID AWS Cloud Map attribute set to the provided value. "
+      },
+      "launchType": {
+        "$ref": "#/types/aws-native:ecs:TaskSetLaunchType",
+        "description": "The launch type that new tasks in the task set will use. For more information, see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html in the Amazon Elastic Container Service Developer Guide. "
+      },
+      "loadBalancers": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskSetLoadBalancer"
+        }
+      },
+      "networkConfiguration": {
+        "$ref": "#/types/aws-native:ecs:TaskSetNetworkConfiguration"
+      },
+      "platformVersion": {
+        "type": "string",
+        "description": "The platform version that the tasks in the task set should use. A platform version is specified only for tasks using the Fargate launch type. If one isn't specified, the LATEST platform version is used by default."
+      },
+      "scale": {
+        "$ref": "#/types/aws-native:ecs:TaskSetScale",
+        "description": "A floating-point percentage of the desired number of tasks to place and keep running in the task set."
+      },
+      "service": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the service to create the task set in."
+      },
+      "serviceRegistries": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ecs:TaskSetServiceRegistry"
+        },
+        "description": "The details of the service discovery registries to assign to this task set. For more information, see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "taskDefinition": {
+        "type": "string",
+        "description": "The short name or full Amazon Resource Name (ARN) of the task definition for the tasks in the task set to use."
+      }
+    }
+  },
+  "aws-native:efs:AccessPoint": {
+    "cfTypeName": "AWS::EFS::AccessPoint",
+    "properties": {
+      "accessPointTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource.\n For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)."
+      },
+      "clientToken": {
+        "type": "string",
+        "description": "The opaque string specified in the request to ensure idempotent creation."
+      },
+      "fileSystemId": {
+        "type": "string",
+        "description": "The ID of the EFS file system that the access point applies to. Accepts only the ID format for input when specifying a file system, for example ``fs-0123456789abcedf2``."
+      },
+      "posixUser": {
+        "$ref": "#/types/aws-native:efs:AccessPointPosixUser",
+        "description": "The full POSIX identity, including the user ID, group ID, and secondary group IDs on the access point that is used for all file operations by NFS clients using the access point."
+      },
+      "rootDirectory": {
+        "$ref": "#/types/aws-native:efs:AccessPointRootDirectory",
+        "description": "The directory on the EFS file system that the access point exposes as the root directory to NFS clients using the access point."
+      }
+    }
+  },
+  "aws-native:efs:FileSystem": {
+    "cfTypeName": "AWS::EFS::FileSystem",
+    "properties": {
+      "availabilityZoneName": {
+        "type": "string",
+        "description": "For One Zone file systems, specify the AWS Availability Zone in which to create the file system. Use the format ``us-east-1a`` to specify the Availability Zone. For more information about One Zone file systems, see [EFS file system types](https://docs.aws.amazon.com/efs/latest/ug/availability-durability.html#file-system-type) in the *Amazon EFS User Guide*.\n  One Zone file systems are not available in all Availability Zones in AWS-Regions where Amazon EFS is available."
+      },
+      "backupPolicy": {
+        "$ref": "#/types/aws-native:efs:FileSystemBackupPolicy",
+        "description": "Use the ``BackupPolicy`` to turn automatic backups on or off for the file system."
+      },
+      "bypassPolicyLockoutSafetyCheck": {
+        "type": "boolean",
+        "description": "(Optional) A boolean that specifies whether or not to bypass the ``FileSystemPolicy`` lockout safety check. The lockout safety check determines whether the policy in the request will lock out, or prevent, the IAM principal that is making the request from making future ``PutFileSystemPolicy`` requests on this file system. Set ``BypassPolicyLockoutSafetyCheck`` to ``True`` only when you intend to prevent the IAM principal that is making the request from making subsequent ``PutFileSystemPolicy`` requests on this file system. The default value is ``False``."
+      },
+      "encrypted": {
+        "type": "boolean",
+        "description": "A Boolean value that, if true, creates an encrypted file system. When creating an encrypted file system, you have the option of specifying a KmsKeyId for an existing kms-key-long. If you don't specify a kms-key, then the default kms-key for EFS, ``/aws/elasticfilesystem``, is used to protect the encrypted file system."
+      },
+      "fileSystemPolicy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The ``FileSystemPolicy`` for the EFS file system. A file system policy is an IAM resource policy used to control NFS access to an EFS file system. For more information, see [Using to control NFS access to Amazon EFS](https://docs.aws.amazon.com/efs/latest/ug/iam-access-control-nfs-efs.html) in the *Amazon EFS User Guide*.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::EFS::FileSystem` for more information about the expected schema for this property."
+      },
+      "fileSystemProtection": {
+        "$ref": "#/types/aws-native:efs:FileSystemProtection",
+        "description": "Describes the protection on the file system."
+      },
+      "fileSystemTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Use to create one or more tags associated with the file system. Each tag is a user-defined key-value pair. Name your file system on creation by including a ``\"Key\":\"Name\",\"Value\":\"{value}\"`` key-value pair. Each key must be unique. For more information, see [Tagging resources](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html) in the *General Reference Guide*."
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The ID of the kms-key-long to be used to protect the encrypted file system. This parameter is only required if you want to use a nondefault kms-key. If this parameter is not specified, the default kms-key for EFS is used. This ID can be in one of the following formats:\n  +  Key ID - A unique identifier of the key, for example ``1234abcd-12ab-34cd-56ef-1234567890ab``.\n  +  ARN - An Amazon Resource Name (ARN) for the key, for example ``arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab``.\n  +  Key alias - A previously created display name for a key, for example ``alias/projectKey1``.\n  +  Key alias ARN - An ARN for a key alias, for example ``arn:aws:kms:us-west-2:444455556666:alias/projectKey1``.\n  \n If ``KmsKeyId`` is specified, the ``Encrypted`` parameter must be set to true."
+      },
+      "lifecyclePolicies": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:efs:FileSystemLifecyclePolicy"
+        },
+        "description": "An array of ``LifecyclePolicy`` objects that define the file system's ``LifecycleConfiguration`` object. A ``LifecycleConfiguration`` object informs Lifecycle management of the following:\n  +  When to move files in the file system from primary storage to IA storage.\n  + When to move files in the file system from primary storage or IA storage to Archive storage.\n +  When to move files that are in IA or Archive storage to primary storage.\n  \n  EFS requires that each ``LifecyclePolicy`` object have only a single transition. This means that in a request body, ``LifecyclePolicies`` needs to be structured as an array of ``LifecyclePolicy`` objects, one object for each transition, ``TransitionToIA``, ``TransitionToArchive`` ``TransitionToPrimaryStorageClass``. See the example requests in the following section for more information."
+      },
+      "performanceMode": {
+        "type": "string",
+        "description": "The Performance mode of the file system. We recommend ``generalPurpose`` performance mode for all file systems. File systems using the ``maxIO`` performance mode can scale to higher levels of aggregate throughput and operations per second with a tradeoff of slightly higher latencies for most file operations. The performance mode can't be changed after the file system has been created. The ``maxIO`` mode is not supported on One Zone file systems.\n  Due to the higher per-operation latencies with Max I/O, we recommend using General Purpose performance mode for all file systems.\n  Default is ``generalPurpose``."
+      },
+      "provisionedThroughputInMibps": {
+        "type": "number",
+        "description": "The throughput, measured in mebibytes per second (MiBps), that you want to provision for a file system that you're creating. Required if ``ThroughputMode`` is set to ``provisioned``. Valid values are 1-3414 MiBps, with the upper limit depending on Region. To increase this limit, contact SUP. For more information, see [Amazon EFS quotas that you can increase](https://docs.aws.amazon.com/efs/latest/ug/limits.html#soft-limits) in the *Amazon EFS User Guide*."
+      },
+      "replicationConfiguration": {
+        "$ref": "#/types/aws-native:efs:FileSystemReplicationConfiguration",
+        "description": "Describes the replication configuration for a specific file system."
+      },
+      "throughputMode": {
+        "type": "string",
+        "description": "Specifies the throughput mode for the file system. The mode can be ``bursting``, ``provisioned``, or ``elastic``. If you set ``ThroughputMode`` to ``provisioned``, you must also set a value for ``ProvisionedThroughputInMibps``. After you create the file system, you can decrease your file system's Provisioned throughput or change between the throughput modes, with certain time restrictions. For more information, see [Specifying throughput with provisioned mode](https://docs.aws.amazon.com/efs/latest/ug/performance.html#provisioned-throughput) in the *Amazon EFS User Guide*. \n Default is ``bursting``."
+      }
+    }
+  },
+  "aws-native:efs:MountTarget": {
+    "cfTypeName": "AWS::EFS::MountTarget",
+    "properties": {
+      "fileSystemId": {
+        "type": "string",
+        "description": "The ID of the file system for which to create the mount target."
+      },
+      "ipAddress": {
+        "type": "string",
+        "description": "Valid IPv4 address within the address range of the specified subnet."
+      },
+      "securityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Up to five VPC security group IDs, of the form ``sg-xxxxxxxx``. These must be for the same VPC as subnet specified."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet to add the mount target in. For One Zone file systems, use the subnet that is associated with the file system's Availability Zone."
+      }
+    }
+  },
+  "aws-native:eks:AccessEntry": {
+    "cfTypeName": "AWS::EKS::AccessEntry",
+    "properties": {
+      "accessPolicies": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:eks:AccessEntryAccessPolicy"
+        },
+        "description": "An array of access policies that are associated with the access entry."
+      },
+      "clusterName": {
+        "type": "string",
+        "description": "The cluster that the access entry is created for."
+      },
+      "kubernetesGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Kubernetes groups that the access entry is associated with."
+      },
+      "principalArn": {
+        "type": "string",
+        "description": "The principal ARN that the access entry is created for."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "type": {
+        "type": "string",
+        "description": "The node type to associate with the access entry."
+      },
+      "username": {
+        "type": "string",
+        "description": "The Kubernetes user that the access entry is associated with."
+      }
+    }
+  },
+  "aws-native:eks:PodIdentityAssociation": {
+    "cfTypeName": "AWS::EKS::PodIdentityAssociation",
+    "properties": {
+      "clusterName": {
+        "type": "string",
+        "description": "The cluster that the pod identity association is created for."
+      },
+      "namespace": {
+        "type": "string",
+        "description": "The Kubernetes namespace that the pod identity association is created for."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The IAM role ARN that the pod identity association is created for."
+      },
+      "serviceAccount": {
+        "type": "string",
+        "description": "The Kubernetes service account that the pod identity association is created for."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:elasticache:GlobalReplicationGroup": {
+    "cfTypeName": "AWS::ElastiCache::GlobalReplicationGroup",
+    "properties": {
+      "automaticFailoverEnabled": {
+        "type": "boolean",
+        "description": "AutomaticFailoverEnabled"
+      },
+      "cacheNodeType": {
+        "type": "string",
+        "description": "The cache node type of the Global Datastore"
+      },
+      "cacheParameterGroupName": {
+        "type": "string",
+        "description": "Cache parameter group name to use for the new engine version. This parameter cannot be modified independently."
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "The engine version of the Global Datastore."
+      },
+      "globalNodeGroupCount": {
+        "type": "integer",
+        "description": "Indicates the number of node groups in the Global Datastore."
+      },
+      "globalReplicationGroupDescription": {
+        "type": "string",
+        "description": "The optional description of the Global Datastore"
+      },
+      "globalReplicationGroupIdSuffix": {
+        "type": "string",
+        "description": "The suffix name of a Global Datastore. Amazon ElastiCache automatically applies a prefix to the Global Datastore ID when it is created. Each AWS Region has its own prefix. "
+      },
+      "members": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticache:GlobalReplicationGroupMember"
+        },
+        "description": "The replication groups that comprise the Global Datastore."
+      },
+      "regionalConfigurations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticache:GlobalReplicationGroupRegionalConfiguration"
+        },
+        "description": "Describes the replication group IDs, the AWS regions where they are stored and the shard configuration for each that comprise the Global Datastore "
+      }
+    }
+  },
+  "aws-native:elasticache:SubnetGroup": {
+    "cfTypeName": "AWS::ElastiCache::SubnetGroup",
+    "properties": {
+      "cacheSubnetGroupName": {
+        "type": "string",
+        "description": "The name for the cache subnet group. This value is stored as a lowercase string."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description for the cache subnet group."
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The EC2 subnet IDs for the cache subnet group."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:elasticache:UserGroup": {
+    "cfTypeName": "AWS::ElastiCache::UserGroup",
+    "properties": {
+      "engine": {
+        "$ref": "#/types/aws-native:elasticache:UserGroupEngine",
+        "description": "Must be redis."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this user."
+      },
+      "userGroupId": {
+        "type": "string",
+        "description": "The ID of the user group."
+      },
+      "userIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of users associated to this user group."
+      }
+    }
+  },
+  "aws-native:elasticbeanstalk:ApplicationVersion": {
+    "cfTypeName": "AWS::ElasticBeanstalk::ApplicationVersion",
+    "properties": {
+      "applicationName": {
+        "type": "string",
+        "description": "The name of the Elastic Beanstalk application that is associated with this application version. "
+      },
+      "description": {
+        "type": "string",
+        "description": "A description of this application version."
+      },
+      "sourceBundle": {
+        "$ref": "#/types/aws-native:elasticbeanstalk:ApplicationVersionSourceBundle",
+        "description": "The Amazon S3 bucket and key that identify the location of the source bundle for this version. "
+      }
+    }
+  },
+  "aws-native:elasticbeanstalk:ConfigurationTemplate": {
+    "cfTypeName": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "properties": {
+      "applicationName": {
+        "type": "string",
+        "description": "The name of the Elastic Beanstalk application to associate with this configuration template. "
+      },
+      "description": {
+        "type": "string",
+        "description": "An optional description for this configuration."
+      },
+      "environmentId": {
+        "type": "string",
+        "description": "The ID of an environment whose settings you want to use to create the configuration template. You must specify EnvironmentId if you don't specify PlatformArn, SolutionStackName, or SourceConfiguration. "
+      },
+      "optionSettings": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticbeanstalk:ConfigurationTemplateConfigurationOptionSetting"
+        },
+        "description": "Option values for the Elastic Beanstalk configuration, such as the instance type. If specified, these values override the values obtained from the solution stack or the source configuration template. For a complete list of Elastic Beanstalk configuration options, see [Option Values](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html) in the AWS Elastic Beanstalk Developer Guide. "
+      },
+      "platformArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the custom platform. For more information, see [Custom Platforms](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/custom-platforms.html) in the AWS Elastic Beanstalk Developer Guide. "
+      },
+      "solutionStackName": {
+        "type": "string",
+        "description": "The name of an Elastic Beanstalk solution stack (platform version) that this configuration uses. For example, 64bit Amazon Linux 2013.09 running Tomcat 7 Java 7. A solution stack specifies the operating system, runtime, and application server for a configuration template. It also determines the set of configuration options as well as the possible and default values. For more information, see [Supported Platforms](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html) in the AWS Elastic Beanstalk Developer Guide.\n\n You must specify SolutionStackName if you don't specify PlatformArn, EnvironmentId, or SourceConfiguration.\n\n Use the ListAvailableSolutionStacks API to obtain a list of available solution stacks. "
+      },
+      "sourceConfiguration": {
+        "$ref": "#/types/aws-native:elasticbeanstalk:ConfigurationTemplateSourceConfiguration",
+        "description": "An Elastic Beanstalk configuration template to base this one on. If specified, Elastic Beanstalk uses the configuration values from the specified configuration template to create a new configuration.\n\nValues specified in OptionSettings override any values obtained from the SourceConfiguration.\n\nYou must specify SourceConfiguration if you don't specify PlatformArn, EnvironmentId, or SolutionStackName.\n\nConstraint: If both solution stack name and source configuration are specified, the solution stack of the source configuration template must match the specified solution stack name. "
+      }
+    }
+  },
+  "aws-native:elasticloadbalancingv2:Listener": {
+    "cfTypeName": "AWS::ElasticLoadBalancingV2::Listener",
+    "properties": {
+      "alpnPolicy": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "[TLS listener] The name of the Application-Layer Protocol Negotiation (ALPN) policy."
+      },
+      "certificates": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticloadbalancingv2:ListenerCertificate"
+        },
+        "description": "The default SSL server certificate for a secure listener. You must provide exactly one certificate if the listener protocol is HTTPS or TLS.\n To create a certificate list for a secure listener, use [AWS::ElasticLoadBalancingV2::ListenerCertificate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenercertificate.html)."
+      },
+      "defaultActions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticloadbalancingv2:ListenerAction"
+        },
+        "description": "The actions for the default rule. You cannot define a condition for a default rule.\n To create additional rules for an Application Load Balancer, use [AWS::ElasticLoadBalancingV2::ListenerRule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html)."
+      },
+      "loadBalancerArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the load balancer."
+      },
+      "mutualAuthentication": {
+        "$ref": "#/types/aws-native:elasticloadbalancingv2:ListenerMutualAuthentication",
+        "description": "The mutual authentication configuration information."
+      },
+      "port": {
+        "type": "integer",
+        "description": "The port on which the load balancer is listening. You cannot specify a port for a Gateway Load Balancer."
+      },
+      "protocol": {
+        "type": "string",
+        "description": "The protocol for connections from clients to the load balancer. For Application Load Balancers, the supported protocols are HTTP and HTTPS. For Network Load Balancers, the supported protocols are TCP, TLS, UDP, and TCP_UDP. You can’t specify the UDP or TCP_UDP protocol if dual-stack mode is enabled. You cannot specify a protocol for a Gateway Load Balancer."
+      },
+      "sslPolicy": {
+        "type": "string",
+        "description": "[HTTPS and TLS listeners] The security policy that defines which protocols and ciphers are supported.\n For more information, see [Security policies](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies) in the *Application Load Balancers Guide* and [Security policies](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html#describe-ssl-policies) in the *Network Load Balancers Guide*."
+      }
+    }
+  },
+  "aws-native:elasticloadbalancingv2:ListenerRule": {
+    "cfTypeName": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "properties": {
+      "actions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticloadbalancingv2:ListenerRuleAction"
+        }
+      },
+      "conditions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticloadbalancingv2:ListenerRuleRuleCondition"
+        }
+      },
+      "listenerArn": {
+        "type": "string"
+      },
+      "priority": {
+        "type": "integer"
+      }
+    }
+  },
+  "aws-native:elasticloadbalancingv2:TrustStoreRevocation": {
+    "cfTypeName": "AWS::ElasticLoadBalancingV2::TrustStoreRevocation",
+    "properties": {
+      "revocationContents": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:elasticloadbalancingv2:TrustStoreRevocationRevocationContent"
+        },
+        "description": "The attributes required to create a trust store revocation."
+      },
+      "trustStoreArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the trust store."
+      }
+    }
+  },
+  "aws-native:emr:StudioSessionMapping": {
+    "cfTypeName": "AWS::EMR::StudioSessionMapping",
+    "properties": {
+      "identityName": {
+        "type": "string",
+        "description": "The name of the user or group. For more information, see UserName and DisplayName in the AWS SSO Identity Store API Reference. Either IdentityName or IdentityId must be specified."
+      },
+      "identityType": {
+        "$ref": "#/types/aws-native:emr:StudioSessionMappingIdentityType",
+        "description": "Specifies whether the identity to map to the Studio is a user or a group."
+      },
+      "sessionPolicyArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the session policy that will be applied to the user or group. Session policies refine Studio user permissions without the need to use multiple IAM user roles."
+      },
+      "studioId": {
+        "type": "string",
+        "description": "The ID of the Amazon EMR Studio to which the user or group will be mapped."
+      }
+    }
+  },
+  "aws-native:entityresolution:IdMappingWorkflow": {
+    "cfTypeName": "AWS::EntityResolution::IdMappingWorkflow",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the IdMappingWorkflow"
+      },
+      "idMappingTechniques": {
+        "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowIdMappingTechniques"
+      },
+      "inputSourceConfig": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowInputSource"
+        }
+      },
+      "outputSourceConfig": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowOutputSource"
+        }
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "workflowName": {
+        "type": "string",
+        "description": "The name of the IdMappingWorkflow"
+      }
+    }
+  },
+  "aws-native:entityresolution:MatchingWorkflow": {
+    "cfTypeName": "AWS::EntityResolution::MatchingWorkflow",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the MatchingWorkflow"
+      },
+      "inputSourceConfig": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowInputSource"
+        }
+      },
+      "outputSourceConfig": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowOutputSource"
+        }
+      },
+      "resolutionTechniques": {
+        "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowResolutionTechniques"
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "workflowName": {
+        "type": "string",
+        "description": "The name of the MatchingWorkflow"
+      }
+    }
+  },
+  "aws-native:entityresolution:SchemaMapping": {
+    "cfTypeName": "AWS::EntityResolution::SchemaMapping",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the SchemaMapping"
+      },
+      "mappedInputFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:entityresolution:SchemaMappingSchemaInputAttribute"
+        },
+        "description": "The SchemaMapping attributes input"
+      },
+      "schemaName": {
+        "type": "string",
+        "description": "The name of the SchemaMapping"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:eventschemas:Discoverer": {
+    "cfTypeName": "AWS::EventSchemas::Discoverer",
+    "properties": {
+      "crossAccount": {
+        "type": "boolean",
+        "description": "Defines whether event schemas from other accounts are discovered. Default is True."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description for the discoverer."
+      },
+      "sourceArn": {
+        "type": "string",
+        "description": "The ARN of the event bus."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Tags associated with the resource."
+      }
+    }
+  },
+  "aws-native:eventschemas:RegistryPolicy": {
+    "cfTypeName": "AWS::EventSchemas::RegistryPolicy",
+    "properties": {
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::EventSchemas::RegistryPolicy` for more information about the expected schema for this property."
+      },
+      "registryName": {
+        "type": "string"
+      },
+      "revisionId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:fis:ExperimentTemplate": {
+    "cfTypeName": "AWS::FIS::ExperimentTemplate",
+    "properties": {
+      "actions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:fis:ExperimentTemplateAction"
+        }
+      },
+      "description": {
+        "type": "string"
+      },
+      "experimentOptions": {
+        "$ref": "#/types/aws-native:fis:ExperimentTemplateExperimentOptions"
+      },
+      "logConfiguration": {
+        "$ref": "#/types/aws-native:fis:ExperimentTemplateLogConfiguration"
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "stopConditions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:fis:ExperimentTemplateStopCondition"
+        }
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "targets": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:fis:ExperimentTemplateTarget"
+        }
+      }
+    }
+  },
+  "aws-native:fis:TargetAccountConfiguration": {
+    "cfTypeName": "AWS::FIS::TargetAccountConfiguration",
+    "properties": {
+      "accountId": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "experimentTemplateId": {
+        "type": "string"
+      },
+      "roleArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:fms:NotificationChannel": {
+    "cfTypeName": "AWS::FMS::NotificationChannel",
+    "properties": {
+      "snsRoleName": {
+        "type": "string"
+      },
+      "snsTopicArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:frauddetector:Detector": {
+    "cfTypeName": "AWS::FraudDetector::Detector",
+    "properties": {
+      "associatedModels": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:frauddetector:DetectorModel"
+        },
+        "description": "The models to associate with this detector."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the detector."
+      },
+      "detectorId": {
+        "type": "string",
+        "description": "The ID of the detector"
+      },
+      "detectorVersionStatus": {
+        "$ref": "#/types/aws-native:frauddetector:DetectorVersionStatus",
+        "description": "The desired detector version status for the detector"
+      },
+      "eventType": {
+        "$ref": "#/types/aws-native:frauddetector:DetectorEventType",
+        "description": "The event type to associate this detector with."
+      },
+      "ruleExecutionMode": {
+        "$ref": "#/types/aws-native:frauddetector:DetectorRuleExecutionMode"
+      },
+      "rules": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:frauddetector:DetectorRule"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Tags associated with this detector."
+      }
+    }
+  },
+  "aws-native:fsx:DataRepositoryAssociation": {
+    "cfTypeName": "AWS::FSx::DataRepositoryAssociation",
+    "properties": {
+      "batchImportMetaDataOnCreate": {
+        "type": "boolean",
+        "description": "A boolean flag indicating whether an import data repository task to import metadata should run after the data repository association is created. The task runs if this flag is set to ``true``."
+      },
+      "dataRepositoryPath": {
+        "type": "string",
+        "description": "The path to the Amazon S3 data repository that will be linked to the file system. The path can be an S3 bucket or prefix in the format ``s3://myBucket/myPrefix/``. This path specifies where in the S3 data repository files will be imported from or exported to."
+      },
+      "fileSystemId": {
+        "type": "string",
+        "description": "The ID of the file system on which the data repository association is configured."
+      },
+      "fileSystemPath": {
+        "type": "string",
+        "description": "A path on the Amazon FSx for Lustre file system that points to a high-level directory (such as ``/ns1/``) or subdirectory (such as ``/ns1/subdir/``) that will be mapped 1-1 with ``DataRepositoryPath``. The leading forward slash in the name is required. Two data repository associations cannot have overlapping file system paths. For example, if a data repository is associated with file system path ``/ns1/``, then you cannot link another data repository with file system path ``/ns1/ns2``.\n This path specifies where in your file system files will be exported from or imported to. This file system directory can be linked to only one Amazon S3 bucket, and no other S3 bucket can be linked to the directory.\n  If you specify only a forward slash (``/``) as the file system path, you can link only one data repository to the file system. You can only specify \"/\" as the file system path for the first data repository associated with a file system."
+      },
+      "importedFileChunkSize": {
+        "type": "integer",
+        "description": "For files imported from a data repository, this value determines the stripe count and maximum amount of data per file (in MiB) stored on a single physical disk. The maximum number of disks that a single file can be striped across is limited by the total number of disks that make up the file system or cache.\n The default chunk size is 1,024 MiB (1 GiB) and can go as high as 512,000 MiB (500 GiB). Amazon S3 objects have a maximum size of 5 TB."
+      },
+      "s3": {
+        "$ref": "#/types/aws-native:fsx:DataRepositoryAssociationS3",
+        "description": "The configuration for an Amazon S3 data repository linked to an Amazon FSx Lustre file system with a data repository association. The configuration defines which file events (new, changed, or deleted files or directories) are automatically imported from the linked data repository to the file system or automatically exported from the file system to the data repository."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource.\n For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)."
+      }
+    }
+  },
+  "aws-native:globalaccelerator:EndpointGroup": {
+    "cfTypeName": "AWS::GlobalAccelerator::EndpointGroup",
+    "properties": {
+      "endpointConfigurations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:globalaccelerator:EndpointGroupEndpointConfiguration"
+        },
+        "description": "The list of endpoint objects."
+      },
+      "endpointGroupRegion": {
+        "type": "string",
+        "description": "The name of the AWS Region where the endpoint group is located"
+      },
+      "healthCheckIntervalSeconds": {
+        "type": "integer",
+        "description": "The time in seconds between each health check for an endpoint. Must be a value of 10 or 30"
+      },
+      "healthCheckPath": {
+        "type": "string"
+      },
+      "healthCheckPort": {
+        "type": "integer",
+        "description": "The port that AWS Global Accelerator uses to check the health of endpoints in this endpoint group."
+      },
+      "healthCheckProtocol": {
+        "$ref": "#/types/aws-native:globalaccelerator:EndpointGroupHealthCheckProtocol",
+        "description": "The protocol that AWS Global Accelerator uses to check the health of endpoints in this endpoint group."
+      },
+      "listenerArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the listener"
+      },
+      "portOverrides": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:globalaccelerator:EndpointGroupPortOverride"
+        }
+      },
+      "thresholdCount": {
+        "type": "integer",
+        "description": "The number of consecutive health checks required to set the state of the endpoint to unhealthy."
+      },
+      "trafficDialPercentage": {
+        "type": "number",
+        "description": "The percentage of traffic to sent to an AWS Region"
+      }
+    }
+  },
+  "aws-native:globalaccelerator:Listener": {
+    "cfTypeName": "AWS::GlobalAccelerator::Listener",
+    "properties": {
+      "acceleratorArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the accelerator."
+      },
+      "clientAffinity": {
+        "$ref": "#/types/aws-native:globalaccelerator:ListenerClientAffinity",
+        "description": "Client affinity lets you direct all requests from a user to the same endpoint."
+      },
+      "portRanges": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:globalaccelerator:ListenerPortRange"
+        }
+      },
+      "protocol": {
+        "$ref": "#/types/aws-native:globalaccelerator:ListenerProtocol",
+        "description": "The protocol for the listener."
+      }
+    }
+  },
+  "aws-native:glue:SchemaVersion": {
+    "cfTypeName": "AWS::Glue::SchemaVersion",
+    "properties": {
+      "schema": {
+        "$ref": "#/types/aws-native:glue:SchemaVersionSchema"
+      },
+      "schemaDefinition": {
+        "type": "string",
+        "description": "Complete definition of the schema in plain-text."
+      }
+    }
+  },
+  "aws-native:glue:SchemaVersionMetadata": {
+    "cfTypeName": "AWS::Glue::SchemaVersionMetadata",
+    "properties": {
+      "key": {
+        "type": "string",
+        "description": "Metadata key"
+      },
+      "schemaVersionId": {
+        "type": "string",
+        "description": "Represents the version ID associated with the schema version."
+      },
+      "value": {
+        "type": "string",
+        "description": "Metadata value"
+      }
+    }
+  },
+  "aws-native:greengrassv2:ComponentVersion": {
+    "cfTypeName": "AWS::GreengrassV2::ComponentVersion",
+    "properties": {
+      "inlineRecipe": {
+        "type": "string"
+      },
+      "lambdaFunction": {
+        "$ref": "#/types/aws-native:greengrassv2:ComponentVersionLambdaFunctionRecipeSource"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:groundstation:DataflowEndpointGroup": {
+    "cfTypeName": "AWS::GroundStation::DataflowEndpointGroup",
+    "properties": {
+      "contactPostPassDurationSeconds": {
+        "type": "integer",
+        "description": "Amount of time, in seconds, after a contact ends that the Ground Station Dataflow Endpoint Group will be in a POSTPASS state. A Ground Station Dataflow Endpoint Group State Change event will be emitted when the Dataflow Endpoint Group enters and exits the POSTPASS state."
+      },
+      "contactPrePassDurationSeconds": {
+        "type": "integer",
+        "description": "Amount of time, in seconds, before a contact starts that the Ground Station Dataflow Endpoint Group will be in a PREPASS state. A Ground Station Dataflow Endpoint Group State Change event will be emitted when the Dataflow Endpoint Group enters and exits the PREPASS state."
+      },
+      "endpointDetails": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:groundstation:DataflowEndpointGroupEndpointDetails"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:guardduty:Detector": {
+    "cfTypeName": "AWS::GuardDuty::Detector",
+    "properties": {
+      "dataSources": {
+        "$ref": "#/types/aws-native:guardduty:DetectorCfnDataSourceConfigurations"
+      },
+      "enable": {
+        "type": "boolean"
+      },
+      "features": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:guardduty:DetectorCfnFeatureConfiguration"
+        }
+      },
+      "findingPublishingFrequency": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:guardduty:Master": {
+    "cfTypeName": "AWS::GuardDuty::Master",
+    "properties": {
+      "detectorId": {
+        "type": "string",
+        "description": "Unique ID of the detector of the GuardDuty member account."
+      },
+      "invitationId": {
+        "type": "string",
+        "description": "Value used to validate the master account to the member account."
+      },
+      "masterId": {
+        "type": "string",
+        "description": "ID of the account used as the master account."
+      }
+    }
+  },
+  "aws-native:guardduty:Member": {
+    "cfTypeName": "AWS::GuardDuty::Member",
+    "properties": {
+      "detectorId": {
+        "type": "string"
+      },
+      "disableEmailNotification": {
+        "type": "boolean"
+      },
+      "email": {
+        "type": "string"
+      },
+      "memberId": {
+        "type": "string"
+      },
+      "message": {
+        "type": "string"
+      },
+      "status": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:healthlake:FhirDatastore": {
+    "cfTypeName": "AWS::HealthLake::FHIRDatastore",
+    "properties": {
+      "datastoreName": {
+        "type": "string"
+      },
+      "datastoreTypeVersion": {
+        "$ref": "#/types/aws-native:healthlake:FhirDatastoreDatastoreTypeVersion"
+      },
+      "identityProviderConfiguration": {
+        "$ref": "#/types/aws-native:healthlake:FhirDatastoreIdentityProviderConfiguration"
+      },
+      "preloadDataConfig": {
+        "$ref": "#/types/aws-native:healthlake:FhirDatastorePreloadDataConfig"
+      },
+      "sseConfiguration": {
+        "$ref": "#/types/aws-native:healthlake:FhirDatastoreSseConfiguration"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:iam:GroupPolicy": {
+    "cfTypeName": "AWS::IAM::GroupPolicy",
+    "properties": {
+      "groupName": {
+        "type": "string",
+        "description": "The name of the group to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::GroupPolicy` for more information about the expected schema for this property."
+      },
+      "policyName": {
+        "type": "string",
+        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
+      }
+    }
+  },
+  "aws-native:iam:OidcProvider": {
+    "cfTypeName": "AWS::IAM::OIDCProvider",
+    "properties": {
+      "clientIdList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "thumbprintList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "url": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:iam:RolePolicy": {
+    "cfTypeName": "AWS::IAM::RolePolicy",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::RolePolicy` for more information about the expected schema for this property."
+      },
+      "policyName": {
+        "type": "string",
+        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
+      },
+      "roleName": {
+        "type": "string",
+        "description": "The name of the role to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
+      }
+    }
+  },
+  "aws-native:iam:ServiceLinkedRole": {
+    "cfTypeName": "AWS::IAM::ServiceLinkedRole",
+    "properties": {
+      "awsServiceName": {
+        "type": "string",
+        "description": "The service principal for the AWS service to which this role is attached."
+      },
+      "customSuffix": {
+        "type": "string",
+        "description": "A string that you provide, which is combined with the service-provided prefix to form the complete role name."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the role."
+      }
+    }
+  },
+  "aws-native:iam:UserPolicy": {
+    "cfTypeName": "AWS::IAM::UserPolicy",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::UserPolicy` for more information about the expected schema for this property."
+      },
+      "policyName": {
+        "type": "string",
+        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
+      },
+      "userName": {
+        "type": "string",
+        "description": "The name of the user to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
+      }
+    }
+  },
+  "aws-native:identitystore:Group": {
+    "cfTypeName": "AWS::IdentityStore::Group",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A string containing the description of the group."
+      },
+      "displayName": {
+        "type": "string",
+        "description": "A string containing the name of the group. This value is commonly displayed when the group is referenced."
+      },
+      "identityStoreId": {
+        "type": "string",
+        "description": "The globally unique identifier for the identity store."
+      }
+    }
+  },
+  "aws-native:identitystore:GroupMembership": {
+    "cfTypeName": "AWS::IdentityStore::GroupMembership",
+    "properties": {
+      "groupId": {
+        "type": "string",
+        "description": "The unique identifier for a group in the identity store."
+      },
+      "identityStoreId": {
+        "type": "string",
+        "description": "The globally unique identifier for the identity store."
+      },
+      "memberId": {
+        "$ref": "#/types/aws-native:identitystore:GroupMembershipMemberId",
+        "description": "An object containing the identifier of a group member."
+      }
+    }
+  },
+  "aws-native:imagebuilder:Image": {
+    "cfTypeName": "AWS::ImageBuilder::Image",
+    "properties": {
+      "containerRecipeArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the container recipe that defines how images are configured and tested."
+      },
+      "distributionConfigurationArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the distribution configuration."
+      },
+      "enhancedImageMetadataEnabled": {
+        "type": "boolean",
+        "description": "Collects additional information about the image being created, including the operating system (OS) version and package list."
+      },
+      "executionRole": {
+        "type": "string",
+        "description": "The execution role name/ARN for the image build, if provided"
+      },
+      "imageRecipeArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the image recipe that defines how images are configured, tested, and assessed."
+      },
+      "imageScanningConfiguration": {
+        "$ref": "#/types/aws-native:imagebuilder:ImageScanningConfiguration",
+        "description": "Contains settings for vulnerability scans."
+      },
+      "imageTestsConfiguration": {
+        "$ref": "#/types/aws-native:imagebuilder:ImageTestsConfiguration",
+        "description": "The image tests configuration used when creating this image."
+      },
+      "infrastructureConfigurationArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the infrastructure configuration."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "The tags associated with the image."
+      },
+      "workflows": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:imagebuilder:ImageWorkflowConfiguration"
+        },
+        "description": "Workflows to define the image build process"
+      }
+    }
+  },
+  "aws-native:inspector:ResourceGroup": {
+    "cfTypeName": "AWS::Inspector::ResourceGroup",
+    "properties": {
+      "resourceGroupTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:inspector:ResourceGroupTag"
+        }
+      }
+    }
+  },
+  "aws-native:inspectorv2:CisScanConfiguration": {
+    "cfTypeName": "AWS::InspectorV2::CisScanConfiguration",
+    "properties": {
+      "scanName": {
+        "type": "string",
+        "description": "Name of the scan"
+      },
+      "schedule": {
+        "$ref": "#/types/aws-native:inspectorv2:CisScanConfigurationSchedule"
+      },
+      "securityLevel": {
+        "$ref": "#/types/aws-native:inspectorv2:CisScanConfigurationCisSecurityLevel"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "targets": {
+        "$ref": "#/types/aws-native:inspectorv2:CisScanConfigurationCisTargets"
+      }
+    }
+  },
+  "aws-native:iot:AccountAuditConfiguration": {
+    "cfTypeName": "AWS::IoT::AccountAuditConfiguration",
+    "properties": {
+      "accountId": {
+        "type": "string",
+        "description": "Your 12-digit account ID (used as the primary identifier for the CloudFormation resource)."
+      },
+      "auditCheckConfigurations": {
+        "$ref": "#/types/aws-native:iot:AccountAuditConfigurationAuditCheckConfigurations"
+      },
+      "auditNotificationTargetConfigurations": {
+        "$ref": "#/types/aws-native:iot:AccountAuditConfigurationAuditNotificationTargetConfigurations"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The ARN of the role that grants permission to AWS IoT to access information about your devices, policies, certificates and other items as required when performing an audit."
+      }
+    }
+  },
+  "aws-native:iot:CaCertificate": {
+    "cfTypeName": "AWS::IoT::CACertificate",
+    "properties": {
+      "autoRegistrationStatus": {
+        "$ref": "#/types/aws-native:iot:CaCertificateAutoRegistrationStatus"
+      },
+      "caCertificatePem": {
+        "type": "string"
+      },
+      "certificateMode": {
+        "$ref": "#/types/aws-native:iot:CaCertificateCertificateMode"
+      },
+      "registrationConfig": {
+        "$ref": "#/types/aws-native:iot:CaCertificateRegistrationConfig"
+      },
+      "removeAutoRegistration": {
+        "type": "boolean"
+      },
+      "status": {
+        "$ref": "#/types/aws-native:iot:CaCertificateStatus"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "verificationCertificatePem": {
+        "type": "string",
+        "description": "The private key verification certificate."
+      }
+    }
+  },
+  "aws-native:iot:Certificate": {
+    "cfTypeName": "AWS::IoT::Certificate",
+    "properties": {
+      "caCertificatePem": {
+        "type": "string"
+      },
+      "certificateMode": {
+        "$ref": "#/types/aws-native:iot:CertificateMode"
+      },
+      "certificatePem": {
+        "type": "string"
+      },
+      "certificateSigningRequest": {
+        "type": "string"
+      },
+      "status": {
+        "$ref": "#/types/aws-native:iot:CertificateStatus"
+      }
+    }
+  },
+  "aws-native:iot:CustomMetric": {
+    "cfTypeName": "AWS::IoT::CustomMetric",
+    "properties": {
+      "displayName": {
+        "type": "string",
+        "description": "Field represents a friendly name in the console for the custom metric; it doesn't have to be unique. Don't use this name as the metric identifier in the device metric report. Can be updated once defined."
+      },
+      "metricName": {
+        "type": "string",
+        "description": "The name of the custom metric. This will be used in the metric report submitted from the device/thing. Shouldn't begin with aws: . Cannot be updated once defined."
+      },
+      "metricType": {
+        "$ref": "#/types/aws-native:iot:CustomMetricMetricType",
+        "description": "The type of the custom metric. Types include string-list, ip-address-list, number-list, and number."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:iot:FleetMetric": {
+    "cfTypeName": "AWS::IoT::FleetMetric",
+    "properties": {
+      "aggregationField": {
+        "type": "string",
+        "description": "The aggregation field to perform aggregation and metric emission"
+      },
+      "aggregationType": {
+        "$ref": "#/types/aws-native:iot:FleetMetricAggregationType"
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of a fleet metric"
+      },
+      "indexName": {
+        "type": "string",
+        "description": "The index name of a fleet metric"
+      },
+      "metricName": {
+        "type": "string",
+        "description": "The name of the fleet metric"
+      },
+      "period": {
+        "type": "integer",
+        "description": "The period of metric emission in seconds"
+      },
+      "queryString": {
+        "type": "string",
+        "description": "The Fleet Indexing query used by a fleet metric"
+      },
+      "queryVersion": {
+        "type": "string",
+        "description": "The version of a Fleet Indexing query used by a fleet metric"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource"
+      },
+      "unit": {
+        "type": "string",
+        "description": "The unit of data points emitted by a fleet metric"
+      }
+    }
+  },
+  "aws-native:iot:JobTemplate": {
+    "cfTypeName": "AWS::IoT::JobTemplate",
+    "properties": {
+      "abortConfig": {
+        "$ref": "#/types/aws-native:iot:AbortConfigProperties",
+        "description": "The criteria that determine when and how a job abort takes place."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description of the Job Template."
+      },
+      "destinationPackageVersions": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "document": {
+        "type": "string",
+        "description": "The job document. Required if you don't specify a value for documentSource."
+      },
+      "documentSource": {
+        "type": "string",
+        "description": "An S3 link to the job document to use in the template. Required if you don't specify a value for document."
+      },
+      "jobArn": {
+        "type": "string",
+        "description": "Optional for copying a JobTemplate from a pre-existing Job configuration."
+      },
+      "jobExecutionsRetryConfig": {
+        "$ref": "#/types/aws-native:iot:JobExecutionsRetryConfigProperties"
+      },
+      "jobExecutionsRolloutConfig": {
+        "$ref": "#/types/aws-native:iot:JobExecutionsRolloutConfigProperties",
+        "description": "Allows you to create a staged rollout of a job."
+      },
+      "jobTemplateId": {
+        "type": "string"
+      },
+      "maintenanceWindows": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:iot:JobTemplateMaintenanceWindow"
+        }
+      },
+      "presignedUrlConfig": {
+        "$ref": "#/types/aws-native:iot:PresignedUrlConfigProperties",
+        "description": "Configuration for pre-signed S3 URLs."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "Metadata that can be used to manage the JobTemplate."
+      },
+      "timeoutConfig": {
+        "$ref": "#/types/aws-native:iot:TimeoutConfigProperties",
+        "description": "Specifies the amount of time each device has to finish its execution of the job."
+      }
+    }
+  },
+  "aws-native:iot:Logging": {
+    "cfTypeName": "AWS::IoT::Logging",
+    "properties": {
+      "accountId": {
+        "type": "string",
+        "description": "Your 12-digit account ID (used as the primary identifier for the CloudFormation resource)."
+      },
+      "defaultLogLevel": {
+        "$ref": "#/types/aws-native:iot:LoggingDefaultLogLevel",
+        "description": "The log level to use. Valid values are: ERROR, WARN, INFO, DEBUG, or DISABLED."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The ARN of the role that allows IoT to write to Cloudwatch logs."
+      }
+    }
+  },
+  "aws-native:iot:MitigationAction": {
+    "cfTypeName": "AWS::IoT::MitigationAction",
+    "properties": {
+      "actionName": {
+        "type": "string",
+        "description": "A unique identifier for the mitigation action."
+      },
+      "actionParams": {
+        "$ref": "#/types/aws-native:iot:MitigationActionActionParams"
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:iot:ProvisioningTemplate": {
+    "cfTypeName": "AWS::IoT::ProvisioningTemplate",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "preProvisioningHook": {
+        "$ref": "#/types/aws-native:iot:ProvisioningTemplateProvisioningHook"
+      },
+      "provisioningRoleArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "templateBody": {
+        "type": "string"
+      },
+      "templateName": {
+        "type": "string"
+      },
+      "templateType": {
+        "$ref": "#/types/aws-native:iot:ProvisioningTemplateTemplateType"
+      }
+    }
+  },
+  "aws-native:iot:ResourceSpecificLogging": {
+    "cfTypeName": "AWS::IoT::ResourceSpecificLogging",
+    "properties": {
+      "logLevel": {
+        "$ref": "#/types/aws-native:iot:ResourceSpecificLoggingLogLevel",
+        "description": "The log level for a specific target. Valid values are: ERROR, WARN, INFO, DEBUG, or DISABLED."
+      },
+      "targetName": {
+        "type": "string",
+        "description": "The target name."
+      },
+      "targetType": {
+        "$ref": "#/types/aws-native:iot:ResourceSpecificLoggingTargetType",
+        "description": "The target type. Value must be THING_GROUP, CLIENT_ID, SOURCE_IP, PRINCIPAL_ID, or EVENT_TYPE."
+      }
+    }
+  },
+  "aws-native:iot:RoleAlias": {
+    "cfTypeName": "AWS::IoT::RoleAlias",
+    "properties": {
+      "credentialDurationSeconds": {
+        "type": "integer"
+      },
+      "roleAlias": {
+        "type": "string",
+        "language": {
+          "csharp": {
+            "name": "RoleAliasValue"
+          }
+        }
+      },
+      "roleArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:iot:SoftwarePackage": {
+    "cfTypeName": "AWS::IoT::SoftwarePackage",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "packageName": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:iot:SoftwarePackageVersion": {
+    "cfTypeName": "AWS::IoT::SoftwarePackageVersion",
+    "properties": {
+      "attributes": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "description": {
+        "type": "string"
+      },
+      "packageName": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "versionName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:iot:TopicRule": {
+    "cfTypeName": "AWS::IoT::TopicRule",
+    "properties": {
+      "ruleName": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "topicRulePayload": {
+        "$ref": "#/types/aws-native:iot:TopicRulePayload"
+      }
+    }
+  },
+  "aws-native:iot:TopicRuleDestination": {
+    "cfTypeName": "AWS::IoT::TopicRuleDestination",
+    "properties": {
+      "httpUrlProperties": {
+        "$ref": "#/types/aws-native:iot:TopicRuleDestinationHttpUrlDestinationSummary",
+        "description": "HTTP URL destination properties."
+      },
+      "status": {
+        "$ref": "#/types/aws-native:iot:TopicRuleDestinationStatus",
+        "description": "The status of the TopicRuleDestination."
+      },
+      "vpcProperties": {
+        "$ref": "#/types/aws-native:iot:TopicRuleDestinationVpcDestinationProperties",
+        "description": "VPC destination properties."
+      }
+    }
+  },
+  "aws-native:iotcoredeviceadvisor:SuiteDefinition": {
+    "cfTypeName": "AWS::IoTCoreDeviceAdvisor::SuiteDefinition",
+    "properties": {
+      "suiteDefinitionConfiguration": {
+        "$ref": "#/types/aws-native:iotcoredeviceadvisor:SuiteDefinitionConfigurationProperties"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:iotsitewise:AccessPolicy": {
+    "cfTypeName": "AWS::IoTSiteWise::AccessPolicy",
+    "properties": {
+      "accessPolicyIdentity": {
+        "$ref": "#/types/aws-native:iotsitewise:AccessPolicyIdentity",
+        "description": "The identity for this access policy. Choose either a user or a group but not both."
+      },
+      "accessPolicyPermission": {
+        "type": "string",
+        "description": "The permission level for this access policy. Valid values are ADMINISTRATOR or VIEWER."
+      },
+      "accessPolicyResource": {
+        "$ref": "#/types/aws-native:iotsitewise:AccessPolicyResource",
+        "description": "The AWS IoT SiteWise Monitor resource for this access policy. Choose either portal or project but not both."
+      }
+    }
+  },
+  "aws-native:iottwinmaker:ComponentType": {
+    "cfTypeName": "AWS::IoTTwinMaker::ComponentType",
+    "properties": {
+      "componentTypeId": {
+        "type": "string",
+        "description": "The ID of the component type."
+      },
+      "compositeComponentTypes": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:iottwinmaker:ComponentTypeCompositeComponentType"
+        },
+        "description": "An map of the composite component types in the component type. Each composite component type's key must be unique to this map."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the component type."
+      },
+      "extendsFrom": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Specifies the parent component type to extend."
+      },
+      "functions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:iottwinmaker:ComponentTypeFunction"
+        },
+        "description": "a Map of functions in the component type. Each function's key must be unique to this map."
+      },
+      "isSingleton": {
+        "type": "boolean",
+        "description": "A Boolean value that specifies whether an entity can have more than one component of this type."
+      },
+      "propertyDefinitions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:iottwinmaker:ComponentTypePropertyDefinition"
+        },
+        "description": "An map of the property definitions in the component type. Each property definition's key must be unique to this map."
+      },
+      "propertyGroups": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:iottwinmaker:ComponentTypePropertyGroup"
+        },
+        "description": "An map of the property groups in the component type. Each property group's key must be unique to this map."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of key-value pairs to associate with a resource."
+      },
+      "workspaceId": {
+        "type": "string",
+        "description": "The ID of the workspace that contains the component type."
+      }
+    }
+  },
+  "aws-native:iottwinmaker:Scene": {
+    "cfTypeName": "AWS::IoTTwinMaker::Scene",
+    "properties": {
+      "capabilities": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of capabilities that the scene uses to render."
+      },
+      "contentLocation": {
+        "type": "string",
+        "description": "The relative path that specifies the location of the content definition file."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the scene."
+      },
+      "sceneId": {
+        "type": "string",
+        "description": "The ID of the scene."
+      },
+      "sceneMetadata": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A key-value pair of scene metadata for the scene."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A key-value pair to associate with a resource."
+      },
+      "workspaceId": {
+        "type": "string",
+        "description": "The ID of the scene."
+      }
+    }
+  },
+  "aws-native:iottwinmaker:SyncJob": {
+    "cfTypeName": "AWS::IoTTwinMaker::SyncJob",
+    "properties": {
+      "syncRole": {
+        "type": "string",
+        "description": "The IAM Role that execute SyncJob."
+      },
+      "syncSource": {
+        "type": "string",
+        "description": "The source of the SyncJob."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A key-value pair to associate with a resource."
+      },
+      "workspaceId": {
+        "type": "string",
+        "description": "The ID of the workspace."
+      }
+    }
+  },
+  "aws-native:iottwinmaker:Workspace": {
+    "cfTypeName": "AWS::IoTTwinMaker::Workspace",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the workspace."
+      },
+      "role": {
+        "type": "string",
+        "description": "The ARN of the execution role associated with the workspace."
+      },
+      "s3Location": {
+        "type": "string",
+        "description": "The ARN of the S3 bucket where resources associated with the workspace are stored."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A map of key-value pairs to associate with a resource."
+      },
+      "workspaceId": {
+        "type": "string",
+        "description": "The ID of the workspace."
+      }
+    }
+  },
+  "aws-native:ivs:StreamKey": {
+    "cfTypeName": "AWS::IVS::StreamKey",
+    "properties": {
+      "channelArn": {
+        "type": "string",
+        "description": "Channel ARN for the stream."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A list of key-value pairs that contain metadata for the asset model."
+      }
+    }
+  },
+  "aws-native:kms:Key": {
+    "cfTypeName": "AWS::KMS::Key",
+    "properties": {
+      "bypassPolicyLockoutSafetyCheck": {
+        "type": "boolean",
+        "description": "Skips (\"bypasses\") the key policy lockout safety check. The default value is false.\n  Setting this value to true increases the risk that the KMS key becomes unmanageable. Do not set this value to true indiscriminately.\n For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key) in the *Developer Guide*.\n  Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description of the KMS key. Use a description that helps you to distinguish this KMS key from others in the account, such as its intended use."
+      },
+      "enableKeyRotation": {
+        "type": "boolean",
+        "description": "Enables automatic rotation of the key material for the specified KMS key. By default, automatic key rotation is not enabled.\n KMS supports automatic rotation only for symmetric encryption KMS keys (``KeySpec`` = ``SYMMETRIC_DEFAULT``). For asymmetric KMS keys, HMAC KMS keys, and KMS keys with Origin ``EXTERNAL``, omit the ``EnableKeyRotation`` property or set it to ``false``.\n To enable automatic key rotation of the key material for a multi-Region KMS key, set ``EnableKeyRotation`` to ``true`` on the primary key (created by using ``AWS::KMS::Key``). KMS copies the rotation status to all replica keys. For details, see [Rotating multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate) in the *Developer Guide*.\n When you enable automatic rotation, KMS automatically creates new key material for the KMS key one year after the enable date and every year thereafter. KMS retains all key material until you delete the KMS key. Fo"
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Specifies whether the KMS key is enabled. Disabled KMS keys cannot be used in cryptographic operations.\n When ``Enabled`` is ``true``, the *key state* of the KMS key is ``Enabled``. When ``Enabled`` is ``false``, the key state of the KMS key is ``Disabled``. The default value is ``true``.\n The actual key state of the KMS key might be affected by actions taken outside of CloudFormation, such as running the [EnableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html), [DisableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html), or [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operations.\n For information about the key states of a KMS key, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*."
+      },
+      "keyPolicy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The key policy to attach to the KMS key.\n If you provide a key policy, it must meet the following criteria:\n  +  The key policy must allow the caller to make a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key. This reduces the risk that the KMS key becomes unmanageable. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam) in the *Developer Guide*. (To omit this condition, set ``BypassPolicyLockoutSafetyCheck`` to true.)\n  +  Each statement in the key policy must contain one or more principals. The principals in the key policy must exist and be visible to KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before including the new principal in a key policy because the new principal might not be immediately visible to KMS. For more information, see [\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::KMS::Key` for more information about the expected schema for this property."
+      },
+      "keySpec": {
+        "$ref": "#/types/aws-native:kms:KeySpec",
+        "description": "Specifies the type of KMS key to create. The default value, ``SYMMETRIC_DEFAULT``, creates a KMS key with a 256-bit symmetric key for encryption and decryption. In China Regions, ``SYMMETRIC_DEFAULT`` creates a 128-bit symmetric key that uses SM4 encryption. You can't change the ``KeySpec`` value after the KMS key is created. For help choosing a key spec for your KMS key, see [Choosing a KMS key type](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html) in the *Developer Guide*.\n The ``KeySpec`` property determines the type of key material in the KMS key and the algorithms that the KMS key supports. To further restrict the algorithms that can be used with the KMS key, use a condition key in its key policy or IAM policy. For more information, see [condition keys](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms) in the *Developer Guide*.\n  If you change the value of the ``KeySpec`` property on an existing KMS key, the u"
+      },
+      "keyUsage": {
+        "$ref": "#/types/aws-native:kms:KeyUsage",
+        "description": "Determines the [cryptographic operations](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations) for which you can use the KMS key. The default value is ``ENCRYPT_DECRYPT``. This property is required for asymmetric KMS keys and HMAC KMS keys. You can't change the ``KeyUsage`` value after the KMS key is created.\n  If you change the value of the ``KeyUsage`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value.\n  Select only one valid value.\n  +  For symmetric encryption KMS keys, omit the property or specify ``ENCRYPT_DECRYPT``.\n  +  For asymmetric KMS keys with RSA key material, specify ``ENCRYPT_DECRYPT`` or ``SIGN_VERIFY``.\n  +  For asymmetric KMS keys with ECC key material, specify"
+      },
+      "multiRegion": {
+        "type": "boolean",
+        "description": "Creates a multi-Region primary key that you can replicate in other AWS-Regions. You can't change the ``MultiRegion`` value after the KMS key is created.\n For a list of AWS-Regions in which multi-Region keys are supported, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the **.\n  If you change the value of the ``MultiRegion`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value.\n  For a multi-Region key, set to this property to ``true``. For a single-Region key, omit this property or set it to ``false``. The default value is ``false``.\n *Multi-Region keys* are an KMS feature that lets you create multiple interoperable KMS keys in different AWS-Regions. Bec"
+      },
+      "origin": {
+        "$ref": "#/types/aws-native:kms:KeyOrigin",
+        "description": "The source of the key material for the KMS key. You cannot change the origin after you create the KMS key. The default is ``AWS_KMS``, which means that KMS creates the key material.\n To [create a KMS key with no key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-create-cmk.html) (for imported key material), set this value to ``EXTERNAL``. For more information about importing key material into KMS, see [Importing Key Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) in the *Developer Guide*.\n You can ignore ``ENABLED`` when Origin is ``EXTERNAL``. When a KMS key with Origin ``EXTERNAL`` is created, the key state is ``PENDING_IMPORT`` and ``ENABLED`` is ``false``. After you import the key material, ``ENABLED`` updated to ``true``. The KMS key can then be used for Cryptographic Operations. \n  CFN doesn't support creating an ``Origin`` parameter of the ``AWS_CLOUDHSM`` or ``EXTERNAL_KEY_STORE`` values."
+      },
+      "pendingWindowInDays": {
+        "type": "integer",
+        "description": "Specifies the number of days in the waiting period before KMS deletes a KMS key that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.\n When you remove a KMS key from a CloudFormation stack, KMS schedules the KMS key for deletion and starts the mandatory waiting period. The ``PendingWindowInDays`` property determines the length of waiting period. During the waiting period, the key state of KMS key is ``Pending Deletion`` or ``Pending Replica Deletion``, which prevents the KMS key from being used in cryptographic operations. When the waiting period expires, KMS permanently deletes the KMS key.\n KMS will not delete a [multi-Region primary key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) that has replica keys. If you remove a multi-Region primary key from a CloudFormation stack, its key state changes to ``PendingReplicaDeletion`` so it cannot be replicated or used in cryptographic ope"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Assigns one or more tags to the replica key.\n  Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see [ABAC for](https://docs.aws.amazon.com/kms/latest/developerguide/abac.html) in the *Developer Guide*.\n  For information about tags in KMS, see [Tagging keys](https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html) in the *Developer Guide*. For information about tags in CloudFormation, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html)."
+      }
+    }
+  },
+  "aws-native:kms:ReplicaKey": {
+    "cfTypeName": "AWS::KMS::ReplicaKey",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description of the AWS KMS key. Use a description that helps you to distinguish this AWS KMS key from others in the account, such as its intended use."
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Specifies whether the AWS KMS key is enabled. Disabled AWS KMS keys cannot be used in cryptographic operations."
+      },
+      "keyPolicy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The key policy that authorizes use of the AWS KMS key. The key policy must observe the following rules.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::KMS::ReplicaKey` for more information about the expected schema for this property."
+      },
+      "pendingWindowInDays": {
+        "type": "integer",
+        "description": "Specifies the number of days in the waiting period before AWS KMS deletes an AWS KMS key that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days."
+      },
+      "primaryKeyArn": {
+        "type": "string",
+        "description": "Identifies the primary AWS KMS key to create a replica of. Specify the Amazon Resource Name (ARN) of the AWS KMS key. You cannot specify an alias or key ID. For help finding the ARN, see Finding the Key ID and ARN in the AWS Key Management Service Developer Guide."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:lakeformation:PrincipalPermissions": {
+    "cfTypeName": "AWS::LakeFormation::PrincipalPermissions",
+    "properties": {
+      "catalog": {
+        "type": "string",
+        "description": "The identifier for the GLUDC. By default, the account ID. The GLUDC is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment."
+      },
+      "permissions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lakeformation:PrincipalPermissionsPermission"
+        },
+        "description": "The permissions granted or revoked."
+      },
+      "permissionsWithGrantOption": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lakeformation:PrincipalPermissionsPermission"
+        },
+        "description": "Indicates the ability to grant permissions (as a subset of permissions granted)."
+      },
+      "principal": {
+        "$ref": "#/types/aws-native:lakeformation:PrincipalPermissionsDataLakePrincipal",
+        "description": "The principal to be granted a permission."
+      },
+      "resource": {
+        "$ref": "#/types/aws-native:lakeformation:PrincipalPermissionsResource",
+        "description": "The resource to be granted or revoked permissions."
+      }
+    }
+  },
+  "aws-native:lakeformation:Tag": {
+    "cfTypeName": "AWS::LakeFormation::Tag",
+    "properties": {
+      "catalogId": {
+        "type": "string",
+        "description": "The identifier for the Data Catalog. By default, the account ID. The Data Catalog is the persistent metadata store. It contains database definitions, table definitions, and other control information to manage your Lake Formation environment."
+      },
+      "tagKey": {
+        "type": "string",
+        "description": "The key-name for the LF-tag."
+      },
+      "tagValues": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of possible values an attribute can take."
+      }
+    }
+  },
+  "aws-native:lakeformation:TagAssociation": {
+    "cfTypeName": "AWS::LakeFormation::TagAssociation",
+    "properties": {
+      "lfTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lakeformation:TagAssociationLfTagPair"
+        },
+        "description": "List of Lake Formation Tags to associate with the Lake Formation Resource"
+      },
+      "resource": {
+        "$ref": "#/types/aws-native:lakeformation:TagAssociationResource",
+        "description": "Resource to tag with the Lake Formation Tags"
+      }
+    }
+  },
+  "aws-native:lambda:CodeSigningConfig": {
+    "cfTypeName": "AWS::Lambda::CodeSigningConfig",
+    "properties": {
+      "allowedPublishers": {
+        "$ref": "#/types/aws-native:lambda:CodeSigningConfigAllowedPublishers",
+        "description": "When the CodeSigningConfig is later on attached to a function, the function code will be expected to be signed by profiles from this list"
+      },
+      "codeSigningPolicies": {
+        "$ref": "#/types/aws-native:lambda:CodeSigningConfigCodeSigningPolicies",
+        "description": "Policies to control how to act if a signature is invalid"
+      },
+      "description": {
+        "type": "string",
+        "description": "A description of the CodeSigningConfig"
+      }
+    }
+  },
+  "aws-native:lambda:EventInvokeConfig": {
+    "cfTypeName": "AWS::Lambda::EventInvokeConfig",
+    "properties": {
+      "destinationConfig": {
+        "$ref": "#/types/aws-native:lambda:EventInvokeConfigDestinationConfig"
+      },
+      "functionName": {
+        "type": "string",
+        "description": "The name of the Lambda function."
+      },
+      "maximumEventAgeInSeconds": {
+        "type": "integer",
+        "description": "The maximum age of a request that Lambda sends to a function for processing."
+      },
+      "maximumRetryAttempts": {
+        "type": "integer",
+        "description": "The maximum number of times to retry when the function returns an error."
+      },
+      "qualifier": {
+        "type": "string",
+        "description": "The identifier of a version or alias."
+      }
+    }
+  },
+  "aws-native:lambda:EventSourceMapping": {
+    "cfTypeName": "AWS::Lambda::EventSourceMapping",
+    "properties": {
+      "amazonManagedKafkaEventSourceConfig": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingAmazonManagedKafkaEventSourceConfig",
+        "description": "Specific configuration settings for an MSK event source."
+      },
+      "batchSize": {
+        "type": "integer",
+        "description": "The maximum number of items to retrieve in a single batch."
+      },
+      "bisectBatchOnFunctionError": {
+        "type": "boolean",
+        "description": "(Streams) If the function returns an error, split the batch in two and retry."
+      },
+      "destinationConfig": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingDestinationConfig",
+        "description": "(Streams) An Amazon SQS queue or Amazon SNS topic destination for discarded records."
+      },
+      "documentDbEventSourceConfig": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingDocumentDbEventSourceConfig",
+        "description": "Document db event source config."
+      },
+      "enabled": {
+        "type": "boolean",
+        "description": "Disables the event source mapping to pause polling and invocation."
+      },
+      "eventSourceArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the event source."
+      },
+      "filterCriteria": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingFilterCriteria",
+        "description": "The filter criteria to control event filtering."
+      },
+      "functionName": {
+        "type": "string",
+        "description": "The name of the Lambda function."
+      },
+      "functionResponseTypes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lambda:EventSourceMappingFunctionResponseTypesItem"
+        },
+        "description": "(Streams) A list of response types supported by the function."
+      },
+      "maximumBatchingWindowInSeconds": {
+        "type": "integer",
+        "description": "(Streams) The maximum amount of time to gather records before invoking the function, in seconds."
+      },
+      "maximumRecordAgeInSeconds": {
+        "type": "integer",
+        "description": "(Streams) The maximum age of a record that Lambda sends to a function for processing."
+      },
+      "maximumRetryAttempts": {
+        "type": "integer",
+        "description": "(Streams) The maximum number of times to retry when the function returns an error."
+      },
+      "parallelizationFactor": {
+        "type": "integer",
+        "description": "(Streams) The number of batches to process from each shard concurrently."
+      },
+      "queues": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "(ActiveMQ) A list of ActiveMQ queues."
+      },
+      "scalingConfig": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingScalingConfig",
+        "description": "The scaling configuration for the event source."
+      },
+      "selfManagedEventSource": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingSelfManagedEventSource",
+        "description": "Self-managed event source endpoints."
+      },
+      "selfManagedKafkaEventSourceConfig": {
+        "$ref": "#/types/aws-native:lambda:EventSourceMappingSelfManagedKafkaEventSourceConfig",
+        "description": "Specific configuration settings for a Self-Managed Apache Kafka event source."
+      },
+      "sourceAccessConfigurations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lambda:EventSourceMappingSourceAccessConfiguration"
+        },
+        "description": "A list of SourceAccessConfiguration."
+      },
+      "startingPosition": {
+        "type": "string",
+        "description": "The position in a stream from which to start reading. Required for Amazon Kinesis and Amazon DynamoDB Streams sources."
+      },
+      "startingPositionTimestamp": {
+        "type": "number",
+        "description": "With StartingPosition set to AT_TIMESTAMP, the time from which to start reading, in Unix time seconds."
+      },
+      "topics": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "(Kafka) A list of Kafka topics."
+      },
+      "tumblingWindowInSeconds": {
+        "type": "integer",
+        "description": "(Streams) Tumbling window (non-overlapping time window) duration to perform aggregations."
+      }
+    }
+  },
+  "aws-native:lambda:LayerVersion": {
+    "cfTypeName": "AWS::Lambda::LayerVersion",
+    "properties": {
+      "compatibleArchitectures": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of compatible instruction set architectures."
+      },
+      "compatibleRuntimes": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of compatible function runtimes. Used for filtering with ListLayers and ListLayerVersions."
+      },
+      "content": {
+        "$ref": "#/types/aws-native:lambda:LayerVersionContent",
+        "description": "The function layer archive."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the version."
+      },
+      "layerName": {
+        "type": "string",
+        "description": "The name or Amazon Resource Name (ARN) of the layer."
+      },
+      "licenseInfo": {
+        "type": "string",
+        "description": "The layer's software license."
+      }
+    }
+  },
+  "aws-native:lambda:LayerVersionPermission": {
+    "cfTypeName": "AWS::Lambda::LayerVersionPermission",
+    "properties": {
+      "action": {
+        "type": "string",
+        "description": "The API action that grants access to the layer."
+      },
+      "layerVersionArn": {
+        "type": "string",
+        "description": "The name or Amazon Resource Name (ARN) of the layer."
+      },
+      "organizationId": {
+        "type": "string",
+        "description": "With the principal set to *, grant permission to all accounts in the specified organization."
+      },
+      "principal": {
+        "type": "string",
+        "description": "An account ID, or * to grant layer usage permission to all accounts in an organization, or all AWS accounts (if organizationId is not specified)."
+      }
+    }
+  },
+  "aws-native:lambda:Permission": {
+    "cfTypeName": "AWS::Lambda::Permission",
+    "properties": {
+      "action": {
+        "type": "string",
+        "description": "The action that the principal can use on the function. For example, ``lambda:InvokeFunction`` or ``lambda:GetFunction``."
+      },
+      "eventSourceToken": {
+        "type": "string",
+        "description": "For Alexa Smart Home functions, a token that the invoker must supply."
+      },
+      "functionName": {
+        "type": "string",
+        "description": "The name of the Lambda function, version, or alias.\n  **Name formats**\n +   *Function name* – ``my-function`` (name-only), ``my-function:v1`` (with alias).\n  +   *Function ARN* – ``arn:aws:lambda:us-west-2:123456789012:function:my-function``.\n  +   *Partial ARN* – ``123456789012:function:my-function``.\n  \n You can append a version number or alias to any of the formats. The length constraint applies only to the full ARN. If you specify only the function name, it is limited to 64 characters in length."
+      },
+      "functionUrlAuthType": {
+        "$ref": "#/types/aws-native:lambda:PermissionFunctionUrlAuthType",
+        "description": "The type of authentication that your function URL uses. Set to ``AWS_IAM`` if you want to restrict access to authenticated users only. Set to ``NONE`` if you want to bypass IAM authentication to create a public endpoint. For more information, see [Security and auth model for Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)."
+      },
+      "principal": {
+        "type": "string",
+        "description": "The AWS-service or AWS-account that invokes the function. If you specify a service, use ``SourceArn`` or ``SourceAccount`` to limit who can invoke the function through that service."
+      },
+      "principalOrgId": {
+        "type": "string",
+        "description": "The identifier for your organization in AOlong. Use this to grant permissions to all the AWS-accounts under this organization."
+      },
+      "sourceAccount": {
+        "type": "string",
+        "description": "For AWS-service, the ID of the AWS-account that owns the resource. Use this together with ``SourceArn`` to ensure that the specified account owns the resource. It is possible for an Amazon S3 bucket to be deleted by its owner and recreated by another account."
+      },
+      "sourceArn": {
+        "type": "string",
+        "description": "For AWS-services, the ARN of the AWS resource that invokes the function. For example, an Amazon S3 bucket or Amazon SNS topic.\n Note that Lambda configures the comparison using the ``StringLike`` operator."
+      }
+    }
+  },
+  "aws-native:lambda:Url": {
+    "cfTypeName": "AWS::Lambda::Url",
+    "properties": {
+      "authType": {
+        "$ref": "#/types/aws-native:lambda:UrlAuthType",
+        "description": "Can be either AWS_IAM if the requests are authorized via IAM, or NONE if no authorization is configured on the Function URL."
+      },
+      "cors": {
+        "$ref": "#/types/aws-native:lambda:UrlCors"
+      },
+      "invokeMode": {
+        "$ref": "#/types/aws-native:lambda:UrlInvokeMode",
+        "description": "The invocation mode for the function’s URL. Set to BUFFERED if you want to buffer responses before returning them to the client. Set to RESPONSE_STREAM if you want to stream responses, allowing faster time to first byte and larger response payload sizes. If not set, defaults to BUFFERED."
+      },
+      "qualifier": {
+        "type": "string",
+        "description": "The alias qualifier for the target function. If TargetFunctionArn is unqualified then Qualifier must be passed."
+      },
+      "targetFunctionArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the function associated with the Function URL."
+      }
+    }
+  },
+  "aws-native:lambda:Version": {
+    "cfTypeName": "AWS::Lambda::Version",
+    "properties": {
+      "codeSha256": {
+        "type": "string",
+        "description": "Only publish a version if the hash value matches the value that's specified. Use this option to avoid publishing a version if the function code has changed since you last updated it. Updates are not supported for this property."
+      },
+      "description": {
+        "type": "string",
+        "description": "A description for the version to override the description in the function configuration. Updates are not supported for this property."
+      },
+      "functionName": {
+        "type": "string",
+        "description": "The name of the Lambda function."
+      },
+      "provisionedConcurrencyConfig": {
+        "$ref": "#/types/aws-native:lambda:VersionProvisionedConcurrencyConfiguration",
+        "description": "Specifies a provisioned concurrency configuration for a function's version. Updates are not supported for this property."
+      },
+      "runtimePolicy": {
+        "$ref": "#/types/aws-native:lambda:VersionRuntimePolicy",
+        "description": "Specifies the runtime management configuration of a function. Displays runtimeVersionArn only for Manual."
+      }
+    }
+  },
+  "aws-native:lex:BotVersion": {
+    "cfTypeName": "AWS::Lex::BotVersion",
+    "properties": {
+      "botId": {
+        "type": "string"
+      },
+      "botVersionLocaleSpecification": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lex:BotVersionLocaleSpecification"
+        }
+      },
+      "description": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:lex:ResourcePolicy": {
+    "cfTypeName": "AWS::Lex::ResourcePolicy",
+    "properties": {
+      "policy": {
+        "$ref": "#/types/aws-native:lex:ResourcePolicyPolicy"
+      },
+      "resourceArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:lightsail:Container": {
+    "cfTypeName": "AWS::Lightsail::Container",
+    "properties": {
+      "containerServiceDeployment": {
+        "$ref": "#/types/aws-native:lightsail:ContainerServiceDeployment",
+        "description": "Describes a container deployment configuration of an Amazon Lightsail container service."
+      },
+      "isDisabled": {
+        "type": "boolean",
+        "description": "A Boolean value to indicate whether the container service is disabled."
+      },
+      "power": {
+        "type": "string",
+        "description": "The power specification for the container service."
+      },
+      "privateRegistryAccess": {
+        "$ref": "#/types/aws-native:lightsail:ContainerPrivateRegistryAccess",
+        "description": "A Boolean value to indicate whether the container service has access to private container image repositories, such as Amazon Elastic Container Registry (Amazon ECR) private repositories."
+      },
+      "publicDomainNames": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lightsail:ContainerPublicDomainName"
+        },
+        "description": "The public domain names to use with the container service, such as example.com and www.example.com."
+      },
+      "scale": {
+        "type": "integer",
+        "description": "The scale specification for the container service."
+      },
+      "serviceName": {
+        "type": "string",
+        "description": "The name for the container service."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:lightsail:Database": {
+    "cfTypeName": "AWS::Lightsail::Database",
+    "properties": {
+      "availabilityZone": {
+        "type": "string",
+        "description": "The Availability Zone in which to create your new database. Use the us-east-2a case-sensitive format."
+      },
+      "backupRetention": {
+        "type": "boolean",
+        "description": "When true, enables automated backup retention for your database. Updates are applied during the next maintenance window because this can result in an outage."
+      },
+      "caCertificateIdentifier": {
+        "type": "string",
+        "description": "Indicates the certificate that needs to be associated with the database."
+      },
+      "masterDatabaseName": {
+        "type": "string",
+        "description": "The name of the database to create when the Lightsail database resource is created. For MySQL, if this parameter isn't specified, no database is created in the database resource. For PostgreSQL, if this parameter isn't specified, a database named postgres is created in the database resource."
+      },
+      "masterUserPassword": {
+        "type": "string",
+        "description": "The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\". It cannot contain spaces."
+      },
+      "masterUsername": {
+        "type": "string",
+        "description": "The name for the master user."
+      },
+      "preferredBackupWindow": {
+        "type": "string",
+        "description": "The daily time range during which automated backups are created for your new database if automated backups are enabled."
+      },
+      "preferredMaintenanceWindow": {
+        "type": "string",
+        "description": "The weekly time range during which system maintenance can occur on your new database."
+      },
+      "publiclyAccessible": {
+        "type": "boolean",
+        "description": "Specifies the accessibility options for your new database. A value of true specifies a database that is available to resources outside of your Lightsail account. A value of false specifies a database that is available only to your Lightsail resources in the same region as your database."
+      },
+      "relationalDatabaseBlueprintId": {
+        "type": "string",
+        "description": "The blueprint ID for your new database. A blueprint describes the major engine version of a database."
+      },
+      "relationalDatabaseBundleId": {
+        "type": "string",
+        "description": "The bundle ID for your new database. A bundle describes the performance specifications for your database."
+      },
+      "relationalDatabaseName": {
+        "type": "string",
+        "description": "The name to use for your new Lightsail database resource."
+      },
+      "relationalDatabaseParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:lightsail:DatabaseRelationalDatabaseParameter"
+        },
+        "description": "Update one or more parameters of the relational database."
+      },
+      "rotateMasterUserPassword": {
+        "type": "boolean",
+        "description": "When true, the master user password is changed to a new strong password generated by Lightsail. Use the get relational database master user password operation to get the new password."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:lightsail:LoadBalancerTlsCertificate": {
+    "cfTypeName": "AWS::Lightsail::LoadBalancerTlsCertificate",
+    "properties": {
+      "certificateAlternativeNames": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "An array of strings listing alternative domains and subdomains for your SSL/TLS certificate."
+      },
+      "certificateDomainName": {
+        "type": "string",
+        "description": "The domain name (e.g., example.com ) for your SSL/TLS certificate."
+      },
+      "certificateName": {
+        "type": "string",
+        "description": "The SSL/TLS certificate name."
+      },
+      "httpsRedirectionEnabled": {
+        "type": "boolean",
+        "description": "A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer."
+      },
+      "isAttached": {
+        "type": "boolean",
+        "description": "When true, the SSL/TLS certificate is attached to the Lightsail load balancer."
+      },
+      "loadBalancerName": {
+        "type": "string",
+        "description": "The name of your load balancer."
+      }
+    }
+  },
+  "aws-native:location:ApiKey": {
+    "cfTypeName": "AWS::Location::APIKey",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "expireTime": {
+        "type": "string"
+      },
+      "forceDelete": {
+        "type": "boolean"
+      },
+      "forceUpdate": {
+        "type": "boolean"
+      },
+      "keyName": {
+        "type": "string"
+      },
+      "noExpiry": {
+        "type": "boolean"
+      },
+      "restrictions": {
+        "$ref": "#/types/aws-native:location:ApiKeyRestrictions"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:location:GeofenceCollection": {
+    "cfTypeName": "AWS::Location::GeofenceCollection",
+    "properties": {
+      "collectionName": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "kmsKeyId": {
+        "type": "string"
+      },
+      "pricingPlan": {
+        "$ref": "#/types/aws-native:location:GeofenceCollectionPricingPlan"
+      },
+      "pricingPlanDataSource": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:location:PlaceIndex": {
+    "cfTypeName": "AWS::Location::PlaceIndex",
+    "properties": {
+      "dataSource": {
+        "type": "string"
+      },
+      "dataSourceConfiguration": {
+        "$ref": "#/types/aws-native:location:PlaceIndexDataSourceConfiguration"
+      },
+      "description": {
+        "type": "string"
+      },
+      "indexName": {
+        "type": "string"
+      },
+      "pricingPlan": {
+        "$ref": "#/types/aws-native:location:PlaceIndexPricingPlan"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:location:RouteCalculator": {
+    "cfTypeName": "AWS::Location::RouteCalculator",
+    "properties": {
+      "calculatorName": {
+        "type": "string"
+      },
+      "dataSource": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "pricingPlan": {
+        "$ref": "#/types/aws-native:location:RouteCalculatorPricingPlan"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:location:TrackerConsumer": {
+    "cfTypeName": "AWS::Location::TrackerConsumer",
+    "properties": {
+      "consumerArn": {
+        "type": "string"
+      },
+      "trackerName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:logs:AccountPolicy": {
+    "cfTypeName": "AWS::Logs::AccountPolicy",
+    "properties": {
+      "policyDocument": {
+        "type": "string",
+        "description": "The body of the policy document you want to use for this topic.\n\nYou can only add one policy per PolicyType.\n\nThe policy must be in JSON string format.\n\nLength Constraints: Maximum length of 30720"
+      },
+      "policyName": {
+        "type": "string",
+        "description": "The name of the account policy"
+      },
+      "policyType": {
+        "$ref": "#/types/aws-native:logs:AccountPolicyPolicyType",
+        "description": "Type of the policy."
+      },
+      "scope": {
+        "$ref": "#/types/aws-native:logs:AccountPolicyScope",
+        "description": "Scope for policy application"
+      },
+      "selectionCriteria": {
+        "type": "string",
+        "description": "Log group  selection criteria to apply policy only to a subset of log groups. SelectionCriteria string can be up to 25KB and cloudwatchlogs determines the length of selectionCriteria by using its UTF-8 bytes"
+      }
+    }
+  },
+  "aws-native:logs:Delivery": {
+    "cfTypeName": "AWS::Logs::Delivery",
+    "properties": {
+      "deliveryDestinationArn": {
+        "type": "string",
+        "description": "The ARN of the delivery destination that is associated with this delivery."
+      },
+      "deliverySourceName": {
+        "type": "string",
+        "description": "The name of the delivery source that is associated with this delivery."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags that have been assigned to this delivery."
+      }
+    }
+  },
+  "aws-native:logs:LogAnomalyDetector": {
+    "cfTypeName": "AWS::Logs::LogAnomalyDetector",
+    "properties": {
+      "accountId": {
+        "type": "string",
+        "description": "Account ID for owner of detector"
+      },
+      "anomalyVisibilityTime": {
+        "type": "number"
+      },
+      "detectorName": {
+        "type": "string",
+        "description": "Name of detector"
+      },
+      "evaluationFrequency": {
+        "$ref": "#/types/aws-native:logs:LogAnomalyDetectorEvaluationFrequency",
+        "description": "How often log group is evaluated"
+      },
+      "filterPattern": {
+        "type": "string"
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data."
+      },
+      "logGroupArnList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of Arns for the given log group"
+      }
+    }
+  },
+  "aws-native:logs:MetricFilter": {
+    "cfTypeName": "AWS::Logs::MetricFilter",
+    "properties": {
+      "filterName": {
+        "type": "string",
+        "description": "A name for the metric filter."
+      },
+      "filterPattern": {
+        "type": "string",
+        "description": "Pattern that Logs follows to interpret each entry in a log."
+      },
+      "logGroupName": {
+        "type": "string",
+        "description": "Existing log group that you want to associate with this filter."
+      },
+      "metricTransformations": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:logs:MetricFilterMetricTransformation"
+        },
+        "description": "A collection of information that defines how metric data gets emitted."
+      }
+    }
+  },
+  "aws-native:logs:ResourcePolicy": {
+    "cfTypeName": "AWS::Logs::ResourcePolicy",
+    "properties": {
+      "policyDocument": {
+        "type": "string",
+        "description": "The policy document"
+      },
+      "policyName": {
+        "type": "string",
+        "description": "A name for resource policy"
+      }
+    }
+  },
+  "aws-native:logs:SubscriptionFilter": {
+    "cfTypeName": "AWS::Logs::SubscriptionFilter",
+    "properties": {
+      "destinationArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the destination."
+      },
+      "distribution": {
+        "$ref": "#/types/aws-native:logs:SubscriptionFilterDistribution",
+        "description": "The method used to distribute log data to the destination. By default, log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream."
+      },
+      "filterName": {
+        "type": "string",
+        "description": "The name of the filter generated by resource."
+      },
+      "filterPattern": {
+        "type": "string",
+        "description": "The filtering expressions that restrict what gets delivered to the destination AWS resource."
+      },
+      "logGroupName": {
+        "type": "string",
+        "description": "Existing log group that you want to associate with this filter."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The ARN of an IAM role that grants CloudWatch Logs permissions to deliver ingested log events to the destination stream. You don't need to provide the ARN when you are working with a logical destination for cross-account delivery."
+      }
+    }
+  },
+  "aws-native:macie:Session": {
+    "cfTypeName": "AWS::Macie::Session",
+    "properties": {
+      "findingPublishingFrequency": {
+        "$ref": "#/types/aws-native:macie:SessionFindingPublishingFrequency",
+        "description": "A enumeration value that specifies how frequently finding updates are published."
+      },
+      "status": {
+        "$ref": "#/types/aws-native:macie:SessionStatus",
+        "description": "A enumeration value that specifies the status of the Macie Session."
+      }
+    }
+  },
+  "aws-native:medialive:Multiplexprogram": {
+    "cfTypeName": "AWS::MediaLive::Multiplexprogram",
+    "properties": {
+      "channelId": {
+        "type": "string",
+        "description": "The MediaLive channel associated with the program."
+      },
+      "multiplexId": {
+        "type": "string",
+        "description": "The ID of the multiplex that the program belongs to."
+      },
+      "multiplexProgramSettings": {
+        "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramSettings",
+        "description": "The settings for this multiplex program."
+      },
+      "packetIdentifiersMap": {
+        "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramPacketIdentifiersMap",
+        "description": "The packet identifier map for this multiplex program."
+      },
+      "pipelineDetails": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramPipelineDetail"
+        },
+        "description": "Contains information about the current sources for the specified program in the specified multiplex. Keep in mind that each multiplex pipeline connects to both pipelines in a given source channel (the channel identified by the program). But only one of those channel pipelines is ever active at one time."
+      },
+      "preferredChannelPipeline": {
+        "$ref": "#/types/aws-native:medialive:MultiplexprogramPreferredChannelPipeline",
+        "description": "The settings for this multiplex program."
+      },
+      "programName": {
+        "type": "string",
+        "description": "The name of the multiplex program."
+      }
+    }
+  },
+  "aws-native:mediapackage:Asset": {
+    "cfTypeName": "AWS::MediaPackage::Asset",
+    "properties": {
+      "awsId": {
+        "type": "string",
+        "description": "The unique identifier for the Asset."
+      },
+      "egressEndpoints": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:mediapackage:AssetEgressEndpoint"
+        },
+        "description": "The list of egress endpoints available for the Asset."
+      },
+      "packagingGroupId": {
+        "type": "string",
+        "description": "The ID of the PackagingGroup for the Asset."
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "The resource ID to include in SPEKE key requests."
+      },
+      "sourceArn": {
+        "type": "string",
+        "description": "ARN of the source object in S3."
+      },
+      "sourceRoleArn": {
+        "type": "string",
+        "description": "The IAM role_arn used to access the source S3 bucket."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A collection of tags associated with a resource"
+      }
+    }
+  },
+  "aws-native:mediapackage:Channel": {
+    "cfTypeName": "AWS::MediaPackage::Channel",
+    "properties": {
+      "awsId": {
+        "type": "string",
+        "description": "The ID of the Channel."
+      },
+      "description": {
+        "type": "string",
+        "description": "A short text description of the Channel."
+      },
+      "egressAccessLogs": {
+        "$ref": "#/types/aws-native:mediapackage:ChannelLogConfiguration",
+        "description": "The configuration parameters for egress access logging."
+      },
+      "hlsIngest": {
+        "$ref": "#/types/aws-native:mediapackage:ChannelHlsIngest",
+        "description": "An HTTP Live Streaming (HLS) ingest resource configuration."
+      },
+      "ingressAccessLogs": {
+        "$ref": "#/types/aws-native:mediapackage:ChannelLogConfiguration",
+        "description": "The configuration parameters for egress access logging."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "A collection of tags associated with a resource"
+      }
+    }
+  },
+  "aws-native:mediapackage:OriginEndpoint": {
+    "cfTypeName": "AWS::MediaPackage::OriginEndpoint",
+    "properties": {
+      "authorization": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointAuthorization"
+      },
+      "awsId": {
+        "type": "string",
+        "description": "The ID of the OriginEndpoint."
+      },
+      "channelId": {
+        "type": "string",
+        "description": "The ID of the Channel the OriginEndpoint is associated with."
+      },
+      "cmafPackage": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointCmafPackage"
+      },
+      "dashPackage": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointDashPackage"
+      },
+      "description": {
+        "type": "string",
+        "description": "A short text description of the OriginEndpoint."
+      },
+      "hlsPackage": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointHlsPackage"
+      },
+      "manifestName": {
+        "type": "string",
+        "description": "A short string appended to the end of the OriginEndpoint URL."
+      },
+      "mssPackage": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointMssPackage"
+      },
+      "origination": {
+        "$ref": "#/types/aws-native:mediapackage:OriginEndpointOrigination",
+        "description": "Control whether origination of video is allowed for this OriginEndpoint. If set to ALLOW, the OriginEndpoint may by requested, pursuant to any other form of access control. If set to DENY, the OriginEndpoint may not be requested. This can be helpful for Live to VOD harvesting, or for temporarily disabling origination"
+      },
+      "startoverWindowSeconds": {
+        "type": "integer",
+        "description": "Maximum duration (seconds) of content to retain for startover playback. If not specified, startover playback will be disabled for the OriginEndpoint."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A collection of tags associated with a resource"
+      },
+      "timeDelaySeconds": {
+        "type": "integer",
+        "description": "Amount of delay (seconds) to enforce on the playback of live content. If not specified, there will be no time delay in effect for the OriginEndpoint."
+      },
+      "whitelist": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of source IP CIDR blocks that will be allowed to access the OriginEndpoint."
+      }
+    }
+  },
+  "aws-native:mediapackage:PackagingConfiguration": {
+    "cfTypeName": "AWS::MediaPackage::PackagingConfiguration",
+    "properties": {
+      "awsId": {
+        "type": "string",
+        "description": "The ID of the PackagingConfiguration."
+      },
+      "cmafPackage": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingConfigurationCmafPackage",
+        "description": "A CMAF packaging configuration."
+      },
+      "dashPackage": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingConfigurationDashPackage",
+        "description": "A Dynamic Adaptive Streaming over HTTP (DASH) packaging configuration."
+      },
+      "hlsPackage": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingConfigurationHlsPackage",
+        "description": "An HTTP Live Streaming (HLS) packaging configuration."
+      },
+      "mssPackage": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingConfigurationMssPackage",
+        "description": "A Microsoft Smooth Streaming (MSS) PackagingConfiguration."
+      },
+      "packagingGroupId": {
+        "type": "string",
+        "description": "The ID of a PackagingGroup."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A collection of tags associated with a resource"
+      }
+    }
+  },
+  "aws-native:mediapackage:PackagingGroup": {
+    "cfTypeName": "AWS::MediaPackage::PackagingGroup",
+    "properties": {
+      "authorization": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingGroupAuthorization",
+        "description": "CDN Authorization"
+      },
+      "awsId": {
+        "type": "string",
+        "description": "The ID of the PackagingGroup."
+      },
+      "egressAccessLogs": {
+        "$ref": "#/types/aws-native:mediapackage:PackagingGroupLogConfiguration",
+        "description": "The configuration parameters for egress access logging."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "A collection of tags associated with a resource"
+      }
+    }
+  },
+  "aws-native:mediapackagev2:ChannelPolicy": {
+    "cfTypeName": "AWS::MediaPackageV2::ChannelPolicy",
+    "properties": {
+      "channelGroupName": {
+        "type": "string"
+      },
+      "channelName": {
+        "type": "string"
+      },
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::MediaPackageV2::ChannelPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:mediapackagev2:OriginEndpointPolicy": {
+    "cfTypeName": "AWS::MediaPackageV2::OriginEndpointPolicy",
+    "properties": {
+      "channelGroupName": {
+        "type": "string"
+      },
+      "channelName": {
+        "type": "string"
+      },
+      "originEndpointName": {
+        "type": "string"
+      },
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::MediaPackageV2::OriginEndpointPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:mediatailor:ChannelPolicy": {
+    "cfTypeName": "AWS::MediaTailor::ChannelPolicy",
+    "properties": {
+      "channelName": {
+        "type": "string"
+      },
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "\u003cp\u003eThe IAM policy for the channel. IAM policies are used to control access to your channel.\u003c/p\u003e\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::MediaTailor::ChannelPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:msk:BatchScramSecret": {
+    "cfTypeName": "AWS::MSK::BatchScramSecret",
+    "properties": {
+      "clusterArn": {
+        "type": "string"
+      },
+      "secretArnList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:msk:ClusterPolicy": {
+    "cfTypeName": "AWS::MSK::ClusterPolicy",
+    "properties": {
+      "clusterArn": {
+        "type": "string",
+        "description": "The arn of the cluster for the resource policy."
+      },
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified cluster.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::MSK::ClusterPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:msk:ServerlessCluster": {
+    "cfTypeName": "AWS::MSK::ServerlessCluster",
+    "properties": {
+      "clientAuthentication": {
+        "$ref": "#/types/aws-native:msk:ServerlessClusterClientAuthentication"
+      },
+      "clusterName": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "A key-value pair to associate with a resource."
+      },
+      "vpcConfigs": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:msk:ServerlessClusterVpcConfig"
+        }
+      }
+    }
+  },
+  "aws-native:msk:VpcConnection": {
+    "cfTypeName": "AWS::MSK::VpcConnection",
+    "properties": {
+      "authentication": {
+        "$ref": "#/types/aws-native:msk:VpcConnectionAuthentication"
+      },
+      "clientSubnets": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "securityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "targetClusterArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the target cluster"
+      },
+      "vpcId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:neptune:DbCluster": {
+    "cfTypeName": "AWS::Neptune::DBCluster",
+    "properties": {
+      "associatedRoles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:neptune:DbClusterDbClusterRole"
+        },
+        "description": "Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf."
+      },
+      "availabilityZones": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Provides the list of EC2 Availability Zones that instances in the DB cluster can be created in."
+      },
+      "backupRetentionPeriod": {
+        "type": "integer",
+        "description": "Specifies the number of days for which automatic DB snapshots are retained."
+      },
+      "copyTagsToSnapshot": {
+        "type": "boolean",
+        "description": "A value that indicates whether to copy all tags from the DB cluster to snapshots of the DB cluster. The default behaviour is not to copy them."
+      },
+      "dbClusterIdentifier": {
+        "type": "string",
+        "description": "The DB cluster identifier. Contains a user-supplied DB cluster identifier. This identifier is the unique key that identifies a DB cluster stored as a lowercase string."
+      },
+      "dbClusterParameterGroupName": {
+        "type": "string",
+        "description": "Provides the name of the DB cluster parameter group."
+      },
+      "dbInstanceParameterGroupName": {
+        "type": "string",
+        "description": "The name of the DB parameter group to apply to all instances of the DB cluster. Used only in case of a major EngineVersion upgrade request."
+      },
+      "dbPort": {
+        "type": "integer",
+        "description": "The port number on which the DB instances in the DB cluster accept connections. \n\nIf not specified, the default port used is `8182`. \n\nNote: `Port` property will soon be deprecated from this resource. Please update existing templates to rename it with new property `DBPort` having same functionalities."
+      },
+      "dbSubnetGroupName": {
+        "type": "string",
+        "description": "Specifies information on the subnet group associated with the DB cluster, including the name, description, and subnets in the subnet group."
+      },
+      "deletionProtection": {
+        "type": "boolean",
+        "description": "Indicates whether or not the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled."
+      },
+      "enableCloudwatchLogsExports": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Specifies a list of log types that are enabled for export to CloudWatch Logs."
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "Indicates the database engine version."
+      },
+      "iamAuthEnabled": {
+        "type": "boolean",
+        "description": "True if mapping of Amazon Identity and Access Management (IAM) accounts to database accounts is enabled, and otherwise false."
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "If `StorageEncrypted` is true, the Amazon KMS key identifier for the encrypted DB cluster."
+      },
+      "preferredBackupWindow": {
+        "type": "string",
+        "description": "Specifies the daily time range during which automated backups are created if automated backups are enabled, as determined by the BackupRetentionPeriod."
+      },
+      "preferredMaintenanceWindow": {
+        "type": "string",
+        "description": "Specifies the weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC)."
+      },
+      "restoreToTime": {
+        "type": "string",
+        "description": "Creates a new DB cluster from a DB snapshot or DB cluster snapshot.\n\nIf a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.\n\nIf a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group."
+      },
+      "restoreType": {
+        "type": "string",
+        "description": "Creates a new DB cluster from a DB snapshot or DB cluster snapshot.\n\nIf a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.\n\nIf a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group."
+      },
+      "serverlessScalingConfiguration": {
+        "$ref": "#/types/aws-native:neptune:DbClusterServerlessScalingConfiguration",
+        "description": "Contains the scaling configuration used by the Neptune Serverless Instances within this DB cluster."
+      },
+      "snapshotIdentifier": {
+        "type": "string",
+        "description": "Specifies the identifier for a DB cluster snapshot. Must match the identifier of an existing snapshot.\n\nAfter you restore a DB cluster using a SnapshotIdentifier, you must specify the same SnapshotIdentifier for any future updates to the DB cluster. When you specify this property for an update, the DB cluster is not restored from the snapshot again, and the data in the database is not changed.\n\nHowever, if you don't specify the SnapshotIdentifier, an empty DB cluster is created, and the original DB cluster is deleted. If you specify a property that is different from the previous snapshot restore property, the DB cluster is restored from the snapshot specified by the SnapshotIdentifier, and the original DB cluster is deleted."
+      },
+      "sourceDbClusterIdentifier": {
+        "type": "string",
+        "description": "Creates a new DB cluster from a DB snapshot or DB cluster snapshot.\n\nIf a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.\n\nIf a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group."
+      },
+      "storageEncrypted": {
+        "type": "boolean",
+        "description": "Indicates whether the DB cluster is encrypted.\n\nIf you specify the `DBClusterIdentifier`, `DBSnapshotIdentifier`, or `SourceDBInstanceIdentifier` property, don't specify this property. The value is inherited from the cluster, snapshot, or source DB instance. If you specify the KmsKeyId property, you must enable encryption.\n\nIf you specify the KmsKeyId, you must enable encryption by setting StorageEncrypted to true."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags assigned to this cluster."
+      },
+      "useLatestRestorableTime": {
+        "type": "boolean",
+        "description": "Creates a new DB cluster from a DB snapshot or DB cluster snapshot.\n\nIf a DB snapshot is specified, the target DB cluster is created from the source DB snapshot with a default configuration and default security group.\n\nIf a DB cluster snapshot is specified, the target DB cluster is created from the source DB cluster restore point with the same configuration as the original source DB cluster, except that the new DB cluster is created with the default security group."
+      },
+      "vpcSecurityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Provides a list of VPC security groups that the DB cluster belongs to."
+      }
+    }
+  },
+  "aws-native:neptunegraph:PrivateGraphEndpoint": {
+    "cfTypeName": "AWS::NeptuneGraph::PrivateGraphEndpoint",
+    "properties": {
+      "graphIdentifier": {
+        "type": "string",
+        "description": "The auto-generated Graph Id assigned by the service."
+      },
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The security group Ids associated with the VPC where you want the private graph endpoint to be created, ie, the graph will be reachable from within the VPC."
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The subnet Ids associated with the VPC where you want the private graph endpoint to be created, ie, the graph will be reachable from within the VPC."
+      },
+      "vpcId": {
+        "type": "string",
+        "description": "The VPC where you want the private graph endpoint to be created, ie, the graph will be reachable from within the VPC."
+      }
+    }
+  },
+  "aws-native:networkfirewall:LoggingConfiguration": {
+    "cfTypeName": "AWS::NetworkFirewall::LoggingConfiguration",
+    "properties": {
+      "firewallArn": {
+        "type": "string"
+      },
+      "firewallName": {
+        "type": "string"
+      },
+      "loggingConfiguration": {
+        "$ref": "#/types/aws-native:networkfirewall:LoggingConfiguration",
+        "language": {
+          "csharp": {
+            "name": "LoggingConfigurationValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:networkmanager:ConnectAttachment": {
+    "cfTypeName": "AWS::NetworkManager::ConnectAttachment",
+    "properties": {
+      "coreNetworkId": {
+        "type": "string",
+        "description": "ID of the CoreNetwork that the attachment will be attached to."
+      },
+      "edgeLocation": {
+        "type": "string",
+        "description": "Edge location of the attachment."
+      },
+      "options": {
+        "$ref": "#/types/aws-native:networkmanager:ConnectAttachmentOptions",
+        "description": "Protocol options for connect attachment"
+      },
+      "proposedSegmentChange": {
+        "$ref": "#/types/aws-native:networkmanager:ConnectAttachmentProposedSegmentChange",
+        "description": "The attachment to move from one segment to another."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Tags for the attachment."
+      },
+      "transportAttachmentId": {
+        "type": "string",
+        "description": "Id of transport attachment"
+      }
+    }
+  },
+  "aws-native:networkmanager:ConnectPeer": {
+    "cfTypeName": "AWS::NetworkManager::ConnectPeer",
+    "properties": {
+      "bgpOptions": {
+        "$ref": "#/types/aws-native:networkmanager:ConnectPeerBgpOptions",
+        "description": "Bgp options for connect peer."
+      },
+      "connectAttachmentId": {
+        "type": "string",
+        "description": "The ID of the attachment to connect."
+      },
+      "coreNetworkAddress": {
+        "type": "string",
+        "description": "The IP address of a core network."
+      },
+      "insideCidrBlocks": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The inside IP addresses used for a Connect peer configuration."
+      },
+      "peerAddress": {
+        "type": "string",
+        "description": "The IP address of the Connect peer."
+      },
+      "subnetArn": {
+        "type": "string",
+        "description": "The subnet ARN for the connect peer."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:networkmanager:CoreNetwork": {
+    "cfTypeName": "AWS::NetworkManager::CoreNetwork",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of core network"
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network that your core network is a part of."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Live policy document for the core network, you must provide PolicyDocument in Json Format\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::NetworkManager::CoreNetwork` for more information about the expected schema for this property."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the global network."
+      }
+    }
+  },
+  "aws-native:networkmanager:CustomerGatewayAssociation": {
+    "cfTypeName": "AWS::NetworkManager::CustomerGatewayAssociation",
+    "properties": {
+      "customerGatewayArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the customer gateway."
+      },
+      "deviceId": {
+        "type": "string",
+        "description": "The ID of the device"
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "linkId": {
+        "type": "string",
+        "description": "The ID of the link"
+      }
+    }
+  },
+  "aws-native:networkmanager:Device": {
+    "cfTypeName": "AWS::NetworkManager::Device",
+    "properties": {
+      "awsLocation": {
+        "$ref": "#/types/aws-native:networkmanager:DeviceAwsLocation",
+        "description": "The Amazon Web Services location of the device, if applicable."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the device."
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "location": {
+        "$ref": "#/types/aws-native:networkmanager:DeviceLocation",
+        "description": "The site location."
+      },
+      "model": {
+        "type": "string",
+        "description": "The device model"
+      },
+      "serialNumber": {
+        "type": "string",
+        "description": "The device serial number."
+      },
+      "siteId": {
+        "type": "string",
+        "description": "The site ID."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the device."
+      },
+      "type": {
+        "type": "string",
+        "description": "The device type."
+      },
+      "vendor": {
+        "type": "string",
+        "description": "The device vendor."
+      }
+    }
+  },
+  "aws-native:networkmanager:GlobalNetwork": {
+    "cfTypeName": "AWS::NetworkManager::GlobalNetwork",
+    "properties": {
+      "createdAt": {
+        "type": "string",
+        "description": "The date and time that the global network was created."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the global network."
+      },
+      "state": {
+        "type": "string",
+        "description": "The state of the global network."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the global network."
+      }
+    }
+  },
+  "aws-native:networkmanager:Link": {
+    "cfTypeName": "AWS::NetworkManager::Link",
+    "properties": {
+      "bandwidth": {
+        "$ref": "#/types/aws-native:networkmanager:LinkBandwidth",
+        "description": "The Bandwidth for the link."
+      },
+      "description": {
+        "type": "string",
+        "description": "The description of the link."
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "provider": {
+        "type": "string",
+        "description": "The provider of the link."
+      },
+      "siteId": {
+        "type": "string",
+        "description": "The ID of the site"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the link."
+      },
+      "type": {
+        "type": "string",
+        "description": "The type of the link."
+      }
+    }
+  },
+  "aws-native:networkmanager:LinkAssociation": {
+    "cfTypeName": "AWS::NetworkManager::LinkAssociation",
+    "properties": {
+      "deviceId": {
+        "type": "string",
+        "description": "The ID of the device"
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "linkId": {
+        "type": "string",
+        "description": "The ID of the link"
+      }
+    }
+  },
+  "aws-native:networkmanager:Site": {
+    "cfTypeName": "AWS::NetworkManager::Site",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the site."
+      },
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "location": {
+        "$ref": "#/types/aws-native:networkmanager:SiteLocation",
+        "description": "The location of the site."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags for the site."
+      }
+    }
+  },
+  "aws-native:networkmanager:SiteToSiteVpnAttachment": {
+    "cfTypeName": "AWS::NetworkManager::SiteToSiteVpnAttachment",
+    "properties": {
+      "coreNetworkId": {
+        "type": "string",
+        "description": "The ID of a core network where you're creating a site-to-site VPN attachment."
+      },
+      "proposedSegmentChange": {
+        "$ref": "#/types/aws-native:networkmanager:SiteToSiteVpnAttachmentProposedSegmentChange",
+        "description": "The attachment to move from one segment to another."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Tags for the attachment."
+      },
+      "vpnConnectionArn": {
+        "type": "string",
+        "description": "The ARN of the site-to-site VPN attachment."
+      }
+    }
+  },
+  "aws-native:networkmanager:TransitGatewayPeering": {
+    "cfTypeName": "AWS::NetworkManager::TransitGatewayPeering",
+    "properties": {
+      "coreNetworkId": {
+        "type": "string",
+        "description": "The Id of the core network that you want to peer a transit gateway to."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "transitGatewayArn": {
+        "type": "string",
+        "description": "The ARN (Amazon Resource Name) of the transit gateway that you will peer to a core network"
+      }
+    }
+  },
+  "aws-native:networkmanager:TransitGatewayRegistration": {
+    "cfTypeName": "AWS::NetworkManager::TransitGatewayRegistration",
+    "properties": {
+      "globalNetworkId": {
+        "type": "string",
+        "description": "The ID of the global network."
+      },
+      "transitGatewayArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the transit gateway."
+      }
+    }
+  },
+  "aws-native:networkmanager:TransitGatewayRouteTableAttachment": {
+    "cfTypeName": "AWS::NetworkManager::TransitGatewayRouteTableAttachment",
+    "properties": {
+      "peeringId": {
+        "type": "string",
+        "description": "The Id of peering between transit gateway and core network."
+      },
+      "proposedSegmentChange": {
+        "$ref": "#/types/aws-native:networkmanager:TransitGatewayRouteTableAttachmentProposedSegmentChange",
+        "description": "The attachment to move from one segment to another."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "transitGatewayRouteTableArn": {
+        "type": "string",
+        "description": "The Arn of transit gateway route table."
+      }
+    }
+  },
+  "aws-native:networkmanager:VpcAttachment": {
+    "cfTypeName": "AWS::NetworkManager::VpcAttachment",
+    "properties": {
+      "coreNetworkId": {
+        "type": "string",
+        "description": "The ID of a core network for the VPC attachment."
+      },
+      "options": {
+        "$ref": "#/types/aws-native:networkmanager:VpcAttachmentVpcOptions",
+        "description": "Vpc options of the attachment."
+      },
+      "proposedSegmentChange": {
+        "$ref": "#/types/aws-native:networkmanager:VpcAttachmentProposedSegmentChange",
+        "description": "The attachment to move from one segment to another."
+      },
+      "subnetArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Subnet Arn list"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Tags for the attachment."
+      },
+      "vpcArn": {
+        "type": "string",
+        "description": "The ARN of the VPC."
+      }
+    }
+  },
+  "aws-native:oam:Link": {
+    "cfTypeName": "AWS::Oam::Link",
+    "properties": {
+      "labelTemplate": {
+        "type": "string"
+      },
+      "resourceTypes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:oam:LinkResourceType"
+        }
+      },
+      "sinkIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Tags to apply to the link"
+      }
+    }
+  },
+  "aws-native:organizations:Organization": {
+    "cfTypeName": "AWS::Organizations::Organization",
+    "properties": {
+      "featureSet": {
+        "$ref": "#/types/aws-native:organizations:OrganizationFeatureSet",
+        "description": "Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality."
+      }
+    }
+  },
+  "aws-native:organizations:ResourcePolicy": {
+    "cfTypeName": "AWS::Organizations::ResourcePolicy",
+    "properties": {
+      "content": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The policy document. For AWS CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML format. AWS CloudFormation always converts a YAML policy to JSON format before submitting it.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Organizations::ResourcePolicy` for more information about the expected schema for this property."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A list of tags that you want to attach to the resource policy"
+      }
+    }
+  },
+  "aws-native:panorama:PackageVersion": {
+    "cfTypeName": "AWS::Panorama::PackageVersion",
+    "properties": {
+      "markLatest": {
+        "type": "boolean"
+      },
+      "ownerAccount": {
+        "type": "string"
+      },
+      "packageId": {
+        "type": "string"
+      },
+      "packageVersion": {
+        "type": "string",
+        "language": {
+          "csharp": {
+            "name": "PackageVersionValue"
+          }
+        }
+      },
+      "patchVersion": {
+        "type": "string"
+      },
+      "updatedLatestPatchVersion": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:pcaconnectorad:Connector": {
+    "cfTypeName": "AWS::PCAConnectorAD::Connector",
+    "properties": {
+      "certificateAuthorityArn": {
+        "type": "string"
+      },
+      "directoryId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "vpcInformation": {
+        "$ref": "#/types/aws-native:pcaconnectorad:ConnectorVpcInformation"
+      }
+    }
+  },
+  "aws-native:pcaconnectorad:DirectoryRegistration": {
+    "cfTypeName": "AWS::PCAConnectorAD::DirectoryRegistration",
+    "properties": {
+      "directoryId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:pcaconnectorad:ServicePrincipalName": {
+    "cfTypeName": "AWS::PCAConnectorAD::ServicePrincipalName",
+    "properties": {
+      "connectorArn": {
+        "type": "string"
+      },
+      "directoryRegistrationArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:pcaconnectorad:TemplateGroupAccessControlEntry": {
+    "cfTypeName": "AWS::PCAConnectorAD::TemplateGroupAccessControlEntry",
+    "properties": {
+      "accessRights": {
+        "$ref": "#/types/aws-native:pcaconnectorad:TemplateGroupAccessControlEntryAccessRights"
+      },
+      "groupDisplayName": {
+        "type": "string"
+      },
+      "groupSecurityIdentifier": {
+        "type": "string"
+      },
+      "templateArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:pinpoint:InAppTemplate": {
+    "cfTypeName": "AWS::Pinpoint::InAppTemplate",
+    "properties": {
+      "content": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:pinpoint:InAppTemplateInAppMessageContent"
+        }
+      },
+      "customConfig": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property."
+      },
+      "layout": {
+        "$ref": "#/types/aws-native:pinpoint:InAppTemplateLayout"
+      },
+      "tags": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property."
+      },
+      "templateDescription": {
+        "type": "string"
+      },
+      "templateName": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:proton:EnvironmentAccountConnection": {
+    "cfTypeName": "AWS::Proton::EnvironmentAccountConnection",
+    "properties": {
+      "codebuildRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM service role in the environment account. AWS Proton uses this role to provision infrastructure resources using CodeBuild-based provisioning in the associated environment account."
+      },
+      "componentRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM service role that AWS Proton uses when provisioning directly defined components in the associated environment account. It determines the scope of infrastructure that a component can provision in the account."
+      },
+      "environmentAccountId": {
+        "type": "string",
+        "description": "The environment account that's connected to the environment account connection."
+      },
+      "environmentName": {
+        "type": "string",
+        "description": "The name of the AWS Proton environment that's created in the associated management account."
+      },
+      "managementAccountId": {
+        "type": "string",
+        "description": "The ID of the management account that accepts or rejects the environment account connection. You create an manage the AWS Proton environment in this account. If the management account accepts the environment account connection, AWS Proton can use the associated IAM role to provision environment infrastructure resources in the associated environment account."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the IAM service role that's created in the environment account. AWS Proton uses this role to provision infrastructure resources in the associated environment account."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "\u003cp\u003eAn optional list of metadata items that you can associate with the Proton environment account connection. A tag is a key-value pair.\u003c/p\u003e\n         \u003cp\u003eFor more information, see \u003ca href=\"https://docs.aws.amazon.com/proton/latest/userguide/resources.html\"\u003eProton resources and tagging\u003c/a\u003e in the\n        \u003ci\u003eProton User Guide\u003c/i\u003e.\u003c/p\u003e"
+      }
+    }
+  },
+  "aws-native:quicksight:RefreshSchedule": {
+    "cfTypeName": "AWS::QuickSight::RefreshSchedule",
+    "properties": {
+      "awsAccountId": {
+        "type": "string"
+      },
+      "dataSetId": {
+        "type": "string"
+      },
+      "schedule": {
+        "$ref": "#/types/aws-native:quicksight:RefreshScheduleMap"
+      }
+    }
+  },
+  "aws-native:rds:CustomDbEngineVersion": {
+    "cfTypeName": "AWS::RDS::CustomDBEngineVersion",
+    "properties": {
+      "databaseInstallationFilesS3BucketName": {
+        "type": "string",
+        "description": "The name of an Amazon S3 bucket that contains database installation files for your CEV. For example, a valid bucket name is `my-custom-installation-files`."
+      },
+      "databaseInstallationFilesS3Prefix": {
+        "type": "string",
+        "description": "The Amazon S3 directory that contains the database installation files for your CEV. For example, a valid bucket name is `123456789012/cev1`. If this setting isn't specified, no prefix is assumed."
+      },
+      "description": {
+        "type": "string",
+        "description": "An optional description of your CEV."
+      },
+      "engine": {
+        "type": "string",
+        "description": "The database engine to use for your custom engine version (CEV). The only supported value is `custom-oracle-ee`."
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "The name of your CEV. The name format is 19.customized_string . For example, a valid name is 19.my_cev1. This setting is required for RDS Custom for Oracle, but optional for Amazon RDS. The combination of Engine and EngineVersion is unique per customer per Region."
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The AWS KMS key identifier for an encrypted CEV. A symmetric KMS key is required for RDS Custom, but optional for Amazon RDS."
+      },
+      "manifest": {
+        "type": "string",
+        "description": "The CEV manifest, which is a JSON document that describes the installation .zip files stored in Amazon S3. Specify the name/value pairs in a file or a quoted string. RDS Custom applies the patches in the order in which they are listed."
+      },
+      "status": {
+        "$ref": "#/types/aws-native:rds:CustomDbEngineVersionStatus",
+        "description": "The availability status to be assigned to the CEV."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:rds:DbCluster": {
+    "cfTypeName": "AWS::RDS::DBCluster",
+    "properties": {
+      "allocatedStorage": {
+        "type": "integer",
+        "description": "The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster."
+      },
+      "associatedRoles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:rds:DbClusterDbClusterRole"
+        },
+        "description": "Provides a list of the AWS Identity and Access Management (IAM) roles that are associated with the DB cluster. IAM roles that are associated with a DB cluster grant permission for the DB cluster to access other AWS services on your behalf."
+      },
+      "autoMinorVersionUpgrade": {
+        "type": "boolean",
+        "description": "A value that indicates whether minor engine upgrades are applied automatically to the DB cluster during the maintenance window. By default, minor engine upgrades are applied automatically."
+      },
+      "availabilityZones": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of Availability Zones (AZs) where instances in the DB cluster can be created. For information on AWS Regions and Availability Zones, see Choosing the Regions and Availability Zones in the Amazon Aurora User Guide."
+      },
+      "backtrackWindow": {
+        "type": "integer",
+        "description": "The target backtrack window, in seconds. To disable backtracking, set this value to 0."
+      },
+      "backupRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days for which automated backups are retained."
+      },
+      "copyTagsToSnapshot": {
+        "type": "boolean",
+        "description": "A value that indicates whether to copy all tags from the DB cluster to snapshots of the DB cluster. The default is not to copy them."
+      },
+      "databaseName": {
+        "type": "string",
+        "description": "The name of your database. If you don't provide a name, then Amazon RDS won't create a database in this DB cluster. For naming constraints, see Naming Constraints in the Amazon RDS User Guide."
+      },
+      "dbClusterIdentifier": {
+        "type": "string",
+        "description": "The DB cluster identifier. This parameter is stored as a lowercase string."
+      },
+      "dbClusterInstanceClass": {
+        "type": "string",
+        "description": "The compute and memory capacity of each DB instance in the Multi-AZ DB cluster, for example db.m6g.xlarge."
+      },
+      "dbClusterParameterGroupName": {
+        "type": "string",
+        "description": "The name of the DB cluster parameter group to associate with this DB cluster."
+      },
+      "dbInstanceParameterGroupName": {
+        "type": "string",
+        "description": "The name of the DB parameter group to apply to all instances of the DB cluster."
+      },
+      "dbSubnetGroupName": {
+        "type": "string",
+        "description": "A DB subnet group that you want to associate with this DB cluster."
+      },
+      "dbSystemId": {
+        "type": "string",
+        "description": "Reserved for future use."
+      },
+      "deletionProtection": {
+        "type": "boolean",
+        "description": "A value that indicates whether the DB cluster has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled."
+      },
+      "domain": {
+        "type": "string",
+        "description": "The Active Directory directory ID to create the DB cluster in."
+      },
+      "domainIamRoleName": {
+        "type": "string",
+        "description": "Specify the name of the IAM role to be used when making API calls to the Directory Service."
+      },
+      "enableCloudwatchLogsExports": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of log types that need to be enabled for exporting to CloudWatch Logs. The values in the list depend on the DB engine being used. For more information, see Publishing Database Logs to Amazon CloudWatch Logs in the Amazon Aurora User Guide."
+      },
+      "enableGlobalWriteForwarding": {
+        "type": "boolean",
+        "description": "Specifies whether to enable this DB cluster to forward write operations to the primary cluster of a global cluster (Aurora global database). By default, write operations are not allowed on Aurora DB clusters that are secondary clusters in an Aurora global database."
+      },
+      "enableHttpEndpoint": {
+        "type": "boolean",
+        "description": "A value that indicates whether to enable the HTTP endpoint for DB cluster. By default, the HTTP endpoint is disabled."
+      },
+      "enableIamDatabaseAuthentication": {
+        "type": "boolean",
+        "description": "A value that indicates whether to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts. By default, mapping is disabled."
+      },
+      "engine": {
+        "type": "string",
+        "description": "The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora), and aurora-postgresql"
+      },
+      "engineMode": {
+        "type": "string",
+        "description": "The DB engine mode of the DB cluster, either provisioned, serverless, parallelquery, global, or multimaster."
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "The version number of the database engine to use."
+      },
+      "globalClusterIdentifier": {
+        "type": "string",
+        "description": "If you are configuring an Aurora global database cluster and want your Aurora DB cluster to be a secondary member in the global database cluster, specify the global cluster ID of the global database cluster. To define the primary database cluster of the global cluster, use the AWS::RDS::GlobalCluster resource.\n\nIf you aren't configuring a global database cluster, don't specify this property."
+      },
+      "iops": {
+        "type": "integer",
+        "description": "The amount of Provisioned IOPS (input/output operations per second) to be initially allocated for each DB instance in the Multi-AZ DB cluster."
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the AWS Key Management Service master key that is used to encrypt the database instances in the DB cluster, such as arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef. If you enable the StorageEncrypted property but don't specify this property, the default master key is used. If you specify this property, you must set the StorageEncrypted property to true."
+      },
+      "manageMasterUserPassword": {
+        "type": "boolean",
+        "description": "A value that indicates whether to manage the master user password with AWS Secrets Manager."
+      },
+      "masterUserPassword": {
+        "type": "string",
+        "description": "The master password for the DB instance."
+      },
+      "masterUserSecret": {
+        "$ref": "#/types/aws-native:rds:DbClusterMasterUserSecret",
+        "description": "Contains the secret managed by RDS in AWS Secrets Manager for the master user password."
+      },
+      "masterUsername": {
+        "type": "string",
+        "description": "The name of the master user for the DB cluster. You must specify MasterUsername, unless you specify SnapshotIdentifier. In that case, don't specify MasterUsername."
+      },
+      "monitoringInterval": {
+        "type": "integer",
+        "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB cluster. To turn off collecting Enhanced Monitoring metrics, specify 0. The default is 0."
+      },
+      "monitoringRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) for the IAM role that permits RDS to send Enhanced Monitoring metrics to Amazon CloudWatch Logs."
+      },
+      "networkType": {
+        "type": "string",
+        "description": "The network type of the DB cluster."
+      },
+      "performanceInsightsEnabled": {
+        "type": "boolean",
+        "description": "A value that indicates whether to turn on Performance Insights for the DB cluster."
+      },
+      "performanceInsightsKmsKeyId": {
+        "type": "string",
+        "description": "The Amazon Web Services KMS key identifier for encryption of Performance Insights data."
+      },
+      "performanceInsightsRetentionPeriod": {
+        "type": "integer",
+        "description": "The amount of time, in days, to retain Performance Insights data."
+      },
+      "port": {
+        "type": "integer",
+        "description": "The port number on which the instances in the DB cluster accept connections. Default: 3306 if engine is set as aurora or 5432 if set to aurora-postgresql."
+      },
+      "preferredBackupWindow": {
+        "type": "string",
+        "description": "The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter. The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region. To see the time blocks available, see Adjusting the Preferred DB Cluster Maintenance Window in the Amazon Aurora User Guide."
+      },
+      "preferredMaintenanceWindow": {
+        "type": "string",
+        "description": "The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC). The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see Adjusting the Preferred DB Cluster Maintenance Window in the Amazon Aurora User Guide."
+      },
+      "publiclyAccessible": {
+        "type": "boolean",
+        "description": "A value that indicates whether the DB cluster is publicly accessible."
+      },
+      "readEndpoint": {
+        "$ref": "#/types/aws-native:rds:DbClusterReadEndpoint"
+      },
+      "replicationSourceIdentifier": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the source DB instance or DB cluster if this DB cluster is created as a Read Replica."
+      },
+      "restoreToTime": {
+        "type": "string",
+        "description": "The date and time to restore the DB cluster to. Value must be a time in Universal Coordinated Time (UTC) format. An example: 2015-03-07T23:45:00Z"
+      },
+      "restoreType": {
+        "type": "string",
+        "description": "The type of restore to be performed. You can specify one of the following values:\nfull-copy - The new DB cluster is restored as a full copy of the source DB cluster.\ncopy-on-write - The new DB cluster is restored as a clone of the source DB cluster."
+      },
+      "scalingConfiguration": {
+        "$ref": "#/types/aws-native:rds:DbClusterScalingConfiguration",
+        "description": "The ScalingConfiguration property type specifies the scaling configuration of an Aurora Serverless DB cluster."
+      },
+      "serverlessV2ScalingConfiguration": {
+        "$ref": "#/types/aws-native:rds:DbClusterServerlessV2ScalingConfiguration",
+        "description": "Contains the scaling configuration of an Aurora Serverless v2 DB cluster."
+      },
+      "snapshotIdentifier": {
+        "type": "string",
+        "description": "The identifier for the DB snapshot or DB cluster snapshot to restore from.\nYou can use either the name or the Amazon Resource Name (ARN) to specify a DB cluster snapshot. However, you can use only the ARN to specify a DB snapshot.\nAfter you restore a DB cluster with a SnapshotIdentifier property, you must specify the same SnapshotIdentifier property for any future updates to the DB cluster. When you specify this property for an update, the DB cluster is not restored from the snapshot again, and the data in the database is not changed. However, if you don't specify the SnapshotIdentifier property, an empty DB cluster is created, and the original DB cluster is deleted. If you specify a property that is different from the previous snapshot restore property, the DB cluster is restored from the specified SnapshotIdentifier property, and the original DB cluster is deleted."
+      },
+      "sourceDbClusterIdentifier": {
+        "type": "string",
+        "description": "The identifier of the source DB cluster from which to restore."
+      },
+      "sourceRegion": {
+        "type": "string",
+        "description": "The AWS Region which contains the source DB cluster when replicating a DB cluster. For example, us-east-1."
+      },
+      "storageEncrypted": {
+        "type": "boolean",
+        "description": "Indicates whether the DB instance is encrypted.\nIf you specify the DBClusterIdentifier, SnapshotIdentifier, or SourceDBInstanceIdentifier property, don't specify this property. The value is inherited from the cluster, snapshot, or source DB instance."
+      },
+      "storageType": {
+        "type": "string",
+        "description": "Specifies the storage type to be associated with the DB cluster."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      },
+      "useLatestRestorableTime": {
+        "type": "boolean",
+        "description": "A value that indicates whether to restore the DB cluster to the latest restorable backup time. By default, the DB cluster is not restored to the latest restorable backup time."
+      },
+      "vpcSecurityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of EC2 VPC security groups to associate with this DB cluster."
+      }
+    }
+  },
+  "aws-native:rds:DbInstance": {
+    "cfTypeName": "AWS::RDS::DBInstance",
+    "properties": {
+      "allocatedStorage": {
+        "type": "string",
+        "description": "The amount of storage in gibibytes (GiB) to be initially allocated for the database instance.\n  If any value is set in the ``Iops`` parameter, ``AllocatedStorage`` must be at least 100 GiB, which corresponds to the minimum Iops value of 1,000. If you increase the ``Iops`` value (in 1,000 IOPS increments), then you must also increase the ``AllocatedStorage`` value (in 100-GiB increments). \n   *Amazon Aurora* \n Not applicable. Aurora cluster volumes automatically grow as the amount of data in your database increases, though you are only charged for the space that you use in an Aurora cluster volume.\n  *Db2* \n Constraints to the amount of storage for each storage type are the following:\n  + General Purpose (SSD) storage (gp3): Must be an integer from 20 to 64000.\n + Provisioned IOPS storage (io1): Must be an integer from 100 to 64000.\n \n  *MySQL* \n Constraints to the amount of storage for each storage type are the following: \n  + General Purpose (SSD) storage (gp2): Must be an integer fro"
+      },
+      "allowMajorVersionUpgrade": {
+        "type": "boolean",
+        "description": "A value that indicates whether major version upgrades are allowed. Changing this parameter doesn't result in an outage and the change is asynchronously applied as soon as possible.\n Constraints: Major version upgrades must be allowed when specifying a value for the ``EngineVersion`` parameter that is a different major version than the DB instance's current version."
+      },
+      "associatedRoles": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:rds:DbInstanceDbInstanceRole"
+        },
+        "description": "The IAMlong (IAM) roles associated with the DB instance. \n  *Amazon Aurora* \n Not applicable. The associated roles are managed by the DB cluster."
+      },
+      "autoMinorVersionUpgrade": {
+        "type": "boolean",
+        "description": "A value that indicates whether minor engine upgrades are applied automatically to the DB instance during the maintenance window. By default, minor engine upgrades are applied automatically."
+      },
+      "automaticBackupReplicationRegion": {
+        "type": "string",
+        "description": "The destination region for the backup replication of the DB instance. For more info, see [Replicating automated backups to another Region](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReplicateBackups.html) in the *Amazon RDS User Guide*."
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The Availability Zone (AZ) where the database will be created. For information on AWS-Regions and Availability Zones, see [Regions and Availability Zones](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html).\n For Amazon Aurora, each Aurora DB cluster hosts copies of its storage in three separate Availability Zones. Specify one of these Availability Zones. Aurora automatically chooses an appropriate Availability Zone if you don't specify one.\n Default: A random, system-chosen Availability Zone in the endpoint's AWS-Region.\n Constraints:\n  +  The ``AvailabilityZone`` parameter can't be specified if the DB instance is a Multi-AZ deployment.\n  +  The specified Availability Zone must be in the same AWS-Region as the current endpoint.\n  \n Example: ``us-east-1d``"
+      },
+      "backupRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days for which automated backups are retained. Setting this parameter to a positive number enables backups. Setting this parameter to 0 disables automated backups.\n *Amazon Aurora*\n Not applicable. The retention period for automated backups is managed by the DB cluster.\n Default: 1\n Constraints:\n  +  Must be a value from 0 to 35\n  +  Can't be set to 0 if the DB instance is a source to read replicas"
+      },
+      "caCertificateIdentifier": {
+        "type": "string",
+        "description": "The identifier of the CA certificate for this DB instance.\n For more information, see [Using SSL/TLS to encrypt a connection to a DB instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) in the *Amazon RDS User Guide* and [Using SSL/TLS to encrypt a connection to a DB cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html) in the *Amazon Aurora User Guide*."
+      },
+      "certificateDetails": {
+        "$ref": "#/types/aws-native:rds:DbInstanceCertificateDetails",
+        "description": "The details of the DB instance's server certificate."
+      },
+      "certificateRotationRestart": {
+        "type": "boolean",
+        "description": "Specifies whether the DB instance is restarted when you rotate your SSL/TLS certificate.\n By default, the DB instance is restarted when you rotate your SSL/TLS certificate. The certificate is not updated until the DB instance is restarted.\n  Set this parameter only if you are *not* using SSL/TLS to connect to the DB instance.\n  If you are using SSL/TLS to connect to the DB instance, follow the appropriate instructions for your DB engine to rotate your SSL/TLS certificate:\n  +  For more information about rotating your SSL/TLS certificate for RDS DB engines, see [Rotating Your SSL/TLS Certificate.](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) in the *Amazon RDS User Guide.* \n  +  For more information about rotating your SSL/TLS certificate for Aurora DB engines, see [Rotating Your SSL/TLS Certificate](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL-certificate-rotation.html) in the *Amazon Aurora User Gui"
+      },
+      "characterSetName": {
+        "type": "string",
+        "description": "For supported engines, indicates that the DB instance should be associated with the specified character set.\n  *Amazon Aurora* \n Not applicable. The character set is managed by the DB cluster. For more information, see [AWS::RDS::DBCluster](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html)."
+      },
+      "copyTagsToSnapshot": {
+        "type": "boolean",
+        "description": "Specifies whether to copy tags from the DB instance to snapshots of the DB instance. By default, tags are not copied.\n This setting doesn't apply to Amazon Aurora DB instances. Copying tags to snapshots is managed by the DB cluster. Setting this value for an Aurora DB instance has no effect on the DB cluster setting."
+      },
+      "customIamInstanceProfile": {
+        "type": "string",
+        "description": "The instance profile associated with the underlying Amazon EC2 instance of an RDS Custom DB instance.\n This setting is required for RDS Custom.\n Constraints:\n  +  The profile must exist in your account.\n  +  The profile must have an IAM role that Amazon EC2 has permissions to assume.\n  +  The instance profile name and the associated IAM role name must start with the prefix ``AWSRDSCustom``.\n  \n For the list of permissions required for the IAM role, see [Configure IAM and your VPC](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc) in the *Amazon RDS User Guide*."
+      },
+      "dbClusterIdentifier": {
+        "type": "string",
+        "description": "The identifier of the DB cluster that the instance will belong to."
+      },
+      "dbClusterSnapshotIdentifier": {
+        "type": "string",
+        "description": "The identifier for the RDS for MySQL Multi-AZ DB cluster snapshot to restore from.\n For more information on Multi-AZ DB clusters, see [Multi-AZ DB cluster deployments](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/multi-az-db-clusters-concepts.html) in the *Amazon RDS User Guide*.\n Constraints:\n  +  Must match the identifier of an existing Multi-AZ DB cluster snapshot.\n  +  Can't be specified when ``DBSnapshotIdentifier`` is specified.\n  +  Must be specified when ``DBSnapshotIdentifier`` isn't specified.\n  +  If you are restoring from a shared manual Multi-AZ DB cluster snapshot, the ``DBClusterSnapshotIdentifier`` must be the ARN of the shared snapshot.\n  +  Can't be the identifier of an Aurora DB cluster snapshot.\n  +  Can't be the identifier of an RDS for PostgreSQL Multi-AZ DB cluster snapshot."
+      },
+      "dbInstanceClass": {
+        "type": "string",
+        "description": "The compute and memory capacity of the DB instance, for example, ``db.m4.large``. Not all DB instance classes are available in all AWS Regions, or for all database engines.\n For the full list of DB instance classes, and availability for your engine, see [DB Instance Class](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html) in the *Amazon RDS User Guide.* For more information about DB instance class pricing and AWS Region support for DB instance classes, see [Amazon RDS Pricing](https://docs.aws.amazon.com/rds/pricing/)."
+      },
+      "dbInstanceIdentifier": {
+        "type": "string",
+        "description": "A name for the DB instance. If you specify a name, AWS CloudFormation converts it to lowercase. If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the DB instance. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html).\n For information about constraints that apply to DB instance identifiers, see [Naming constraints in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints) in the *Amazon RDS User Guide*.\n  If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you must replace the resource, specify a new name."
+      },
+      "dbName": {
+        "type": "string",
+        "description": "The meaning of this parameter differs according to the database engine you use.\n  If you specify the ``DBSnapshotIdentifier`` property, this property only applies to RDS for Oracle.\n   *Amazon Aurora* \n Not applicable. The database name is managed by the DB cluster.\n  *Db2* \n The name of the database to create when the DB instance is created. If this parameter isn't specified, no database is created in the DB instance.\n Constraints:\n  + Must contain 1 to 64 letters or numbers.\n + Must begin with a letter. Subsequent characters can be letters, underscores, or digits (0-9).\n + Can't be a word reserved by the specified database engine.\n \n  *MySQL* \n The name of the database to create when the DB instance is created. If this parameter is not specified, no database is created in the DB instance.\n Constraints:\n  +  Must contain 1 to 64 letters or numbers.\n  +  Can't be a word reserved by the specified database engine\n  \n  *MariaDB* \n The name of the database to create when the DB instance is"
+      },
+      "dbParameterGroupName": {
+        "type": "string",
+        "description": "The name of an existing DB parameter group or a reference to an [AWS::RDS::DBParameterGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html) resource created in the template.\n To list all of the available DB parameter group names, use the following command:\n ``aws rds describe-db-parameter-groups --query \"DBParameterGroups[].DBParameterGroupName\" --output text``\n  If any of the data members of the referenced parameter group are changed during an update, the DB instance might need to be restarted, which causes some interruption. If the parameter group contains static parameters, whether they were changed or not, an update triggers a reboot.\n  If you don't specify a value for ``DBParameterGroupName`` property, the default DB parameter group for the specified engine and engine version is used."
+      },
+      "dbSecurityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of the DB security groups to assign to the DB instance. The list can include both the name of existing DB security groups or references to AWS::RDS::DBSecurityGroup resources created in the template.\n  If you set DBSecurityGroups, you must not set VPCSecurityGroups, and vice versa. Also, note that the DBSecurityGroups property exists only for backwards compatibility with older regions and is no longer recommended for providing security information to an RDS DB instance. Instead, use VPCSecurityGroups.\n  If you specify this property, AWS CloudFormation sends only the following properties (if specified) to Amazon RDS during create operations:\n  +  ``AllocatedStorage``\n  +  ``AutoMinorVersionUpgrade``\n  +  ``AvailabilityZone``\n  +  ``BackupRetentionPeriod``\n  +  ``CharacterSetName``\n  +  ``DBInstanceClass``\n  +  ``DBName``\n  +  ``DBParameterGroupName``\n  +  ``DBSecurityGroups``\n  +  ``DBSubnetGroupName``\n  +  ``Engine``\n  +  ``EngineVersion``\n  +  ``Iops``\n  +  ``LicenseModel``\n  +"
+      },
+      "dbSnapshotIdentifier": {
+        "type": "string",
+        "description": "The name or Amazon Resource Name (ARN) of the DB snapshot that's used to restore the DB instance. If you're restoring from a shared manual DB snapshot, you must specify the ARN of the snapshot.\n By specifying this property, you can create a DB instance from the specified DB snapshot. If the ``DBSnapshotIdentifier`` property is an empty string or the ``AWS::RDS::DBInstance`` declaration has no ``DBSnapshotIdentifier`` property, AWS CloudFormation creates a new database. If the property contains a value (other than an empty string), AWS CloudFormation creates a database from the specified snapshot. If a snapshot with the specified name doesn't exist, AWS CloudFormation can't create the database and it rolls back the stack.\n Some DB instance properties aren't valid when you restore from a snapshot, such as the ``MasterUsername`` and ``MasterUserPassword`` properties. For information about the properties that you can specify, see the ``RestoreDBInstanceFromDBSnapshot`` action in the *Amazo"
+      },
+      "dbSubnetGroupName": {
+        "type": "string",
+        "description": "A DB subnet group to associate with the DB instance. If you update this value, the new subnet group must be a subnet group in a new VPC. \n If there's no DB subnet group, then the DB instance isn't a VPC DB instance.\n For more information about using Amazon RDS in a VPC, see [Using Amazon RDS with Amazon Virtual Private Cloud (VPC)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.html) in the *Amazon RDS User Guide*. \n *Amazon Aurora*\n Not applicable. The DB subnet group is managed by the DB cluster. If specified, the setting must match the DB cluster setting."
+      },
+      "dedicatedLogVolume": {
+        "type": "boolean",
+        "description": "Indicates whether the DB instance has a dedicated log volume (DLV) enabled."
+      },
+      "deleteAutomatedBackups": {
+        "type": "boolean",
+        "description": "A value that indicates whether to remove automated backups immediately after the DB instance is deleted. This parameter isn't case-sensitive. The default is to remove automated backups immediately after the DB instance is deleted.\n *Amazon Aurora*\n Not applicable. When you delete a DB cluster, all automated backups for that DB cluster are deleted and can't be recovered. Manual DB cluster snapshots of the DB cluster are not deleted."
+      },
+      "deletionProtection": {
+        "type": "boolean",
+        "description": "A value that indicates whether the DB instance has deletion protection enabled. The database can't be deleted when deletion protection is enabled. By default, deletion protection is disabled. For more information, see [Deleting a DB Instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DeleteInstance.html). \n  *Amazon Aurora* \n Not applicable. You can enable or disable deletion protection for the DB cluster. For more information, see ``CreateDBCluster``. DB instances in a DB cluster can be deleted even when deletion protection is enabled for the DB cluster."
+      },
+      "domain": {
+        "type": "string",
+        "description": "The Active Directory directory ID to create the DB instance in. Currently, only Db2, MySQL, Microsoft SQL Server, Oracle, and PostgreSQL DB instances can be created in an Active Directory Domain.\n For more information, see [Kerberos Authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/kerberos-authentication.html) in the *Amazon RDS User Guide*."
+      },
+      "domainAuthSecretArn": {
+        "type": "string",
+        "description": "The ARN for the Secrets Manager secret with the credentials for the user joining the domain.\n Example: ``arn:aws:secretsmanager:region:account-number:secret:myselfmanagedADtestsecret-123456``"
+      },
+      "domainDnsIps": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The IPv4 DNS IP addresses of your primary and secondary Active Directory domain controllers.\n Constraints:\n  +  Two IP addresses must be provided. If there isn't a secondary domain controller, use the IP address of the primary domain controller for both entries in the list.\n  \n Example: ``123.124.125.126,234.235.236.237``"
+      },
+      "domainFqdn": {
+        "type": "string",
+        "description": "The fully qualified domain name (FQDN) of an Active Directory domain.\n Constraints:\n  +  Can't be longer than 64 characters.\n  \n Example: ``mymanagedADtest.mymanagedAD.mydomain``"
+      },
+      "domainIamRoleName": {
+        "type": "string",
+        "description": "The name of the IAM role to use when making API calls to the Directory Service.\n This setting doesn't apply to the following DB instances:\n  +  Amazon Aurora (The domain is managed by the DB cluster.)\n  +  RDS Custom"
+      },
+      "domainOu": {
+        "type": "string",
+        "description": "The Active Directory organizational unit for your DB instance to join.\n Constraints:\n  +  Must be in the distinguished name format.\n  +  Can't be longer than 64 characters.\n  \n Example: ``OU=mymanagedADtestOU,DC=mymanagedADtest,DC=mymanagedAD,DC=mydomain``"
+      },
+      "enableCloudwatchLogsExports": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of log types that need to be enabled for exporting to CloudWatch Logs. The values in the list depend on the DB engine being used. For more information, see [Publishing Database Logs to Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch) in the *Amazon Relational Database Service User Guide*.\n  *Amazon Aurora* \n Not applicable. CloudWatch Logs exports are managed by the DB cluster. \n  *Db2* \n Valid values: ``diag.log``, ``notify.log`` \n  *MariaDB* \n Valid values: ``audit``, ``error``, ``general``, ``slowquery`` \n  *Microsoft SQL Server* \n Valid values: ``agent``, ``error`` \n *MySQL* \n Valid values: ``audit``, ``error``, ``general``, ``slowquery`` \n  *Oracle* \n Valid values: ``alert``, ``audit``, ``listener``, ``trace``, ``oemagent`` \n  *PostgreSQL* \n Valid values: ``postgresql``, ``upgrade``"
+      },
+      "enableIamDatabaseAuthentication": {
+        "type": "boolean",
+        "description": "A value that indicates whether to enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts. By default, mapping is disabled.\n This property is supported for RDS for MariaDB, RDS for MySQL, and RDS for PostgreSQL. For more information, see [IAM Database Authentication for MariaDB, MySQL, and PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) in the *Amazon RDS User Guide.* \n  *Amazon Aurora* \n Not applicable. Mapping AWS IAM accounts to database accounts is managed by the DB cluster."
+      },
+      "enablePerformanceInsights": {
+        "type": "boolean",
+        "description": "Specifies whether to enable Performance Insights for the DB instance. For more information, see [Using Amazon Performance Insights](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html) in the *Amazon RDS User Guide*.\n This setting doesn't apply to RDS Custom DB instances."
+      },
+      "endpoint": {
+        "$ref": "#/types/aws-native:rds:DbInstanceEndpoint",
+        "description": "The connection endpoint for the DB instance.\n  The endpoint might not be shown for instances with the status of ``creating``."
+      },
+      "engine": {
+        "type": "string",
+        "description": "The name of the database engine that you want to use for this DB instance.\n Not every database engine is available in every AWS Region.\n  When you are creating a DB instance, the ``Engine`` property is required.\n  Valid Values:\n  +  ``aurora-mysql`` (for Aurora MySQL DB instances)\n  +  ``aurora-postgresql`` (for Aurora PostgreSQL DB instances)\n  +   ``custom-oracle-ee`` (for RDS Custom for Oracle DB instances)\n  +  ``custom-oracle-ee-cdb`` (for RDS Custom for Oracle DB instances)\n  +  ``custom-sqlserver-ee`` (for RDS Custom for SQL Server DB instances)\n  +  ``custom-sqlserver-se`` (for RDS Custom for SQL Server DB instances)\n  +  ``custom-sqlserver-web`` (for RDS Custom for SQL Server DB instances)\n  +  ``db2-ae``\n  +  ``db2-se``\n  +  ``mariadb``\n  +  ``mysql``\n  +  ``oracle-ee``\n  +  ``oracle-ee-cdb``\n  +  ``oracle-se2``\n  +  ``oracle-se2-cdb``\n  +  ``postgres``\n  +  ``sqlserver-ee``\n  +  ``sqlserver-se``\n  +  ``sqlserver-ex``\n  +  ``sqlserver-web``"
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "The version number of the database engine to use.\n For a list of valid engine versions, use the ``DescribeDBEngineVersions`` action.\n The following are the database engines and links to information about the major and minor versions that are available with Amazon RDS. Not every database engine is available for every AWS Region.\n  *Amazon Aurora* \n Not applicable. The version number of the database engine to be used by the DB instance is managed by the DB cluster.\n  *Db2* \n See [Amazon RDS for Db2](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Db2.html#Db2.Concepts.VersionMgmt) in the *Amazon RDS User Guide.*\n *MariaDB*\n See [MariaDB on Amazon RDS Versions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MariaDB.html#MariaDB.Concepts.VersionMgmt) in the *Amazon RDS User Guide.*\n *Microsoft SQL Server*\n See [Microsoft SQL Server Versions on Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.VersionSu"
+      },
+      "iops": {
+        "type": "integer",
+        "description": "The number of I/O operations per second (IOPS) that the database provisions. The value must be equal to or greater than 1000. \n If you specify this property, you must follow the range of allowed ratios of your requested IOPS rate to the amount of storage that you allocate (IOPS to allocated storage). For example, you can provision an Oracle database instance with 1000 IOPS and 200 GiB of storage (a ratio of 5:1), or specify 2000 IOPS with 200 GiB of storage (a ratio of 10:1). For more information, see [Amazon RDS Provisioned IOPS Storage to Improve Performance](https://docs.aws.amazon.com/AmazonRDS/latest/DeveloperGuide/CHAP_Storage.html#USER_PIOPS) in the *Amazon RDS User Guide*.\n  If you specify ``io1`` for the ``StorageType`` property, then you must also specify the ``Iops`` property.\n  Constraints:\n  + For RDS for Db2, MariaDB, MySQL, Oracle, and PostgreSQL - Must be a multiple between .5 and 50 of the storage amount for the DB instance.\n + For RDS for SQL Server - Must be a multip"
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The ARN of the AWS KMS key that's used to encrypt the DB instance, such as ``arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef``. If you enable the StorageEncrypted property but don't specify this property, AWS CloudFormation uses the default KMS key. If you specify this property, you must set the StorageEncrypted property to true. \n If you specify the ``SourceDBInstanceIdentifier`` property, the value is inherited from the source DB instance if the read replica is created in the same region.\n If you create an encrypted read replica in a different AWS Region, then you must specify a KMS key for the destination AWS Region. KMS encryption keys are specific to the region that they're created in, and you can't use encryption keys from one region in another region.\n If you specify the ``SnapshotIdentifier`` property, the ``StorageEncrypted`` property value is inherited from the snapshot, and if the DB instance is encrypted, the specified ``KmsKeyId`` property is us"
+      },
+      "licenseModel": {
+        "type": "string",
+        "description": "License model information for this DB instance.\n  Valid Values:\n  +  Aurora MySQL - ``general-public-license``\n  +  Aurora PostgreSQL - ``postgresql-license``\n  +  RDS for Db2 - ``bring-your-own-license``. For more information about RDS for Db2 licensing, see [](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/db2-licensing.html) in the *Amazon RDS User Guide.*\n  +  RDS for MariaDB - ``general-public-license``\n  +  RDS for Microsoft SQL Server - ``license-included``\n  +  RDS for MySQL - ``general-public-license``\n  +  RDS for Oracle - ``bring-your-own-license`` or ``license-included``\n  +  RDS for PostgreSQL - ``postgresql-license``\n  \n  If you've specified ``DBSecurityGroups`` and then you update the license model, AWS CloudFormation replaces the underlying DB instance. This will incur some interruptions to database availability."
+      },
+      "manageMasterUserPassword": {
+        "type": "boolean",
+        "description": "Specifies whether to manage the master user password with AWS Secrets Manager.\n For more information, see [Password management with Secrets Manager](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html) in the *Amazon RDS User Guide.* \n Constraints:\n  +  Can't manage the master user password with AWS Secrets Manager if ``MasterUserPassword`` is specified."
+      },
+      "masterUserPassword": {
+        "type": "string",
+        "description": "The password for the master user. The password can include any printable ASCII character except \"/\", \"\"\", or \"@\".\n  *Amazon Aurora* \n Not applicable. The password for the master user is managed by the DB cluster.\n  *RDS for Db2* \n Must contain from 8 to 255 characters.\n  *RDS for MariaDB* \n Constraints: Must contain from 8 to 41 characters.\n  *RDS for Microsoft SQL Server* \n Constraints: Must contain from 8 to 128 characters.\n  *RDS for MySQL* \n Constraints: Must contain from 8 to 41 characters.\n  *RDS for Oracle* \n Constraints: Must contain from 8 to 30 characters.\n  *RDS for PostgreSQL* \n Constraints: Must contain from 8 to 128 characters."
+      },
+      "masterUserSecret": {
+        "$ref": "#/types/aws-native:rds:DbInstanceMasterUserSecret",
+        "description": "The secret managed by RDS in AWS Secrets Manager for the master user password.\n For more information, see [Password management with Secrets Manager](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html) in the *Amazon RDS User Guide.*"
+      },
+      "masterUsername": {
+        "type": "string",
+        "description": "The master user name for the DB instance.\n  If you specify the ``SourceDBInstanceIdentifier`` or ``DBSnapshotIdentifier`` property, don't specify this property. The value is inherited from the source DB instance or snapshot.\n When migrating a self-managed Db2 database, we recommend that you use the same master username as your self-managed Db2 instance name.\n   *Amazon Aurora* \n Not applicable. The name for the master user is managed by the DB cluster. \n  *RDS for Db2* \n Constraints:\n  +  Must be 1 to 16 letters or numbers.\n  +  First character must be a letter.\n  +  Can't be a reserved word for the chosen database engine.\n  \n  *RDS for MariaDB* \n Constraints:\n   +  Must be 1 to 16 letters or numbers.\n  +  Can't be a reserved word for the chosen database engine.\n  \n  *RDS for Microsoft SQL Server* \n Constraints:\n   +  Must be 1 to 128 letters or numbers.\n  +  First character must be a letter.\n  +  Can't be a reserved word for the chosen database engine.\n  \n  *RDS for MySQL* \n Constrain"
+      },
+      "maxAllocatedStorage": {
+        "type": "integer",
+        "description": "The upper limit in gibibytes (GiB) to which Amazon RDS can automatically scale the storage of the DB instance.\n For more information about this setting, including limitations that apply to it, see [Managing capacity automatically with Amazon RDS storage autoscaling](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PIOPS.StorageTypes.html#USER_PIOPS.Autoscaling) in the *Amazon RDS User Guide*.\n This setting doesn't apply to the following DB instances:\n  +  Amazon Aurora (Storage is managed by the DB cluster.)\n  +  RDS Custom"
+      },
+      "monitoringInterval": {
+        "type": "integer",
+        "description": "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collection of Enhanced Monitoring metrics, specify 0. The default is 0.\n If ``MonitoringRoleArn`` is specified, then you must set ``MonitoringInterval`` to a value other than 0.\n This setting doesn't apply to RDS Custom.\n Valid Values: ``0, 1, 5, 10, 15, 30, 60``"
+      },
+      "monitoringRoleArn": {
+        "type": "string",
+        "description": "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to Amazon CloudWatch Logs. For example, ``arn:aws:iam:123456789012:role/emaccess``. For information on creating a monitoring role, see [Setting Up and Enabling Enhanced Monitoring](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#USER_Monitoring.OS.Enabling) in the *Amazon RDS User Guide*.\n If ``MonitoringInterval`` is set to a value other than ``0``, then you must supply a ``MonitoringRoleArn`` value.\n This setting doesn't apply to RDS Custom DB instances."
+      },
+      "multiAz": {
+        "type": "boolean",
+        "description": "Specifies whether the database instance is a Multi-AZ DB instance deployment. You can't set the ``AvailabilityZone`` parameter if the ``MultiAZ`` parameter is set to true. \n  For more information, see [Multi-AZ deployments for high availability](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html) in the *Amazon RDS User Guide*.\n  *Amazon Aurora* \n Not applicable. Amazon Aurora storage is replicated across all of the Availability Zones and doesn't require the ``MultiAZ`` option to be set."
+      },
+      "ncharCharacterSetName": {
+        "type": "string",
+        "description": "The name of the NCHAR character set for the Oracle DB instance.\n This setting doesn't apply to RDS Custom DB instances."
+      },
+      "networkType": {
+        "type": "string",
+        "description": "The network type of the DB instance.\n Valid values:\n  +   ``IPV4`` \n  +   ``DUAL`` \n  \n The network type is determined by the ``DBSubnetGroup`` specified for the DB instance. A ``DBSubnetGroup`` can support only the IPv4 protocol or the IPv4 and IPv6 protocols (``DUAL``).\n For more information, see [Working with a DB instance in a VPC](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html) in the *Amazon RDS User Guide.*"
+      },
+      "optionGroupName": {
+        "type": "string",
+        "description": "Indicates that the DB instance should be associated with the specified option group.\n Permanent options, such as the TDE option for Oracle Advanced Security TDE, can't be removed from an option group. Also, that option group can't be removed from a DB instance once it is associated with a DB instance."
+      },
+      "performanceInsightsKmsKeyId": {
+        "type": "string",
+        "description": "The AWS KMS key identifier for encryption of Performance Insights data.\n The KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.\n If you do not specify a value for ``PerformanceInsightsKMSKeyId``, then Amazon RDS uses your default KMS key. There is a default KMS key for your AWS account. Your AWS account has a different default KMS key for each AWS Region.\n For information about enabling Performance Insights, see [EnablePerformanceInsights](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-enableperformanceinsights)."
+      },
+      "performanceInsightsRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days to retain Performance Insights data.\n This setting doesn't apply to RDS Custom DB instances.\n Valid Values:\n  +   ``7`` \n  +   *month* * 31, where *month* is a number of months from 1-23. Examples: ``93`` (3 months * 31), ``341`` (11 months * 31), ``589`` (19 months * 31)\n  +   ``731`` \n  \n Default: ``7`` days\n If you specify a retention period that isn't valid, such as ``94``, Amazon RDS returns an error."
+      },
+      "port": {
+        "type": "string",
+        "description": "The port number on which the database accepts connections.\n  *Amazon Aurora* \n Not applicable. The port number is managed by the DB cluster.\n  *Db2* \n Default value: ``50000``"
+      },
+      "preferredBackupWindow": {
+        "type": "string",
+        "description": "The daily time range during which automated backups are created if automated backups are enabled, using the ``BackupRetentionPeriod`` parameter. For more information, see [Backup Window](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html#USER_WorkingWithAutomatedBackups.BackupWindow) in the *Amazon RDS User Guide.* \n Constraints:\n  + Must be in the format ``hh24:mi-hh24:mi``.\n  + Must be in Universal Coordinated Time (UTC).\n  + Must not conflict with the preferred maintenance window.\n  + Must be at least 30 minutes.\n  \n  *Amazon Aurora* \n Not applicable. The daily time range for creating automated backups is managed by the DB cluster."
+      },
+      "preferredMaintenanceWindow": {
+        "type": "string",
+        "description": "The weekly time range during which system maintenance can occur, in Universal Coordinated Time (UTC).\n Format: ``ddd:hh24:mi-ddd:hh24:mi`` \n The default is a 30-minute window selected at random from an 8-hour block of time for each AWS Region, occurring on a random day of the week. To see the time blocks available, see [Adjusting the Preferred DB Instance Maintenance Window](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html#AdjustingTheMaintenanceWindow) in the *Amazon RDS User Guide.* \n  This property applies when AWS CloudFormation initially creates the DB instance. If you use AWS CloudFormation to update the DB instance, those updates are applied immediately.\n  Constraints: Minimum 30-minute window."
+      },
+      "processorFeatures": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:rds:DbInstanceProcessorFeature"
+        },
+        "description": "The number of CPU cores and the number of threads per core for the DB instance class of the DB instance.\n This setting doesn't apply to Amazon Aurora or RDS Custom DB instances."
+      },
+      "promotionTier": {
+        "type": "integer",
+        "description": "The order of priority in which an Aurora Replica is promoted to the primary instance after a failure of the existing primary instance. For more information, see [Fault Tolerance for an Aurora DB Cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Concepts.AuroraHighAvailability.html#Aurora.Managing.FaultTolerance) in the *Amazon Aurora User Guide*.\n This setting doesn't apply to RDS Custom DB instances.\n Default: ``1`` \n Valid Values: ``0 - 15``"
+      },
+      "publiclyAccessible": {
+        "type": "boolean",
+        "description": "Indicates whether the DB instance is an internet-facing instance. If you specify true, AWS CloudFormation creates an instance with a publicly resolvable DNS name, which resolves to a public IP address. If you specify false, AWS CloudFormation creates an internal instance with a DNS name that resolves to a private IP address. \n The default behavior value depends on your VPC setup and the database subnet group. For more information, see the ``PubliclyAccessible`` parameter in the [CreateDBInstance](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html) in the *Amazon RDS API Reference*."
+      },
+      "replicaMode": {
+        "type": "string",
+        "description": "The open mode of an Oracle read replica. For more information, see [Working with Oracle Read Replicas for Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/oracle-read-replicas.html) in the *Amazon RDS User Guide*.\n This setting is only supported in RDS for Oracle.\n Default: ``open-read-only``\n Valid Values: ``open-read-only`` or ``mounted``"
+      },
+      "restoreTime": {
+        "type": "string",
+        "description": "The date and time to restore from.\n Constraints:\n  +  Must be a time in Universal Coordinated Time (UTC) format.\n  +  Must be before the latest restorable time for the DB instance.\n  +  Can't be specified if the ``UseLatestRestorableTime`` parameter is enabled.\n  \n Example: ``2009-09-07T23:45:00Z``"
+      },
+      "sourceDbClusterIdentifier": {
+        "type": "string",
+        "description": "The identifier of the Multi-AZ DB cluster that will act as the source for the read replica. Each DB cluster can have up to 15 read replicas.\n Constraints:\n  +  Must be the identifier of an existing Multi-AZ DB cluster.\n  +  Can't be specified if the ``SourceDBInstanceIdentifier`` parameter is also specified.\n  +  The specified DB cluster must have automatic backups enabled, that is, its backup retention period must be greater than 0.\n  +  The source DB cluster must be in the same AWS-Region as the read replica. Cross-Region replication isn't supported."
+      },
+      "sourceDbInstanceAutomatedBackupsArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the replicated automated backups from which to restore, for example, ``arn:aws:rds:us-east-1:123456789012:auto-backup:ab-L2IJCEXJP7XQ7HOJ4SIEXAMPLE``.\n This setting doesn't apply to RDS Custom."
+      },
+      "sourceDbInstanceIdentifier": {
+        "type": "string",
+        "description": "If you want to create a read replica DB instance, specify the ID of the source DB instance. Each DB instance can have a limited number of read replicas. For more information, see [Working with Read Replicas](https://docs.aws.amazon.com/AmazonRDS/latest/DeveloperGuide/USER_ReadRepl.html) in the *Amazon RDS User Guide*.\n For information about constraints that apply to DB instance identifiers, see [Naming constraints in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints) in the *Amazon RDS User Guide*.\n The ``SourceDBInstanceIdentifier`` property determines whether a DB instance is a read replica. If you remove the ``SourceDBInstanceIdentifier`` property from your template and then update your stack, AWS CloudFormation promotes the Read Replica to a standalone DB instance.\n   +  If you specify a source DB instance that uses VPC security groups, we recommend that you specify the ``VPCSecurityGroups`` property. If you don't specify the"
+      },
+      "sourceDbiResourceId": {
+        "type": "string",
+        "description": "The resource ID of the source DB instance from which to restore."
+      },
+      "sourceRegion": {
+        "type": "string",
+        "description": "The ID of the region that contains the source DB instance for the read replica."
+      },
+      "storageEncrypted": {
+        "type": "boolean",
+        "description": "A value that indicates whether the DB instance is encrypted. By default, it isn't encrypted.\n If you specify the ``KmsKeyId`` property, then you must enable encryption.\n If you specify the ``SourceDBInstanceIdentifier`` property, don't specify this property. The value is inherited from the source DB instance, and if the DB instance is encrypted, the specified ``KmsKeyId`` property is used.\n If you specify the ``DBSnapshotIdentifier`` and the specified snapshot is encrypted, don't specify this property. The value is inherited from the snapshot, and the specified ``KmsKeyId`` property is used.\n If you specify the ``DBSnapshotIdentifier`` and the specified snapshot isn't encrypted, you can use this property to specify that the restored DB instance is encrypted. Specify the ``KmsKeyId`` property for the KMS key to use for encryption. If you don't want the restored DB instance to be encrypted, then don't set this property or set it to ``false``.\n *Amazon Aurora*\n Not applicable. The encrypt"
+      },
+      "storageThroughput": {
+        "type": "integer",
+        "description": "Specifies the storage throughput value for the DB instance. This setting applies only to the ``gp3`` storage type. \n This setting doesn't apply to RDS Custom or Amazon Aurora."
+      },
+      "storageType": {
+        "type": "string",
+        "description": "Specifies the storage type to be associated with the DB instance.\n  Valid values: ``gp2 | gp3 | io1 | standard`` \n The ``standard`` value is also known as magnetic.\n  If you specify ``io1`` or ``gp3``, you must also include a value for the ``Iops`` parameter. \n  Default: ``io1`` if the ``Iops`` parameter is specified, otherwise ``gp2`` \n For more information, see [Amazon RDS DB Instance Storage](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html) in the *Amazon RDS User Guide*.\n  *Amazon Aurora* \n Not applicable. Aurora data is stored in the cluster volume, which is a single, virtual volume that uses solid state drives (SSDs)."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An optional array of key-value pairs to apply to this DB instance."
+      },
+      "tdeCredentialArn": {
+        "type": "string"
+      },
+      "tdeCredentialPassword": {
+        "type": "string"
+      },
+      "timezone": {
+        "type": "string",
+        "description": "The time zone of the DB instance. The time zone parameter is currently supported only by [Microsoft SQL Server](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone)."
+      },
+      "useDefaultProcessorFeatures": {
+        "type": "boolean",
+        "description": "Specifies whether the DB instance class of the DB instance uses its default processor features.\n This setting doesn't apply to RDS Custom DB instances."
+      },
+      "useLatestRestorableTime": {
+        "type": "boolean",
+        "description": "Specifies whether the DB instance is restored from the latest backup time. By default, the DB instance isn't restored from the latest backup time.\n Constraints:\n  +  Can't be specified if the ``RestoreTime`` parameter is provided."
+      },
+      "vpcSecurityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of the VPC security group IDs to assign to the DB instance. The list can include both the physical IDs of existing VPC security groups and references to [AWS::EC2::SecurityGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html) resources created in the template.\n If you plan to update the resource, don't specify VPC security groups in a shared VPC.\n  If you set ``VPCSecurityGroups``, you must not set [DBSecurityGroups](https://docs.aws.amazon.com//AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsecuritygroups), and vice versa.\n  You can migrate a DB instance in your stack from an RDS DB security group to a VPC security group, but keep the following in mind:\n  +  You can't revert to using an RDS security group after you establish a VPC security group membership.\n  +  When you migrate your DB instance to VPC security groups, if your stack update rolls back because the DB instanc"
+      }
+    }
+  },
+  "aws-native:rds:DbProxyTargetGroup": {
+    "cfTypeName": "AWS::RDS::DBProxyTargetGroup",
+    "properties": {
+      "connectionPoolConfigurationInfo": {
+        "$ref": "#/types/aws-native:rds:DbProxyTargetGroupConnectionPoolConfigurationInfoFormat"
+      },
+      "dbClusterIdentifiers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "dbInstanceIdentifiers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "dbProxyName": {
+        "type": "string",
+        "description": "The identifier for the proxy."
+      },
+      "targetGroupName": {
+        "$ref": "#/types/aws-native:rds:DbProxyTargetGroupTargetGroupName",
+        "description": "The identifier for the DBProxyTargetGroup"
+      }
+    }
+  },
+  "aws-native:rds:EventSubscription": {
+    "cfTypeName": "AWS::RDS::EventSubscription",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "A Boolean value; set to true to activate the subscription, set to false to create the subscription but not active it."
+      },
+      "eventCategories": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the Events topic in the Amazon RDS User Guide or by using the DescribeEventCategories action."
+      },
+      "snsTopicArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it."
+      },
+      "sourceIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens."
+      },
+      "sourceType": {
+        "type": "string",
+        "description": "The type of source that will be generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned."
+      },
+      "subscriptionName": {
+        "type": "string",
+        "description": "The name of the subscription."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:rds:GlobalCluster": {
+    "cfTypeName": "AWS::RDS::GlobalCluster",
+    "properties": {
+      "deletionProtection": {
+        "type": "boolean",
+        "description": "The deletion protection setting for the new global database. The global database can't be deleted when deletion protection is enabled."
+      },
+      "engine": {
+        "$ref": "#/types/aws-native:rds:GlobalClusterEngine",
+        "description": "The name of the database engine to be used for this DB cluster. Valid Values: aurora (for MySQL 5.6-compatible Aurora), aurora-mysql (for MySQL 5.7-compatible Aurora).\nIf you specify the SourceDBClusterIdentifier property, don't specify this property. The value is inherited from the cluster."
+      },
+      "engineVersion": {
+        "type": "string",
+        "description": "The version number of the database engine to use. If you specify the SourceDBClusterIdentifier property, don't specify this property. The value is inherited from the cluster."
+      },
+      "globalClusterIdentifier": {
+        "type": "string",
+        "description": "The cluster identifier of the new global database cluster. This parameter is stored as a lowercase string."
+      },
+      "sourceDbClusterIdentifier": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) to use as the primary cluster of the global database. This parameter is optional. This parameter is stored as a lowercase string."
+      },
+      "storageEncrypted": {
+        "type": "boolean",
+        "description": " The storage encryption setting for the new global database cluster.\nIf you specify the SourceDBClusterIdentifier property, don't specify this property. The value is inherited from the cluster."
+      }
+    }
+  },
+  "aws-native:redshift:Cluster": {
+    "cfTypeName": "AWS::Redshift::Cluster",
+    "properties": {
+      "allowVersionUpgrade": {
+        "type": "boolean",
+        "description": "Major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. Default value is True"
+      },
+      "aquaConfigurationStatus": {
+        "type": "string",
+        "description": "The value represents how the cluster is configured to use AQUA (Advanced Query Accelerator) after the cluster is restored. Possible values include the following.\n\nenabled - Use AQUA if it is available for the current Region and Amazon Redshift node type.\ndisabled - Don't use AQUA.\nauto - Amazon Redshift determines whether to use AQUA.\n"
+      },
+      "automatedSnapshotRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Default value is 1"
+      },
+      "availabilityZone": {
+        "type": "string",
+        "description": "The EC2 Availability Zone (AZ) in which you want Amazon Redshift to provision the cluster. Default: A random, system-chosen Availability Zone in the region that is specified by the endpoint"
+      },
+      "availabilityZoneRelocation": {
+        "type": "boolean",
+        "description": "The option to enable relocation for an Amazon Redshift cluster between Availability Zones after the cluster modification is complete."
+      },
+      "availabilityZoneRelocationStatus": {
+        "type": "string",
+        "description": "The availability zone relocation status of the cluster"
+      },
+      "classic": {
+        "type": "boolean",
+        "description": "A boolean value indicating whether the resize operation is using the classic resize process. If you don't provide this parameter or set the value to false , the resize type is elastic."
+      },
+      "clusterIdentifier": {
+        "type": "string",
+        "description": "A unique identifier for the cluster. You use this identifier to refer to the cluster for any subsequent cluster operations such as deleting or modifying. All alphabetical characters must be lower case, no hypens at the end, no two consecutive hyphens. Cluster name should be unique for all clusters within an AWS account"
+      },
+      "clusterParameterGroupName": {
+        "type": "string",
+        "description": "The name of the parameter group to be associated with this cluster."
+      },
+      "clusterSecurityGroups": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of security groups to be associated with this cluster."
+      },
+      "clusterSubnetGroupName": {
+        "type": "string",
+        "description": "The name of a cluster subnet group to be associated with this cluster."
+      },
+      "clusterType": {
+        "type": "string",
+        "description": "The type of the cluster. When cluster type is specified as single-node, the NumberOfNodes parameter is not required and if multi-node, the NumberOfNodes parameter is required"
+      },
+      "clusterVersion": {
+        "type": "string",
+        "description": "The version of the Amazon Redshift engine software that you want to deploy on the cluster.The version selected runs on all the nodes in the cluster."
+      },
+      "dbName": {
+        "type": "string",
+        "description": "The name of the first database to be created when the cluster is created. To create additional databases after the cluster is created, connect to the cluster with a SQL client and use SQL commands to create a database."
+      },
+      "deferMaintenance": {
+        "type": "boolean",
+        "description": "A boolean indicating whether to enable the deferred maintenance window."
+      },
+      "deferMaintenanceDuration": {
+        "type": "integer",
+        "description": "An integer indicating the duration of the maintenance window in days. If you specify a duration, you can't specify an end time. The duration must be 45 days or less."
+      },
+      "deferMaintenanceEndTime": {
+        "type": "string",
+        "description": "A timestamp indicating end time for the deferred maintenance window. If you specify an end time, you can't specify a duration."
+      },
+      "deferMaintenanceStartTime": {
+        "type": "string",
+        "description": "A timestamp indicating the start time for the deferred maintenance window."
+      },
+      "destinationRegion": {
+        "type": "string",
+        "description": "The destination AWS Region that you want to copy snapshots to. Constraints: Must be the name of a valid AWS Region. For more information, see Regions and Endpoints in the Amazon Web Services [https://docs.aws.amazon.com/general/latest/gr/rande.html#redshift_region] General Reference"
+      },
+      "elasticIp": {
+        "type": "string",
+        "description": "The Elastic IP (EIP) address for the cluster."
+      },
+      "encrypted": {
+        "type": "boolean",
+        "description": "If true, the data in the cluster is encrypted at rest."
+      },
+      "endpoint": {
+        "$ref": "#/types/aws-native:redshift:ClusterEndpoint"
+      },
+      "enhancedVpcRouting": {
+        "type": "boolean",
+        "description": "An option that specifies whether to create the cluster with enhanced VPC routing enabled. To create a cluster that uses enhanced VPC routing, the cluster must be in a VPC. For more information, see Enhanced VPC Routing in the Amazon Redshift Cluster Management Guide.\n\nIf this option is true , enhanced VPC routing is enabled.\n\nDefault: false"
+      },
+      "hsmClientCertificateIdentifier": {
+        "type": "string",
+        "description": "Specifies the name of the HSM client certificate the Amazon Redshift cluster uses to retrieve the data encryption keys stored in an HSM"
+      },
+      "hsmConfigurationIdentifier": {
+        "type": "string",
+        "description": "Specifies the name of the HSM configuration that contains the information the Amazon Redshift cluster can use to retrieve and store keys in an HSM."
+      },
+      "iamRoles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of AWS Identity and Access Management (IAM) roles that can be used by the cluster to access other AWS services. You must supply the IAM roles in their Amazon Resource Name (ARN) format. You can supply up to 50 IAM roles in a single request"
+      },
+      "kmsKeyId": {
+        "type": "string",
+        "description": "The AWS Key Management Service (KMS) key ID of the encryption key that you want to use to encrypt data in the cluster."
+      },
+      "loggingProperties": {
+        "$ref": "#/types/aws-native:redshift:ClusterLoggingProperties"
+      },
+      "maintenanceTrackName": {
+        "type": "string",
+        "description": "The name for the maintenance track that you want to assign for the cluster. This name change is asynchronous. The new track name stays in the PendingModifiedValues for the cluster until the next maintenance window. When the maintenance track changes, the cluster is switched to the latest cluster release available for the maintenance track. At this point, the maintenance track name is applied."
+      },
+      "manageMasterPassword": {
+        "type": "boolean",
+        "description": "A boolean indicating if the redshift cluster's admin user credentials is managed by Redshift or not. You can't use MasterUserPassword if ManageMasterPassword is true. If ManageMasterPassword is false or not set, Amazon Redshift uses MasterUserPassword for the admin user account's password."
+      },
+      "manualSnapshotRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days to retain newly copied snapshots in the destination AWS Region after they are copied from the source AWS Region. If the value is -1, the manual snapshot is retained indefinitely.\n\nThe value must be either -1 or an integer between 1 and 3,653."
+      },
+      "masterPasswordSecretKmsKeyId": {
+        "type": "string",
+        "description": "The ID of the Key Management Service (KMS) key used to encrypt and store the cluster's admin user credentials secret."
+      },
+      "masterUserPassword": {
+        "type": "string",
+        "description": "The password associated with the master user account for the cluster that is being created. You can't use MasterUserPassword if ManageMasterPassword is true. Password must be between 8 and 64 characters in length, should have at least one uppercase letter.Must contain at least one lowercase letter.Must contain one number.Can be any printable ASCII character."
+      },
+      "masterUsername": {
+        "type": "string",
+        "description": "The user name associated with the master user account for the cluster that is being created. The user name can't be PUBLIC and first character must be a letter."
+      },
+      "multiAz": {
+        "type": "boolean",
+        "description": "A boolean indicating if the redshift cluster is multi-az or not. If you don't provide this parameter or set the value to false, the redshift cluster will be single-az."
+      },
+      "namespaceResourcePolicy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "The namespace resource policy document that will be attached to a Redshift cluster.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Redshift::Cluster` for more information about the expected schema for this property."
+      },
+      "nodeType": {
+        "type": "string",
+        "description": "The node type to be provisioned for the cluster.Valid Values: ds2.xlarge | ds2.8xlarge | dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ra3.4xlarge | ra3.16xlarge"
+      },
+      "numberOfNodes": {
+        "type": "integer",
+        "description": "The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node."
+      },
+      "ownerAccount": {
+        "type": "string"
+      },
+      "port": {
+        "type": "integer",
+        "description": "The port number on which the cluster accepts incoming connections. The cluster is accessible only via the JDBC and ODBC connection strings"
+      },
+      "preferredMaintenanceWindow": {
+        "type": "string",
+        "description": "The weekly time range (in UTC) during which automated cluster maintenance can occur."
+      },
+      "publiclyAccessible": {
+        "type": "boolean",
+        "description": "If true, the cluster can be accessed from a public network."
+      },
+      "resourceAction": {
+        "type": "string",
+        "description": "The Redshift operation to be performed. Resource Action supports pause-cluster, resume-cluster, failover-primary-compute APIs"
+      },
+      "revisionTarget": {
+        "type": "string",
+        "description": "The identifier of the database revision. You can retrieve this value from the response to the DescribeClusterDbRevisions request."
+      },
+      "rotateEncryptionKey": {
+        "type": "boolean",
+        "description": "A boolean indicating if we want to rotate Encryption Keys."
+      },
+      "snapshotClusterIdentifier": {
+        "type": "string",
+        "description": "The name of the cluster the source snapshot was created from. This parameter is required if your IAM user has a policy containing a snapshot resource element that specifies anything other than * for the cluster name."
+      },
+      "snapshotCopyGrantName": {
+        "type": "string",
+        "description": "The name of the snapshot copy grant to use when snapshots of an AWS KMS-encrypted cluster are copied to the destination region."
+      },
+      "snapshotCopyManual": {
+        "type": "boolean",
+        "description": "Indicates whether to apply the snapshot retention period to newly copied manual snapshots instead of automated snapshots."
+      },
+      "snapshotCopyRetentionPeriod": {
+        "type": "integer",
+        "description": "The number of days to retain automated snapshots in the destination region after they are copied from the source region. \n\n Default is 7. \n\n Constraints: Must be at least 1 and no more than 35."
+      },
+      "snapshotIdentifier": {
+        "type": "string",
+        "description": "The name of the snapshot from which to create the new cluster. This parameter isn't case sensitive."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The list of tags for the cluster parameter group."
+      },
+      "vpcSecurityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster."
+      }
+    }
+  },
+  "aws-native:redshift:ClusterParameterGroup": {
+    "cfTypeName": "AWS::Redshift::ClusterParameterGroup",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A description of the parameter group."
+      },
+      "parameterGroupFamily": {
+        "type": "string",
+        "description": "The Amazon Redshift engine version to which the cluster parameter group applies. The cluster engine version determines the set of parameters."
+      },
+      "parameterGroupName": {
+        "type": "string",
+        "description": "The name of the cluster parameter group."
+      },
+      "parameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:redshift:ClusterParameterGroupParameter"
+        },
+        "description": "An array of parameters to be modified. A maximum of 20 parameters can be modified in a single request."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:redshift:ClusterSubnetGroup": {
+    "cfTypeName": "AWS::Redshift::ClusterSubnetGroup",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "The description of the parameter group."
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The list of VPC subnet IDs"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The list of tags for the cluster parameter group."
+      }
+    }
+  },
+  "aws-native:redshift:EndpointAccess": {
+    "cfTypeName": "AWS::Redshift::EndpointAccess",
+    "properties": {
+      "clusterIdentifier": {
+        "type": "string",
+        "description": "A unique identifier for the cluster. You use this identifier to refer to the cluster for any subsequent cluster operations such as deleting or modifying. All alphabetical characters must be lower case, no hypens at the end, no two consecutive hyphens. Cluster name should be unique for all clusters within an AWS account"
+      },
+      "endpointName": {
+        "type": "string",
+        "description": "The name of the endpoint."
+      },
+      "resourceOwner": {
+        "type": "string",
+        "description": "The AWS account ID of the owner of the cluster."
+      },
+      "subnetGroupName": {
+        "type": "string",
+        "description": "The subnet group name where Amazon Redshift chooses to deploy the endpoint."
+      },
+      "vpcSecurityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of vpc security group ids to apply to the created endpoint access."
+      }
+    }
+  },
+  "aws-native:redshift:EndpointAuthorization": {
+    "cfTypeName": "AWS::Redshift::EndpointAuthorization",
+    "properties": {
+      "account": {
+        "type": "string",
+        "description": "The target AWS account ID to grant or revoke access for."
+      },
+      "clusterIdentifier": {
+        "type": "string",
+        "description": "The cluster identifier."
+      },
+      "force": {
+        "type": "boolean",
+        "description": " Indicates whether to force the revoke action. If true, the Redshift-managed VPC endpoints associated with the endpoint authorization are also deleted."
+      },
+      "vpcIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The virtual private cloud (VPC) identifiers to grant or revoke access to."
+      }
+    }
+  },
+  "aws-native:redshift:EventSubscription": {
+    "cfTypeName": "AWS::Redshift::EventSubscription",
+    "properties": {
+      "enabled": {
+        "type": "boolean",
+        "description": "A boolean value; set to true to activate the subscription, and set to false to create the subscription but not activate it."
+      },
+      "eventCategories": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:redshift:EventSubscriptionEventCategoriesItem"
+        },
+        "description": "Specifies the Amazon Redshift event categories to be published by the event notification subscription."
+      },
+      "severity": {
+        "$ref": "#/types/aws-native:redshift:EventSubscriptionSeverity",
+        "description": "Specifies the Amazon Redshift event severity to be published by the event notification subscription."
+      },
+      "snsTopicArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications."
+      },
+      "sourceIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "A list of one or more identifiers of Amazon Redshift source objects."
+      },
+      "sourceType": {
+        "$ref": "#/types/aws-native:redshift:EventSubscriptionSourceType",
+        "description": "The type of source that will be generating the events."
+      },
+      "subscriptionName": {
+        "type": "string",
+        "description": "The name of the Amazon Redshift event notification subscription"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:refactorspaces:Route": {
+    "cfTypeName": "AWS::RefactorSpaces::Route",
+    "properties": {
+      "applicationIdentifier": {
+        "type": "string"
+      },
+      "defaultRoute": {
+        "$ref": "#/types/aws-native:refactorspaces:RouteDefaultRouteInput"
+      },
+      "environmentIdentifier": {
+        "type": "string"
+      },
+      "routeType": {
+        "$ref": "#/types/aws-native:refactorspaces:RouteType"
+      },
+      "serviceIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Metadata that you can assign to help organize the frameworks that you create. Each tag is a key-value pair."
+      },
+      "uriPathRoute": {
+        "$ref": "#/types/aws-native:refactorspaces:RouteUriPathRouteInput"
+      }
+    }
+  },
+  "aws-native:rekognition:Collection": {
+    "cfTypeName": "AWS::Rekognition::Collection",
+    "properties": {
+      "collectionId": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:resiliencehub:ResiliencyPolicy": {
+    "cfTypeName": "AWS::ResilienceHub::ResiliencyPolicy",
+    "properties": {
+      "dataLocationConstraint": {
+        "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyDataLocationConstraint",
+        "description": "Data Location Constraint of the Policy."
+      },
+      "policy": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyFailurePolicy"
+        }
+      },
+      "policyDescription": {
+        "type": "string",
+        "description": "Description of Resiliency Policy."
+      },
+      "policyName": {
+        "type": "string",
+        "description": "Name of Resiliency Policy."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "tier": {
+        "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyTier",
+        "description": "Resiliency Policy Tier."
+      }
+    }
+  },
+  "aws-native:resourceexplorer2:DefaultViewAssociation": {
+    "cfTypeName": "AWS::ResourceExplorer2::DefaultViewAssociation",
+    "properties": {
+      "viewArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:resourceexplorer2:Index": {
+    "cfTypeName": "AWS::ResourceExplorer2::Index",
+    "properties": {
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "type": {
+        "$ref": "#/types/aws-native:resourceexplorer2:IndexType"
+      }
+    }
+  },
+  "aws-native:robomaker:RobotApplicationVersion": {
+    "cfTypeName": "AWS::RoboMaker::RobotApplicationVersion",
+    "properties": {
+      "application": {
+        "type": "string"
+      },
+      "currentRevisionId": {
+        "type": "string",
+        "description": "The revision ID of robot application."
+      }
+    }
+  },
+  "aws-native:robomaker:SimulationApplicationVersion": {
+    "cfTypeName": "AWS::RoboMaker::SimulationApplicationVersion",
+    "properties": {
+      "application": {
+        "type": "string"
+      },
+      "currentRevisionId": {
+        "type": "string",
+        "description": "The revision ID of robot application."
+      }
+    }
+  },
+  "aws-native:route53:Dnssec": {
+    "cfTypeName": "AWS::Route53::DNSSEC",
+    "properties": {
+      "hostedZoneId": {
+        "type": "string",
+        "description": "The unique string (ID) used to identify a hosted zone."
+      }
+    }
+  },
+  "aws-native:route53:HealthCheck": {
+    "cfTypeName": "AWS::Route53::HealthCheck",
+    "properties": {
+      "healthCheckConfig": {
+        "$ref": "#/types/aws-native:route53:HealthCheckConfigProperties",
+        "description": "A complex type that contains information about the health check."
+      },
+      "healthCheckTags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:route53:HealthCheckTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:route53resolver:ResolverConfig": {
+    "cfTypeName": "AWS::Route53Resolver::ResolverConfig",
+    "properties": {
+      "autodefinedReverseFlag": {
+        "$ref": "#/types/aws-native:route53resolver:ResolverConfigAutodefinedReverseFlag",
+        "description": "Represents the desired status of AutodefinedReverse. The only supported value on creation is DISABLE. Deletion of this resource will return AutodefinedReverse to its default value (ENABLED)."
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "ResourceId"
+      }
+    }
+  },
+  "aws-native:route53resolver:ResolverDnssecConfig": {
+    "cfTypeName": "AWS::Route53Resolver::ResolverDNSSECConfig",
+    "properties": {
+      "resourceId": {
+        "type": "string",
+        "description": "ResourceId"
+      }
+    }
+  },
+  "aws-native:route53resolver:ResolverQueryLoggingConfigAssociation": {
+    "cfTypeName": "AWS::Route53Resolver::ResolverQueryLoggingConfigAssociation",
+    "properties": {
+      "resolverQueryLogConfigId": {
+        "type": "string",
+        "description": "ResolverQueryLogConfigId"
+      },
+      "resourceId": {
+        "type": "string",
+        "description": "ResourceId"
+      }
+    }
+  },
+  "aws-native:s3:AccessGrant": {
+    "cfTypeName": "AWS::S3::AccessGrant",
+    "properties": {
+      "accessGrantsLocationConfiguration": {
+        "$ref": "#/types/aws-native:s3:AccessGrantsLocationConfiguration",
+        "description": "The configuration options of the grant location, which is the S3 path to the data to which you are granting access."
+      },
+      "accessGrantsLocationId": {
+        "type": "string",
+        "description": "The custom S3 location to be accessed by the grantee"
+      },
+      "applicationArn": {
+        "type": "string",
+        "description": "The ARN of the application grantees will use to access the location"
+      },
+      "grantee": {
+        "$ref": "#/types/aws-native:s3:AccessGrantGrantee",
+        "description": "The principal who will be granted permission to access S3."
+      },
+      "permission": {
+        "$ref": "#/types/aws-native:s3:AccessGrantPermission",
+        "description": "The level of access to be afforded to the grantee"
+      },
+      "s3PrefixType": {
+        "$ref": "#/types/aws-native:s3:AccessGrantS3PrefixType",
+        "description": "The type of S3SubPrefix."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        }
+      }
+    }
+  },
+  "aws-native:s3:AccessGrantsInstance": {
+    "cfTypeName": "AWS::S3::AccessGrantsInstance",
+    "properties": {
+      "identityCenterArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the specified AWS Identity Center."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        }
+      }
+    }
+  },
+  "aws-native:s3:AccessGrantsLocation": {
+    "cfTypeName": "AWS::S3::AccessGrantsLocation",
+    "properties": {
+      "iamRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the access grant location's associated IAM role."
+      },
+      "locationScope": {
+        "type": "string",
+        "description": "Descriptor for where the location actually points"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        }
+      }
+    }
+  },
+  "aws-native:s3:BucketPolicy": {
+    "cfTypeName": "AWS::S3::BucketPolicy",
+    "properties": {
+      "bucket": {
+        "type": "string",
+        "description": "The name of the Amazon S3 bucket to which the policy applies."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified bucket. In IAM, you must provide policy documents in JSON format. However, in CloudFormation you can provide the policy in JSON or YAML format because CloudFormation converts YAML to JSON before submitting it to IAM. For more information, see the AWS::IAM::Policy [PolicyDocument](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policydocument) resource description in this guide and [Access Policy Language Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-language-overview.html) in the *Amazon S3 User Guide*.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::S3::BucketPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:s3:MultiRegionAccessPointPolicy": {
+    "cfTypeName": "AWS::S3::MultiRegionAccessPointPolicy",
+    "properties": {
+      "mrapName": {
+        "type": "string",
+        "description": "The name of the Multi Region Access Point to apply policy"
+      },
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Policy document to apply to a Multi Region Access Point\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::S3::MultiRegionAccessPointPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:s3:StorageLens": {
+    "cfTypeName": "AWS::S3::StorageLens",
+    "properties": {
+      "storageLensConfiguration": {
+        "$ref": "#/types/aws-native:s3:StorageLensConfiguration"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A set of tags (key-value pairs) for this Amazon S3 Storage Lens configuration."
+      }
+    }
+  },
+  "aws-native:s3express:BucketPolicy": {
+    "cfTypeName": "AWS::S3Express::BucketPolicy",
+    "properties": {
+      "bucket": {
+        "type": "string",
+        "description": "The name of the S3 directory bucket to which the policy applies."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified bucket. In IAM, you must provide policy documents in JSON format. However, in CloudFormation you can provide the policy in JSON or YAML format because CloudFormation converts YAML to JSON before submitting it to IAM.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::S3Express::BucketPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:s3express:DirectoryBucket": {
+    "cfTypeName": "AWS::S3Express::DirectoryBucket",
+    "properties": {
+      "bucketName": {
+        "type": "string",
+        "description": "Specifies a name for the bucket. The bucket name must contain only lowercase letters, numbers, and hyphens (-). A directory bucket name must be unique in the chosen Availability Zone. The bucket name must also follow the format 'bucket_base_name--az_id--x-s3' (for example, 'DOC-EXAMPLE-BUCKET--usw2-az1--x-s3'). If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the bucket name."
+      },
+      "dataRedundancy": {
+        "$ref": "#/types/aws-native:s3express:DirectoryBucketDataRedundancy",
+        "description": "Specifies the number of Availability Zone that's used for redundancy for the bucket."
+      },
+      "locationName": {
+        "type": "string",
+        "description": "Specifies the AZ ID of the Availability Zone where the directory bucket will be created. An example AZ ID value is 'use1-az5'."
+      }
+    }
+  },
+  "aws-native:s3objectlambda:AccessPointPolicy": {
+    "cfTypeName": "AWS::S3ObjectLambda::AccessPointPolicy",
+    "properties": {
+      "objectLambdaAccessPoint": {
+        "type": "string",
+        "description": "The name of the Amazon S3 ObjectLambdaAccessPoint to which the policy applies."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified ObjectLambdaAccessPoint. For more information, see Access Policy Language Overview (https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-language-overview.html) in the Amazon Simple Storage Service Developer Guide. \n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::S3ObjectLambda::AccessPointPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:s3outposts:BucketPolicy": {
+    "cfTypeName": "AWS::S3Outposts::BucketPolicy",
+    "properties": {
+      "bucket": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the specified bucket."
+      },
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document containing permissions to add to the specified bucket.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::S3Outposts::BucketPolicy` for more information about the expected schema for this property."
+      }
+    }
+  },
+  "aws-native:s3outposts:Endpoint": {
+    "cfTypeName": "AWS::S3Outposts::Endpoint",
+    "properties": {
+      "accessType": {
+        "$ref": "#/types/aws-native:s3outposts:EndpointAccessType",
+        "description": "The type of access for the on-premise network connectivity for the Outpost endpoint. To access endpoint from an on-premises network, you must specify the access type and provide the customer owned Ipv4 pool."
+      },
+      "customerOwnedIpv4Pool": {
+        "type": "string",
+        "description": "The ID of the customer-owned IPv4 pool for the Endpoint. IP addresses will be allocated from this pool for the endpoint."
+      },
+      "failedReason": {
+        "$ref": "#/types/aws-native:s3outposts:EndpointFailedReason",
+        "description": "The failure reason, if any, for a create or delete endpoint operation."
+      },
+      "outpostId": {
+        "type": "string",
+        "description": "The id of the customer outpost on which the bucket resides."
+      },
+      "securityGroupId": {
+        "type": "string",
+        "description": "The ID of the security group to use with the endpoint."
+      },
+      "subnetId": {
+        "type": "string",
+        "description": "The ID of the subnet in the selected VPC. The subnet must belong to the Outpost."
+      }
+    }
+  },
+  "aws-native:sagemaker:DataQualityJobDefinition": {
+    "cfTypeName": "AWS::SageMaker::DataQualityJobDefinition",
+    "properties": {
+      "dataQualityAppSpecification": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityAppSpecification"
+      },
+      "dataQualityBaselineConfig": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityBaselineConfig"
+      },
+      "dataQualityJobInput": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityJobInput"
+      },
+      "dataQualityJobOutputConfig": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionMonitoringOutputConfig"
+      },
+      "endpointName": {
+        "type": "string"
+      },
+      "jobDefinitionName": {
+        "type": "string"
+      },
+      "jobResources": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionMonitoringResources"
+      },
+      "networkConfig": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionNetworkConfig"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
+      },
+      "stoppingCondition": {
+        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionStoppingCondition"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:sagemaker:Device": {
+    "cfTypeName": "AWS::SageMaker::Device",
+    "properties": {
+      "device": {
+        "$ref": "#/types/aws-native:sagemaker:Device",
+        "description": "The Edge Device you want to register against a device fleet",
+        "language": {
+          "csharp": {
+            "name": "DeviceValue"
+          }
+        }
+      },
+      "deviceFleetName": {
+        "type": "string",
+        "description": "The name of the edge device fleet"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Associate tags with the resource"
+      }
+    }
+  },
+  "aws-native:sagemaker:ImageVersion": {
+    "cfTypeName": "AWS::SageMaker::ImageVersion",
+    "properties": {
+      "alias": {
+        "type": "string"
+      },
+      "aliases": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "baseImage": {
+        "type": "string"
+      },
+      "horovod": {
+        "type": "boolean"
+      },
+      "imageName": {
+        "type": "string"
+      },
+      "jobType": {
+        "$ref": "#/types/aws-native:sagemaker:ImageVersionJobType"
+      },
+      "mlFramework": {
+        "type": "string"
+      },
+      "processor": {
+        "$ref": "#/types/aws-native:sagemaker:ImageVersionProcessor"
+      },
+      "programmingLang": {
+        "type": "string"
+      },
+      "releaseNotes": {
+        "type": "string"
+      },
+      "vendorGuidance": {
+        "$ref": "#/types/aws-native:sagemaker:ImageVersionVendorGuidance"
+      }
+    }
+  },
+  "aws-native:sagemaker:ModelBiasJobDefinition": {
+    "cfTypeName": "AWS::SageMaker::ModelBiasJobDefinition",
+    "properties": {
+      "endpointName": {
+        "type": "string"
+      },
+      "jobDefinitionName": {
+        "type": "string"
+      },
+      "jobResources": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionMonitoringResources"
+      },
+      "modelBiasAppSpecification": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasAppSpecification"
+      },
+      "modelBiasBaselineConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasBaselineConfig"
+      },
+      "modelBiasJobInput": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasJobInput"
+      },
+      "modelBiasJobOutputConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionMonitoringOutputConfig"
+      },
+      "networkConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionNetworkConfig"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
+      },
+      "stoppingCondition": {
+        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionStoppingCondition"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:sagemaker:ModelExplainabilityJobDefinition": {
+    "cfTypeName": "AWS::SageMaker::ModelExplainabilityJobDefinition",
+    "properties": {
+      "endpointName": {
+        "type": "string"
+      },
+      "jobDefinitionName": {
+        "type": "string"
+      },
+      "jobResources": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionMonitoringResources"
+      },
+      "modelExplainabilityAppSpecification": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityAppSpecification"
+      },
+      "modelExplainabilityBaselineConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityBaselineConfig"
+      },
+      "modelExplainabilityJobInput": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityJobInput"
+      },
+      "modelExplainabilityJobOutputConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionMonitoringOutputConfig"
+      },
+      "networkConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionNetworkConfig"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
+      },
+      "stoppingCondition": {
+        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionStoppingCondition"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:sagemaker:ModelQualityJobDefinition": {
+    "cfTypeName": "AWS::SageMaker::ModelQualityJobDefinition",
+    "properties": {
+      "endpointName": {
+        "type": "string"
+      },
+      "jobDefinitionName": {
+        "type": "string"
+      },
+      "jobResources": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionMonitoringResources"
+      },
+      "modelQualityAppSpecification": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityAppSpecification"
+      },
+      "modelQualityBaselineConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityBaselineConfig"
+      },
+      "modelQualityJobInput": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityJobInput"
+      },
+      "modelQualityJobOutputConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionMonitoringOutputConfig"
+      },
+      "networkConfig": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionNetworkConfig"
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
+      },
+      "stoppingCondition": {
+        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionStoppingCondition"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:securityhub:AutomationRule": {
+    "cfTypeName": "AWS::SecurityHub::AutomationRule",
+    "properties": {
+      "actions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:securityhub:AutomationRulesAction"
+        }
+      },
+      "criteria": {
+        "$ref": "#/types/aws-native:securityhub:AutomationRulesFindingFilters",
+        "description": "A set of [Security Finding Format (ASFF)](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) finding field attributes and corresponding expected values that ASH uses to filter findings. If a rule is enabled and a finding matches the criteria specified in this parameter, ASH applies the rule action to the finding."
+      },
+      "description": {
+        "type": "string"
+      },
+      "isTerminal": {
+        "type": "boolean"
+      },
+      "ruleName": {
+        "type": "string"
+      },
+      "ruleOrder": {
+        "type": "integer"
+      },
+      "ruleStatus": {
+        "$ref": "#/types/aws-native:securityhub:AutomationRuleRuleStatus",
+        "description": "Whether the rule is active after it is created. If this parameter is equal to ``ENABLED``, ASH applies the rule to findings and finding updates after the rule is created."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:securityhub:Hub": {
+    "cfTypeName": "AWS::SecurityHub::Hub",
+    "properties": {
+      "autoEnableControls": {
+        "type": "boolean",
+        "description": "Whether to automatically enable new controls when they are added to standards that are enabled"
+      },
+      "controlFindingGenerator": {
+        "type": "string",
+        "description": "This field, used when enabling Security Hub, specifies whether the calling account has consolidated control findings turned on. If the value for this field is set to SECURITY_CONTROL, Security Hub generates a single finding for a control check even when the check applies to multiple enabled standards.  If the value for this field is set to STANDARD_CONTROL, Security Hub generates separate findings for a control check when the check applies to multiple enabled standards."
+      },
+      "enableDefaultStandards": {
+        "type": "boolean",
+        "description": "Whether to enable the security standards that Security Hub has designated as automatically enabled."
+      },
+      "tags": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "aws-native:securityhub:Standard": {
+    "cfTypeName": "AWS::SecurityHub::Standard",
+    "properties": {
+      "disabledStandardsControls": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:securityhub:StandardsControl"
+        },
+        "description": "Specifies which controls are to be disabled in a standard. \n *Maximum*: ``100``"
+      },
+      "standardsArn": {
+        "type": "string",
+        "description": "The ARN of the standard that you want to enable. To view a list of available ASH standards and their ARNs, use the [DescribeStandards](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeStandards.html) API operation."
+      }
+    }
+  },
+  "aws-native:servicecatalog:CloudFormationProvisionedProduct": {
+    "cfTypeName": "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
+    "properties": {
+      "acceptLanguage": {
+        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductAcceptLanguage"
+      },
+      "notificationArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "pathId": {
+        "type": "string"
+      },
+      "pathName": {
+        "type": "string"
+      },
+      "productId": {
+        "type": "string"
+      },
+      "productName": {
+        "type": "string"
+      },
+      "provisionedProductName": {
+        "type": "string"
+      },
+      "provisioningArtifactId": {
+        "type": "string"
+      },
+      "provisioningArtifactName": {
+        "type": "string"
+      },
+      "provisioningParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningParameter"
+        }
+      },
+      "provisioningPreferences": {
+        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningPreferences"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:servicecatalog:ServiceActionAssociation": {
+    "cfTypeName": "AWS::ServiceCatalog::ServiceActionAssociation",
+    "properties": {
+      "productId": {
+        "type": "string"
+      },
+      "provisioningArtifactId": {
+        "type": "string"
+      },
+      "serviceActionId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:servicecatalogappregistry:AttributeGroupAssociation": {
+    "cfTypeName": "AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation",
+    "properties": {
+      "application": {
+        "type": "string",
+        "description": "The name or the Id of the Application."
+      },
+      "attributeGroup": {
+        "type": "string",
+        "description": "The name or the Id of the AttributeGroup."
+      }
+    }
+  },
+  "aws-native:servicecatalogappregistry:ResourceAssociation": {
+    "cfTypeName": "AWS::ServiceCatalogAppRegistry::ResourceAssociation",
+    "properties": {
+      "application": {
+        "type": "string",
+        "description": "The name or the Id of the Application."
+      },
+      "resource": {
+        "type": "string",
+        "description": "The name or the Id of the Resource."
+      },
+      "resourceType": {
+        "$ref": "#/types/aws-native:servicecatalogappregistry:ResourceAssociationResourceType",
+        "description": "The type of the CFN Resource for now it's enum CFN_STACK."
+      }
+    }
+  },
+  "aws-native:ses:ConfigurationSetEventDestination": {
+    "cfTypeName": "AWS::SES::ConfigurationSetEventDestination",
+    "properties": {
+      "configurationSetName": {
+        "type": "string",
+        "description": "The name of the configuration set that contains the event destination."
+      },
+      "eventDestination": {
+        "$ref": "#/types/aws-native:ses:ConfigurationSetEventDestinationEventDestination",
+        "description": "The event destination object."
+      }
+    }
+  },
+  "aws-native:ses:DedicatedIpPool": {
+    "cfTypeName": "AWS::SES::DedicatedIpPool",
+    "properties": {
+      "poolName": {
+        "type": "string",
+        "description": "The name of the dedicated IP pool."
+      },
+      "scalingMode": {
+        "type": "string",
+        "description": "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD."
+      }
+    }
+  },
+  "aws-native:ses:EmailIdentity": {
+    "cfTypeName": "AWS::SES::EmailIdentity",
+    "properties": {
+      "configurationSetAttributes": {
+        "$ref": "#/types/aws-native:ses:EmailIdentityConfigurationSetAttributes"
+      },
+      "dkimAttributes": {
+        "$ref": "#/types/aws-native:ses:EmailIdentityDkimAttributes"
+      },
+      "dkimSigningAttributes": {
+        "$ref": "#/types/aws-native:ses:EmailIdentityDkimSigningAttributes"
+      },
+      "emailIdentity": {
+        "type": "string",
+        "description": "The email address or domain to verify.",
+        "language": {
+          "csharp": {
+            "name": "EmailIdentityValue"
+          }
+        }
+      },
+      "feedbackAttributes": {
+        "$ref": "#/types/aws-native:ses:EmailIdentityFeedbackAttributes"
+      },
+      "mailFromAttributes": {
+        "$ref": "#/types/aws-native:ses:EmailIdentityMailFromAttributes"
+      }
+    }
+  },
+  "aws-native:ses:Template": {
+    "cfTypeName": "AWS::SES::Template",
+    "properties": {
+      "template": {
+        "$ref": "#/types/aws-native:ses:Template",
+        "language": {
+          "csharp": {
+            "name": "TemplateValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:ses:VdmAttributes": {
+    "cfTypeName": "AWS::SES::VdmAttributes",
+    "properties": {
+      "dashboardAttributes": {
+        "$ref": "#/types/aws-native:ses:VdmAttributesDashboardAttributes"
+      },
+      "guardianAttributes": {
+        "$ref": "#/types/aws-native:ses:VdmAttributesGuardianAttributes"
+      }
+    }
+  },
+  "aws-native:shield:DrtAccess": {
+    "cfTypeName": "AWS::Shield::DRTAccess",
+    "properties": {
+      "logBucketList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Authorizes the Shield Response Team (SRT) to access the specified Amazon S3 bucket containing log data such as Application Load Balancer access logs, CloudFront logs, or logs from third party sources. You can associate up to 10 Amazon S3 buckets with your subscription."
+      },
+      "roleArn": {
+        "type": "string",
+        "description": "Authorizes the Shield Response Team (SRT) using the specified role, to access your AWS account to assist with DDoS attack mitigation during potential attacks. This enables the SRT to inspect your AWS WAF configuration and create or update AWS WAF rules and web ACLs."
+      }
+    }
+  },
+  "aws-native:shield:ProactiveEngagement": {
+    "cfTypeName": "AWS::Shield::ProactiveEngagement",
+    "properties": {
+      "emergencyContactList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:shield:ProactiveEngagementEmergencyContact"
+        },
+        "description": "A list of email addresses and phone numbers that the Shield Response Team (SRT) can use to contact you for escalations to the SRT and to initiate proactive customer support.\nTo enable proactive engagement, the contact list must include at least one phone number."
+      },
+      "proactiveEngagementStatus": {
+        "$ref": "#/types/aws-native:shield:ProactiveEngagementStatus",
+        "description": "If `ENABLED`, the Shield Response Team (SRT) will use email and phone to notify contacts about escalations to the SRT and to initiate proactive customer support.\nIf `DISABLED`, the SRT will not proactively notify contacts about escalations or to initiate proactive customer support."
+      }
+    }
+  },
+  "aws-native:shield:ProtectionGroup": {
+    "cfTypeName": "AWS::Shield::ProtectionGroup",
+    "properties": {
+      "aggregation": {
+        "$ref": "#/types/aws-native:shield:ProtectionGroupAggregation",
+        "description": "Defines how AWS Shield combines resource data for the group in order to detect, mitigate, and report events.\n* Sum - Use the total traffic across the group. This is a good choice for most cases. Examples include Elastic IP addresses for EC2 instances that scale manually or automatically.\n* Mean - Use the average of the traffic across the group. This is a good choice for resources that share traffic uniformly. Examples include accelerators and load balancers.\n* Max - Use the highest traffic from each resource. This is useful for resources that don't share traffic and for resources that share that traffic in a non-uniform way. Examples include Amazon CloudFront and origin resources for CloudFront distributions."
+      },
+      "members": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Names (ARNs) of the resources to include in the protection group. You must set this when you set `Pattern` to `ARBITRARY` and you must not set it for any other `Pattern` setting."
+      },
+      "pattern": {
+        "$ref": "#/types/aws-native:shield:ProtectionGroupPattern",
+        "description": "The criteria to use to choose the protected resources for inclusion in the group. You can include all resources that have protections, provide a list of resource Amazon Resource Names (ARNs), or include all resources of a specified resource type."
+      },
+      "protectionGroupId": {
+        "type": "string",
+        "description": "The name of the protection group. You use this to identify the protection group in lists and to manage the protection group, for example to update, delete, or describe it."
+      },
+      "resourceType": {
+        "$ref": "#/types/aws-native:shield:ProtectionGroupResourceType",
+        "description": "The resource type to include in the protection group. All protected resources of this type are included in the protection group. Newly protected resources of this type are automatically added to the group. You must set this when you set `Pattern` to `BY_RESOURCE_TYPE` and you must not set it for any other `Pattern` setting."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "One or more tag key-value pairs for the Protection object."
+      }
+    }
+  },
+  "aws-native:signer:ProfilePermission": {
+    "cfTypeName": "AWS::Signer::ProfilePermission",
+    "properties": {
+      "action": {
+        "type": "string"
+      },
+      "principal": {
+        "type": "string"
+      },
+      "profileName": {
+        "type": "string"
+      },
+      "profileVersion": {
+        "type": "string"
+      },
+      "statementId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:signer:SigningProfile": {
+    "cfTypeName": "AWS::Signer::SigningProfile",
+    "properties": {
+      "platformId": {
+        "$ref": "#/types/aws-native:signer:SigningProfilePlatformId",
+        "description": "The ID of the target signing platform."
+      },
+      "signatureValidityPeriod": {
+        "$ref": "#/types/aws-native:signer:SigningProfileSignatureValidityPeriod",
+        "description": "Signature validity period of the profile."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "A list of tags associated with the signing profile."
+      }
+    }
+  },
+  "aws-native:sns:TopicInlinePolicy": {
+    "cfTypeName": "AWS::SNS::TopicInlinePolicy",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document that contains permissions to add to the specified SNS topics.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::SNS::TopicInlinePolicy` for more information about the expected schema for this property."
+      },
+      "topicArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the topic to which you want to add the policy."
+      }
+    }
+  },
+  "aws-native:sns:TopicPolicy": {
+    "cfTypeName": "AWS::SNS::TopicPolicy",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document that contains permissions to add to the specified SNS topics.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::SNS::TopicPolicy` for more information about the expected schema for this property."
+      },
+      "topics": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Names (ARN) of the topics to which you want to add the policy. You can use the ``Ref`` function to specify an ``AWS::SNS::Topic`` resource."
+      }
+    }
+  },
+  "aws-native:sqs:QueueInlinePolicy": {
+    "cfTypeName": "AWS::SQS::QueueInlinePolicy",
+    "properties": {
+      "policyDocument": {
+        "$ref": "pulumi.json#/Any",
+        "description": "A policy document that contains permissions to add to the specified SQS queue\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::SQS::QueueInlinePolicy` for more information about the expected schema for this property."
+      },
+      "queue": {
+        "type": "string",
+        "description": "The URL of the SQS queue."
+      }
+    }
+  },
+  "aws-native:ssm:ResourceDataSync": {
+    "cfTypeName": "AWS::SSM::ResourceDataSync",
+    "properties": {
+      "bucketName": {
+        "type": "string"
+      },
+      "bucketPrefix": {
+        "type": "string"
+      },
+      "bucketRegion": {
+        "type": "string"
+      },
+      "kmsKeyArn": {
+        "type": "string"
+      },
+      "s3Destination": {
+        "$ref": "#/types/aws-native:ssm:ResourceDataSyncS3Destination"
+      },
+      "syncFormat": {
+        "type": "string"
+      },
+      "syncName": {
+        "type": "string"
+      },
+      "syncSource": {
+        "$ref": "#/types/aws-native:ssm:ResourceDataSyncSyncSource"
+      },
+      "syncType": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:ssm:ResourcePolicy": {
+    "cfTypeName": "AWS::SSM::ResourcePolicy",
+    "properties": {
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Actual policy statement.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::SSM::ResourcePolicy` for more information about the expected schema for this property."
+      },
+      "resourceArn": {
+        "type": "string",
+        "description": "Arn of OpsItemGroup etc."
+      }
+    }
+  },
+  "aws-native:ssmcontacts:Contact": {
+    "cfTypeName": "AWS::SSMContacts::Contact",
+    "properties": {
+      "alias": {
+        "type": "string",
+        "description": "Alias of the contact. String value with 20 to 256 characters. Only alphabetical, numeric characters, dash, or underscore allowed."
+      },
+      "displayName": {
+        "type": "string",
+        "description": "Name of the contact. String value with 3 to 256 characters. Only alphabetical, space, numeric characters, dash, or underscore allowed."
+      },
+      "plan": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ssmcontacts:ContactStage"
+        },
+        "description": "The stages that an escalation plan or engagement plan engages contacts and contact methods in."
+      },
+      "type": {
+        "$ref": "#/types/aws-native:ssmcontacts:ContactType",
+        "description": "Contact type, which specify type of contact. Currently supported values: \"PERSONAL\", \"SHARED\", \"OTHER\"."
+      }
+    }
+  },
+  "aws-native:ssmcontacts:ContactChannel": {
+    "cfTypeName": "AWS::SSMContacts::ContactChannel",
+    "properties": {
+      "channelAddress": {
+        "type": "string",
+        "description": "The details that SSM Incident Manager uses when trying to engage the contact channel."
+      },
+      "channelName": {
+        "type": "string",
+        "description": "The device name. String of 6 to 50 alphabetical, numeric, dash, and underscore characters."
+      },
+      "channelType": {
+        "$ref": "#/types/aws-native:ssmcontacts:ContactChannelChannelType",
+        "description": "Device type, which specify notification channel. Currently supported values: \"SMS\", \"VOICE\", \"EMAIL\", \"CHATBOT."
+      },
+      "contactId": {
+        "type": "string",
+        "description": "ARN of the contact resource"
+      },
+      "deferActivation": {
+        "type": "boolean",
+        "description": "If you want to activate the channel at a later time, you can choose to defer activation. SSM Incident Manager can't engage your contact channel until it has been activated."
+      }
+    }
+  },
+  "aws-native:ssmcontacts:Plan": {
+    "cfTypeName": "AWS::SSMContacts::Plan",
+    "properties": {
+      "contactId": {
+        "type": "string",
+        "description": "Contact ID for the AWS SSM Incident Manager Contact to associate the plan."
+      },
+      "rotationIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Rotation Ids to associate with Oncall Contact for engagement."
+      },
+      "stages": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ssmcontacts:PlanStage"
+        },
+        "description": "The stages that an escalation plan or engagement plan engages contacts and contact methods in."
+      }
+    }
+  },
+  "aws-native:ssmincidents:ReplicationSet": {
+    "cfTypeName": "AWS::SSMIncidents::ReplicationSet",
+    "properties": {
+      "deletionProtected": {
+        "type": "boolean"
+      },
+      "regions": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:ssmincidents:ReplicationSetReplicationRegion"
+        },
+        "description": "The ReplicationSet configuration."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags to apply to the replication set."
+      }
+    }
+  },
+  "aws-native:sso:Assignment": {
+    "cfTypeName": "AWS::SSO::Assignment",
+    "properties": {
+      "instanceArn": {
+        "type": "string",
+        "description": "The sso instance that the permission set is owned."
+      },
+      "permissionSetArn": {
+        "type": "string",
+        "description": "The permission set that the assignemt will be assigned"
+      },
+      "principalId": {
+        "type": "string",
+        "description": "The assignee's identifier, user id/group id"
+      },
+      "principalType": {
+        "$ref": "#/types/aws-native:sso:AssignmentPrincipalType",
+        "description": "The assignee's type, user/group"
+      },
+      "targetId": {
+        "type": "string",
+        "description": "The account id to be provisioned."
+      },
+      "targetType": {
+        "$ref": "#/types/aws-native:sso:AssignmentTargetType",
+        "description": "The type of resource to be provsioned to, only aws account now"
+      }
+    }
+  },
+  "aws-native:sso:InstanceAccessControlAttributeConfiguration": {
+    "cfTypeName": "AWS::SSO::InstanceAccessControlAttributeConfiguration",
+    "properties": {
+      "accessControlAttributes": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:sso:InstanceAccessControlAttributeConfigurationAccessControlAttribute"
+        }
+      },
+      "instanceAccessControlAttributeConfiguration": {
+        "$ref": "#/types/aws-native:sso:InstanceAccessControlAttributeConfigurationProperties",
+        "description": "The InstanceAccessControlAttributeConfiguration property has been deprecated but is still supported for backwards compatibility purposes. We recomend that you use  AccessControlAttributes property instead.",
+        "language": {
+          "csharp": {
+            "name": "InstanceAccessControlAttributeConfigurationValue"
+          }
+        }
+      },
+      "instanceArn": {
+        "type": "string",
+        "description": "The ARN of the AWS SSO instance under which the operation will be executed."
+      }
+    }
+  },
+  "aws-native:stepfunctions:StateMachineVersion": {
+    "cfTypeName": "AWS::StepFunctions::StateMachineVersion",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "stateMachineArn": {
+        "type": "string"
+      },
+      "stateMachineRevisionId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:supportapp:AccountAlias": {
+    "cfTypeName": "AWS::SupportApp::AccountAlias",
+    "properties": {
+      "accountAlias": {
+        "type": "string",
+        "description": "An account alias associated with a customer's account.",
+        "language": {
+          "csharp": {
+            "name": "AccountAliasValue"
+          }
+        }
+      }
+    }
+  },
+  "aws-native:supportapp:SlackChannelConfiguration": {
+    "cfTypeName": "AWS::SupportApp::SlackChannelConfiguration",
+    "properties": {
+      "channelId": {
+        "type": "string",
+        "description": "The channel ID in Slack, which identifies a channel within a workspace."
+      },
+      "channelName": {
+        "type": "string",
+        "description": "The channel name in Slack."
+      },
+      "channelRoleArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of an IAM role that grants the AWS Support App access to perform operations for AWS services."
+      },
+      "notifyOnAddCorrespondenceToCase": {
+        "type": "boolean",
+        "description": "Whether to notify when a correspondence is added to a case."
+      },
+      "notifyOnCaseSeverity": {
+        "$ref": "#/types/aws-native:supportapp:SlackChannelConfigurationNotifyOnCaseSeverity",
+        "description": "The severity level of a support case that a customer wants to get notified for."
+      },
+      "notifyOnCreateOrReopenCase": {
+        "type": "boolean",
+        "description": "Whether to notify when a case is created or reopened."
+      },
+      "notifyOnResolveCase": {
+        "type": "boolean",
+        "description": "Whether to notify when a case is resolved."
+      },
+      "teamId": {
+        "type": "string",
+        "description": "The team ID in Slack, which uniquely identifies a workspace."
+      }
+    }
+  },
+  "aws-native:supportapp:SlackWorkspaceConfiguration": {
+    "cfTypeName": "AWS::SupportApp::SlackWorkspaceConfiguration",
+    "properties": {
+      "teamId": {
+        "type": "string",
+        "description": "The team ID in Slack, which uniquely identifies a workspace."
+      },
+      "versionId": {
+        "type": "string",
+        "description": "An identifier used to update an existing Slack workspace configuration in AWS CloudFormation."
+      }
+    }
+  },
+  "aws-native:systemsmanagersap:Application": {
+    "cfTypeName": "AWS::SystemsManagerSAP::Application",
+    "properties": {
+      "applicationId": {
+        "type": "string"
+      },
+      "applicationType": {
+        "$ref": "#/types/aws-native:systemsmanagersap:ApplicationType"
+      },
+      "credentials": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:systemsmanagersap:ApplicationCredential"
+        }
+      },
+      "instances": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "sapInstanceNumber": {
+        "type": "string"
+      },
+      "sid": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "The tags of a SystemsManagerSAP application."
+      }
+    }
+  },
+  "aws-native:transfer:Agreement": {
+    "cfTypeName": "AWS::Transfer::Agreement",
+    "properties": {
+      "accessRole": {
+        "type": "string",
+        "description": "Specifies the access role for the agreement."
+      },
+      "baseDirectory": {
+        "type": "string",
+        "description": "Specifies the base directory for the agreement."
+      },
+      "description": {
+        "type": "string",
+        "description": "A textual description for the agreement."
+      },
+      "localProfileId": {
+        "type": "string",
+        "description": "A unique identifier for the local profile."
+      },
+      "partnerProfileId": {
+        "type": "string",
+        "description": "A unique identifier for the partner profile."
+      },
+      "serverId": {
+        "type": "string",
+        "description": "A unique identifier for the server."
+      },
+      "status": {
+        "$ref": "#/types/aws-native:transfer:AgreementStatus",
+        "description": "Specifies the status of the agreement."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Key-value pairs that can be used to group and search for agreements. Tags are metadata attached to agreements for any purpose."
+      }
+    }
+  },
+  "aws-native:transfer:Certificate": {
+    "cfTypeName": "AWS::Transfer::Certificate",
+    "properties": {
+      "activeDate": {
+        "type": "string",
+        "description": "Specifies the active date for the certificate."
+      },
+      "certificate": {
+        "type": "string",
+        "description": "Specifies the certificate body to be imported.",
+        "language": {
+          "csharp": {
+            "name": "CertificateValue"
+          }
+        }
+      },
+      "certificateChain": {
+        "type": "string",
+        "description": "Specifies the certificate chain to be imported."
+      },
+      "description": {
+        "type": "string",
+        "description": "A textual description for the certificate."
+      },
+      "inactiveDate": {
+        "type": "string",
+        "description": "Specifies the inactive date for the certificate."
+      },
+      "privateKey": {
+        "type": "string",
+        "description": "Specifies the private key for the certificate."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Key-value pairs that can be used to group and search for certificates. Tags are metadata attached to certificates for any purpose."
+      },
+      "usage": {
+        "$ref": "#/types/aws-native:transfer:CertificateUsage",
+        "description": "Specifies the usage type for the certificate."
+      }
+    }
+  },
+  "aws-native:transfer:Connector": {
+    "cfTypeName": "AWS::Transfer::Connector",
+    "properties": {
+      "accessRole": {
+        "type": "string",
+        "description": "Specifies the access role for the connector."
+      },
+      "as2Config": {
+        "$ref": "#/types/aws-native:transfer:As2ConfigProperties",
+        "description": "Configuration for an AS2 connector."
+      },
+      "loggingRole": {
+        "type": "string",
+        "description": "Specifies the logging role for the connector."
+      },
+      "sftpConfig": {
+        "$ref": "#/types/aws-native:transfer:SftpConfigProperties",
+        "description": "Configuration for an SFTP connector."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Key-value pairs that can be used to group and search for connectors. Tags are metadata attached to connectors for any purpose."
+      },
+      "url": {
+        "type": "string",
+        "description": "URL for Connector"
+      }
+    }
+  },
+  "aws-native:transfer:Profile": {
+    "cfTypeName": "AWS::Transfer::Profile",
+    "properties": {
+      "as2Id": {
+        "type": "string",
+        "description": "AS2 identifier agreed with a trading partner."
+      },
+      "certificateIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "List of the certificate IDs associated with this profile to be used for encryption and signing of AS2 messages."
+      },
+      "profileType": {
+        "$ref": "#/types/aws-native:transfer:ProfileType",
+        "description": "Enum specifying whether the profile is local or associated with a trading partner."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "An array of key-value pairs to apply to this resource."
+      }
+    }
+  },
+  "aws-native:transfer:Workflow": {
+    "cfTypeName": "AWS::Transfer::Workflow",
+    "properties": {
+      "description": {
+        "type": "string",
+        "description": "A textual description for the workflow."
+      },
+      "onExceptionSteps": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:transfer:WorkflowStep"
+        },
+        "description": "Specifies the steps (actions) to take if any errors are encountered during execution of the workflow."
+      },
+      "steps": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:transfer:WorkflowStep"
+        },
+        "description": "Specifies the details for the steps that are in the specified workflow."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        },
+        "description": "Key-value pairs that can be used to group and search for workflows. Tags are metadata attached to workflows for any purpose."
+      }
+    }
+  },
+  "aws-native:verifiedpermissions:IdentitySource": {
+    "cfTypeName": "AWS::VerifiedPermissions::IdentitySource",
+    "properties": {
+      "configuration": {
+        "$ref": "#/types/aws-native:verifiedpermissions:IdentitySourceConfiguration"
+      },
+      "policyStoreId": {
+        "type": "string"
+      },
+      "principalEntityType": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:verifiedpermissions:Policy": {
+    "cfTypeName": "AWS::VerifiedPermissions::Policy",
+    "properties": {
+      "definition": {
+        "oneOf": [
+          {
+            "$ref": "#/types/aws-native:verifiedpermissions:PolicyDefinition0Properties"
+          },
+          {
+            "$ref": "#/types/aws-native:verifiedpermissions:PolicyDefinition1Properties"
+          }
+        ]
+      },
+      "policyStoreId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:verifiedpermissions:PolicyStore": {
+    "cfTypeName": "AWS::VerifiedPermissions::PolicyStore",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "schema": {
+        "$ref": "#/types/aws-native:verifiedpermissions:PolicyStoreSchemaDefinition"
+      },
+      "validationSettings": {
+        "$ref": "#/types/aws-native:verifiedpermissions:PolicyStoreValidationSettings"
+      }
+    }
+  },
+  "aws-native:verifiedpermissions:PolicyTemplate": {
+    "cfTypeName": "AWS::VerifiedPermissions::PolicyTemplate",
+    "properties": {
+      "description": {
+        "type": "string"
+      },
+      "policyStoreId": {
+        "type": "string"
+      },
+      "statement": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:vpclattice:AccessLogSubscription": {
+    "cfTypeName": "AWS::VpcLattice::AccessLogSubscription",
+    "properties": {
+      "destinationArn": {
+        "type": "string"
+      },
+      "resourceIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:vpclattice:AuthPolicy": {
+    "cfTypeName": "AWS::VpcLattice::AuthPolicy",
+    "properties": {
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::VpcLattice::AuthPolicy` for more information about the expected schema for this property."
+      },
+      "resourceIdentifier": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:vpclattice:ResourcePolicy": {
+    "cfTypeName": "AWS::VpcLattice::ResourcePolicy",
+    "properties": {
+      "policy": {
+        "$ref": "pulumi.json#/Any",
+        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::VpcLattice::ResourcePolicy` for more information about the expected schema for this property."
+      },
+      "resourceArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:vpclattice:ServiceNetworkServiceAssociation": {
+    "cfTypeName": "AWS::VpcLattice::ServiceNetworkServiceAssociation",
+    "properties": {
+      "dnsEntry": {
+        "$ref": "#/types/aws-native:vpclattice:ServiceNetworkServiceAssociationDnsEntry"
+      },
+      "serviceIdentifier": {
+        "type": "string"
+      },
+      "serviceNetworkIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:vpclattice:ServiceNetworkVpcAssociation": {
+    "cfTypeName": "AWS::VpcLattice::ServiceNetworkVpcAssociation",
+    "properties": {
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "serviceNetworkIdentifier": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "vpcIdentifier": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:wafv2:LoggingConfiguration": {
+    "cfTypeName": "AWS::WAFv2::LoggingConfiguration",
+    "properties": {
+      "logDestinationConfigs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "The Amazon Resource Names (ARNs) of the logging destinations that you want to associate with the web ACL."
+      },
+      "loggingFilter": {
+        "$ref": "#/types/aws-native:wafv2:LoggingFilterProperties",
+        "description": "Filtering that specifies which web requests are kept in the logs and which are dropped. You can filter on the rule action and on the web request labels that were applied by matching rules during web ACL evaluation."
+      },
+      "redactedFields": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:wafv2:LoggingConfigurationFieldToMatch"
+        },
+        "description": "The parts of the request that you want to keep out of the logs. For example, if you redact the HEADER field, the HEADER field in the firehose will be xxx."
+      },
+      "resourceArn": {
+        "type": "string",
+        "description": "The Amazon Resource Name (ARN) of the web ACL that you want to associate with LogDestinationConfigs."
+      }
+    }
+  },
+  "aws-native:wafv2:WebAclAssociation": {
+    "cfTypeName": "AWS::WAFv2::WebACLAssociation",
+    "properties": {
+      "resourceArn": {
+        "type": "string"
+      },
+      "webAclArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:wisdom:AssistantAssociation": {
+    "cfTypeName": "AWS::Wisdom::AssistantAssociation",
+    "properties": {
+      "assistantId": {
+        "type": "string"
+      },
+      "association": {
+        "$ref": "#/types/aws-native:wisdom:AssistantAssociationAssociationData"
+      },
+      "associationType": {
+        "$ref": "#/types/aws-native:wisdom:AssistantAssociationAssociationType"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        }
+      }
+    }
+  },
+  "aws-native:workspaces:ConnectionAlias": {
+    "cfTypeName": "AWS::WorkSpaces::ConnectionAlias",
+    "properties": {
+      "connectionString": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:CreateOnlyTag"
+        }
+      }
+    }
+  },
+  "aws-native:workspacesweb:BrowserSettings": {
+    "cfTypeName": "AWS::WorkSpacesWeb::BrowserSettings",
+    "properties": {
+      "additionalEncryptionContext": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "browserPolicy": {
+        "type": "string"
+      },
+      "customerManagedKey": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:workspacesweb:IpAccessSettings": {
+    "cfTypeName": "AWS::WorkSpacesWeb::IpAccessSettings",
+    "properties": {
+      "additionalEncryptionContext": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "customerManagedKey": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "displayName": {
+        "type": "string"
+      },
+      "ipRules": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:workspacesweb:IpAccessSettingsIpRule"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:workspacesweb:NetworkSettings": {
+    "cfTypeName": "AWS::WorkSpacesWeb::NetworkSettings",
+    "properties": {
+      "securityGroupIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "subnetIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "vpcId": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:workspacesweb:Portal": {
+    "cfTypeName": "AWS::WorkSpacesWeb::Portal",
+    "properties": {
+      "additionalEncryptionContext": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "authenticationType": {
+        "$ref": "#/types/aws-native:workspacesweb:PortalAuthenticationType"
+      },
+      "browserSettingsArn": {
+        "type": "string"
+      },
+      "customerManagedKey": {
+        "type": "string"
+      },
+      "displayName": {
+        "type": "string"
+      },
+      "ipAccessSettingsArn": {
+        "type": "string"
+      },
+      "networkSettingsArn": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "trustStoreArn": {
+        "type": "string"
+      },
+      "userAccessLoggingSettingsArn": {
+        "type": "string"
+      },
+      "userSettingsArn": {
+        "type": "string"
+      }
+    }
+  },
+  "aws-native:workspacesweb:TrustStore": {
+    "cfTypeName": "AWS::WorkSpacesWeb::TrustStore",
+    "properties": {
+      "certificateList": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:workspacesweb:UserAccessLoggingSettings": {
+    "cfTypeName": "AWS::WorkSpacesWeb::UserAccessLoggingSettings",
+    "properties": {
+      "kinesisStreamArn": {
+        "type": "string",
+        "description": "Kinesis stream ARN to which log events are published."
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  },
+  "aws-native:workspacesweb:UserSettings": {
+    "cfTypeName": "AWS::WorkSpacesWeb::UserSettings",
+    "properties": {
+      "additionalEncryptionContext": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "cookieSynchronizationConfiguration": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsCookieSynchronizationConfiguration"
+      },
+      "copyAllowed": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
+      },
+      "customerManagedKey": {
+        "type": "string"
+      },
+      "disconnectTimeoutInMinutes": {
+        "type": "number"
+      },
+      "downloadAllowed": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
+      },
+      "idleDisconnectTimeoutInMinutes": {
+        "type": "number"
+      },
+      "pasteAllowed": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
+      },
+      "printAllowed": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      },
+      "uploadAllowed": {
+        "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
+      }
+    }
+  },
+  "aws-native:xray:ResourcePolicy": {
+    "cfTypeName": "AWS::XRay::ResourcePolicy",
+    "properties": {
+      "bypassPolicyLockoutCheck": {
+        "type": "boolean",
+        "description": "A flag to indicate whether to bypass the resource policy lockout safety check"
+      },
+      "policyDocument": {
+        "type": "string",
+        "description": "The resource policy document, which can be up to 5kb in size."
+      },
+      "policyName": {
+        "type": "string",
+        "description": "The name of the resource policy. Must be unique within a specific AWS account."
+      }
+    }
+  },
+  "aws-native:xray:SamplingRule": {
+    "cfTypeName": "AWS::XRay::SamplingRule",
+    "properties": {
+      "ruleName": {
+        "type": "string"
+      },
+      "samplingRule": {
+        "$ref": "#/types/aws-native:xray:SamplingRule",
+        "language": {
+          "csharp": {
+            "name": "SamplingRuleValue"
+          }
+        }
+      },
+      "samplingRuleRecord": {
+        "$ref": "#/types/aws-native:xray:SamplingRuleRecord"
+      },
+      "samplingRuleUpdate": {
+        "$ref": "#/types/aws-native:xray:SamplingRuleUpdate"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
+      }
+    }
+  }
+}

--- a/reports/missedAutonaming.json
+++ b/reports/missedAutonaming.json
@@ -692,43 +692,6 @@
       }
     }
   },
-  "aws-native:applicationautoscaling:ScalingPolicy": {
-    "cfTypeName": "AWS::ApplicationAutoScaling::ScalingPolicy",
-    "properties": {
-      "policyName": {
-        "type": "string",
-        "description": "The name of the scaling policy.\n\nUpdates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name."
-      },
-      "policyType": {
-        "type": "string",
-        "description": "The scaling policy type.\n\nThe following policy types are supported:\n\nTargetTrackingScaling Not supported for Amazon EMR\n\nStepScaling Not supported for DynamoDB, Amazon Comprehend, Lambda, Amazon Keyspaces, Amazon MSK, Amazon ElastiCache, or Neptune."
-      },
-      "resourceId": {
-        "type": "string",
-        "description": "The identifier of the resource associated with the scaling policy. This string consists of the resource type and unique identifier."
-      },
-      "scalableDimension": {
-        "type": "string",
-        "description": "The scalable dimension. This string consists of the service namespace, resource type, and scaling property."
-      },
-      "scalingTargetId": {
-        "type": "string",
-        "description": "The CloudFormation-generated ID of an Application Auto Scaling scalable target. For more information about the ID, see the Return Value section of the AWS::ApplicationAutoScaling::ScalableTarget resource."
-      },
-      "serviceNamespace": {
-        "type": "string",
-        "description": "The namespace of the AWS service that provides the resource, or a custom-resource."
-      },
-      "stepScalingPolicyConfiguration": {
-        "$ref": "#/types/aws-native:applicationautoscaling:ScalingPolicyStepScalingPolicyConfiguration",
-        "description": "A step scaling policy."
-      },
-      "targetTrackingScalingPolicyConfiguration": {
-        "$ref": "#/types/aws-native:applicationautoscaling:ScalingPolicyTargetTrackingScalingPolicyConfiguration",
-        "description": "A target tracking scaling policy."
-      }
-    }
-  },
   "aws-native:applicationinsights:Application": {
     "cfTypeName": "AWS::ApplicationInsights::Application",
     "properties": {
@@ -999,27 +962,6 @@
       }
     }
   },
-  "aws-native:athena:PreparedStatement": {
-    "cfTypeName": "AWS::Athena::PreparedStatement",
-    "properties": {
-      "description": {
-        "type": "string",
-        "description": "The description of the prepared statement."
-      },
-      "queryStatement": {
-        "type": "string",
-        "description": "The query string for the prepared statement."
-      },
-      "statementName": {
-        "type": "string",
-        "description": "The name of the prepared statement."
-      },
-      "workGroup": {
-        "type": "string",
-        "description": "The name of the workgroup to which the prepared statement belongs."
-      }
-    }
-  },
   "aws-native:autoscaling:ScalingPolicy": {
     "cfTypeName": "AWS::AutoScaling::ScalingPolicy",
     "properties": {
@@ -1196,169 +1138,11 @@
       }
     }
   },
-  "aws-native:ce:AnomalyMonitor": {
-    "cfTypeName": "AWS::CE::AnomalyMonitor",
-    "properties": {
-      "monitorDimension": {
-        "$ref": "#/types/aws-native:ce:AnomalyMonitorMonitorDimension",
-        "description": "The dimensions to evaluate"
-      },
-      "monitorName": {
-        "type": "string",
-        "description": "The name of the monitor."
-      },
-      "monitorSpecification": {
-        "type": "string"
-      },
-      "monitorType": {
-        "$ref": "#/types/aws-native:ce:AnomalyMonitorMonitorType"
-      },
-      "resourceTags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:ce:AnomalyMonitorResourceTag"
-        },
-        "description": "Tags to assign to monitor."
-      }
-    }
-  },
-  "aws-native:ce:AnomalySubscription": {
-    "cfTypeName": "AWS::CE::AnomalySubscription",
-    "properties": {
-      "frequency": {
-        "$ref": "#/types/aws-native:ce:AnomalySubscriptionFrequency",
-        "description": "The frequency at which anomaly reports are sent over email. "
-      },
-      "monitorArnList": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "A list of cost anomaly monitors."
-      },
-      "resourceTags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:ce:AnomalySubscriptionResourceTag"
-        },
-        "description": "Tags to assign to subscription."
-      },
-      "subscribers": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:ce:AnomalySubscriptionSubscriber"
-        },
-        "description": "A list of subscriber"
-      },
-      "subscriptionName": {
-        "type": "string",
-        "description": "The name of the subscription."
-      },
-      "threshold": {
-        "type": "number",
-        "description": "The dollar value that triggers a notification if the threshold is exceeded. "
-      },
-      "thresholdExpression": {
-        "type": "string",
-        "description": "An Expression object in JSON String format used to specify the anomalies that you want to generate alerts for."
-      }
-    }
-  },
   "aws-native:certificatemanager:Account": {
     "cfTypeName": "AWS::CertificateManager::Account",
     "properties": {
       "expiryEventsConfiguration": {
         "$ref": "#/types/aws-native:certificatemanager:AccountExpiryEventsConfiguration"
-      }
-    }
-  },
-  "aws-native:chatbot:MicrosoftTeamsChannelConfiguration": {
-    "cfTypeName": "AWS::Chatbot::MicrosoftTeamsChannelConfiguration",
-    "properties": {
-      "configurationName": {
-        "type": "string",
-        "description": "The name of the configuration"
-      },
-      "guardrailPolicies": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set."
-      },
-      "iamRoleArn": {
-        "type": "string",
-        "description": "The ARN of the IAM role that defines the permissions for AWS Chatbot"
-      },
-      "loggingLevel": {
-        "type": "string",
-        "description": "Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs"
-      },
-      "snsTopicArns": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications."
-      },
-      "teamId": {
-        "type": "string",
-        "description": "The id of the Microsoft Teams team"
-      },
-      "teamsChannelId": {
-        "type": "string",
-        "description": "The id of the Microsoft Teams channel"
-      },
-      "teamsTenantId": {
-        "type": "string",
-        "description": "The id of the Microsoft Teams tenant"
-      },
-      "userRoleRequired": {
-        "type": "boolean",
-        "description": "Enables use of a user role requirement in your chat configuration"
-      }
-    }
-  },
-  "aws-native:chatbot:SlackChannelConfiguration": {
-    "cfTypeName": "AWS::Chatbot::SlackChannelConfiguration",
-    "properties": {
-      "configurationName": {
-        "type": "string",
-        "description": "The name of the configuration"
-      },
-      "guardrailPolicies": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set."
-      },
-      "iamRoleArn": {
-        "type": "string",
-        "description": "The ARN of the IAM role that defines the permissions for AWS Chatbot"
-      },
-      "loggingLevel": {
-        "type": "string",
-        "description": "Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs"
-      },
-      "slackChannelId": {
-        "type": "string",
-        "description": "The id of the Slack channel"
-      },
-      "slackWorkspaceId": {
-        "type": "string",
-        "description": "The id of the Slack workspace"
-      },
-      "snsTopicArns": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications."
-      },
-      "userRoleRequired": {
-        "type": "boolean",
-        "description": "Enables use of a user role requirement in your chat configuration"
       }
     }
   },
@@ -1710,60 +1494,6 @@
       }
     }
   },
-  "aws-native:cloudwatch:CompositeAlarm": {
-    "cfTypeName": "AWS::CloudWatch::CompositeAlarm",
-    "properties": {
-      "actionsEnabled": {
-        "type": "boolean",
-        "description": "Indicates whether actions should be executed during any changes to the alarm state. The default is TRUE."
-      },
-      "actionsSuppressor": {
-        "type": "string",
-        "description": "Actions will be suppressed if the suppressor alarm is in the ALARM state. ActionsSuppressor can be an AlarmName or an Amazon Resource Name (ARN) from an existing alarm. "
-      },
-      "actionsSuppressorExtensionPeriod": {
-        "type": "integer",
-        "description": "Actions will be suppressed if WaitPeriod is active. The length of time that actions are suppressed is in seconds."
-      },
-      "actionsSuppressorWaitPeriod": {
-        "type": "integer",
-        "description": "Actions will be suppressed if ExtensionPeriod is active. The length of time that actions are suppressed is in seconds."
-      },
-      "alarmActions": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The list of actions to execute when this alarm transitions into an ALARM state from any other state. Specify each action as an Amazon Resource Name (ARN)."
-      },
-      "alarmDescription": {
-        "type": "string",
-        "description": "The description of the alarm"
-      },
-      "alarmName": {
-        "type": "string",
-        "description": "The name of the Composite Alarm"
-      },
-      "alarmRule": {
-        "type": "string",
-        "description": "Expression which aggregates the state of other Alarms (Metric or Composite Alarms)"
-      },
-      "insufficientDataActions": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The actions to execute when this alarm transitions to the INSUFFICIENT_DATA state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
-      },
-      "okActions": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The actions to execute when this alarm transitions to the OK state from any other state. Each action is specified as an Amazon Resource Name (ARN)."
-      }
-    }
-  },
   "aws-native:codepipeline:CustomActionType": {
     "cfTypeName": "AWS::CodePipeline::CustomActionType",
     "properties": {
@@ -1916,101 +1646,6 @@
       }
     }
   },
-  "aws-native:cognito:UserPoolClient": {
-    "cfTypeName": "AWS::Cognito::UserPoolClient",
-    "properties": {
-      "accessTokenValidity": {
-        "type": "integer"
-      },
-      "allowedOAuthFlows": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "allowedOAuthFlowsUserPoolClient": {
-        "type": "boolean"
-      },
-      "allowedOAuthScopes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "analyticsConfiguration": {
-        "$ref": "#/types/aws-native:cognito:UserPoolClientAnalyticsConfiguration"
-      },
-      "authSessionValidity": {
-        "type": "integer"
-      },
-      "callbackUrls": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "clientName": {
-        "type": "string"
-      },
-      "defaultRedirectUri": {
-        "type": "string"
-      },
-      "enablePropagateAdditionalUserContextData": {
-        "type": "boolean"
-      },
-      "enableTokenRevocation": {
-        "type": "boolean"
-      },
-      "explicitAuthFlows": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "generateSecret": {
-        "type": "boolean"
-      },
-      "idTokenValidity": {
-        "type": "integer"
-      },
-      "logoutUrls": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "preventUserExistenceErrors": {
-        "type": "string"
-      },
-      "readAttributes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "refreshTokenValidity": {
-        "type": "integer"
-      },
-      "supportedIdentityProviders": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "tokenValidityUnits": {
-        "$ref": "#/types/aws-native:cognito:UserPoolClientTokenValidityUnits"
-      },
-      "userPoolId": {
-        "type": "string"
-      },
-      "writeAttributes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      }
-    }
-  },
   "aws-native:cognito:UserPoolDomain": {
     "cfTypeName": "AWS::Cognito::UserPoolDomain",
     "properties": {
@@ -2018,54 +1653,6 @@
         "$ref": "#/types/aws-native:cognito:UserPoolDomainCustomDomainConfigType"
       },
       "domain": {
-        "type": "string"
-      },
-      "userPoolId": {
-        "type": "string"
-      }
-    }
-  },
-  "aws-native:cognito:UserPoolGroup": {
-    "cfTypeName": "AWS::Cognito::UserPoolGroup",
-    "properties": {
-      "description": {
-        "type": "string"
-      },
-      "groupName": {
-        "type": "string"
-      },
-      "precedence": {
-        "type": "integer"
-      },
-      "roleArn": {
-        "type": "string"
-      },
-      "userPoolId": {
-        "type": "string"
-      }
-    }
-  },
-  "aws-native:cognito:UserPoolIdentityProvider": {
-    "cfTypeName": "AWS::Cognito::UserPoolIdentityProvider",
-    "properties": {
-      "attributeMapping": {
-        "$ref": "pulumi.json#/Any",
-        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property."
-      },
-      "idpIdentifiers": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "providerDetails": {
-        "$ref": "pulumi.json#/Any",
-        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property."
-      },
-      "providerName": {
-        "type": "string"
-      },
-      "providerType": {
         "type": "string"
       },
       "userPoolId": {
@@ -2179,27 +1766,6 @@
           "$ref": "#/types/aws-native:index:Tag"
         },
         "description": "The tags for the AggregationAuthorization."
-      }
-    }
-  },
-  "aws-native:configuration:StoredQuery": {
-    "cfTypeName": "AWS::Config::StoredQuery",
-    "properties": {
-      "queryDescription": {
-        "type": "string"
-      },
-      "queryExpression": {
-        "type": "string"
-      },
-      "queryName": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "The tags for the stored query."
       }
     }
   },
@@ -3141,59 +2707,6 @@
       "targetEndpointArn": {
         "type": "string",
         "description": "The Amazon Resource Name (ARN) of the target endpoint for this AWS DMS Serverless replication configuration"
-      }
-    }
-  },
-  "aws-native:dynamodb:GlobalTable": {
-    "cfTypeName": "AWS::DynamoDB::GlobalTable",
-    "properties": {
-      "attributeDefinitions": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:dynamodb:GlobalTableAttributeDefinition"
-        }
-      },
-      "billingMode": {
-        "type": "string"
-      },
-      "globalSecondaryIndexes": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:dynamodb:GlobalTableGlobalSecondaryIndex"
-        }
-      },
-      "keySchema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:dynamodb:GlobalTableKeySchema"
-        }
-      },
-      "localSecondaryIndexes": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:dynamodb:GlobalTableLocalSecondaryIndex"
-        }
-      },
-      "replicas": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:dynamodb:GlobalTableReplicaSpecification"
-        }
-      },
-      "sseSpecification": {
-        "$ref": "#/types/aws-native:dynamodb:GlobalTableSseSpecification"
-      },
-      "streamSpecification": {
-        "$ref": "#/types/aws-native:dynamodb:GlobalTableStreamSpecification"
-      },
-      "tableName": {
-        "type": "string"
-      },
-      "timeToLiveSpecification": {
-        "$ref": "#/types/aws-native:dynamodb:GlobalTableTimeToLiveSpecification"
-      },
-      "writeProvisionedThroughputSettings": {
-        "$ref": "#/types/aws-native:dynamodb:GlobalTableWriteProvisionedThroughputSettings"
       }
     }
   },
@@ -4552,44 +4065,6 @@
       "vpcId": {
         "type": "string",
         "description": "The ID of the VPC."
-      }
-    }
-  },
-  "aws-native:ec2:SecurityGroup": {
-    "cfTypeName": "AWS::EC2::SecurityGroup",
-    "properties": {
-      "groupDescription": {
-        "type": "string",
-        "description": "A description for the security group."
-      },
-      "groupName": {
-        "type": "string",
-        "description": "The name of the security group."
-      },
-      "securityGroupEgress": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:ec2:SecurityGroupEgress"
-        },
-        "description": "[VPC only] The outbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group."
-      },
-      "securityGroupIngress": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:ec2:SecurityGroupIngress"
-        },
-        "description": "The inbound rules associated with the security group. There is a short interruption during which you cannot connect to the security group."
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "Any tags assigned to the security group."
-      },
-      "vpcId": {
-        "type": "string",
-        "description": "The ID of the VPC for the security group."
       }
     }
   },
@@ -6338,80 +5813,6 @@
       }
     }
   },
-  "aws-native:entityresolution:IdMappingWorkflow": {
-    "cfTypeName": "AWS::EntityResolution::IdMappingWorkflow",
-    "properties": {
-      "description": {
-        "type": "string",
-        "description": "The description of the IdMappingWorkflow"
-      },
-      "idMappingTechniques": {
-        "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowIdMappingTechniques"
-      },
-      "inputSourceConfig": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowInputSource"
-        }
-      },
-      "outputSourceConfig": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:entityresolution:IdMappingWorkflowOutputSource"
-        }
-      },
-      "roleArn": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
-      },
-      "workflowName": {
-        "type": "string",
-        "description": "The name of the IdMappingWorkflow"
-      }
-    }
-  },
-  "aws-native:entityresolution:MatchingWorkflow": {
-    "cfTypeName": "AWS::EntityResolution::MatchingWorkflow",
-    "properties": {
-      "description": {
-        "type": "string",
-        "description": "The description of the MatchingWorkflow"
-      },
-      "inputSourceConfig": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowInputSource"
-        }
-      },
-      "outputSourceConfig": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowOutputSource"
-        }
-      },
-      "resolutionTechniques": {
-        "$ref": "#/types/aws-native:entityresolution:MatchingWorkflowResolutionTechniques"
-      },
-      "roleArn": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
-      },
-      "workflowName": {
-        "type": "string",
-        "description": "The name of the MatchingWorkflow"
-      }
-    }
-  },
   "aws-native:entityresolution:SchemaMapping": {
     "cfTypeName": "AWS::EntityResolution::SchemaMapping",
     "properties": {
@@ -6835,49 +6236,6 @@
       }
     }
   },
-  "aws-native:healthlake:FhirDatastore": {
-    "cfTypeName": "AWS::HealthLake::FHIRDatastore",
-    "properties": {
-      "datastoreName": {
-        "type": "string"
-      },
-      "datastoreTypeVersion": {
-        "$ref": "#/types/aws-native:healthlake:FhirDatastoreDatastoreTypeVersion"
-      },
-      "identityProviderConfiguration": {
-        "$ref": "#/types/aws-native:healthlake:FhirDatastoreIdentityProviderConfiguration"
-      },
-      "preloadDataConfig": {
-        "$ref": "#/types/aws-native:healthlake:FhirDatastorePreloadDataConfig"
-      },
-      "sseConfiguration": {
-        "$ref": "#/types/aws-native:healthlake:FhirDatastoreSseConfiguration"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
-      }
-    }
-  },
-  "aws-native:iam:GroupPolicy": {
-    "cfTypeName": "AWS::IAM::GroupPolicy",
-    "properties": {
-      "groupName": {
-        "type": "string",
-        "description": "The name of the group to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-."
-      },
-      "policyDocument": {
-        "$ref": "pulumi.json#/Any",
-        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::GroupPolicy` for more information about the expected schema for this property."
-      },
-      "policyName": {
-        "type": "string",
-        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
-      }
-    }
-  },
   "aws-native:iam:OidcProvider": {
     "cfTypeName": "AWS::IAM::OIDCProvider",
     "properties": {
@@ -6904,23 +6262,6 @@
       }
     }
   },
-  "aws-native:iam:RolePolicy": {
-    "cfTypeName": "AWS::IAM::RolePolicy",
-    "properties": {
-      "policyDocument": {
-        "$ref": "pulumi.json#/Any",
-        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::RolePolicy` for more information about the expected schema for this property."
-      },
-      "policyName": {
-        "type": "string",
-        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
-      },
-      "roleName": {
-        "type": "string",
-        "description": "The name of the role to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
-      }
-    }
-  },
   "aws-native:iam:ServiceLinkedRole": {
     "cfTypeName": "AWS::IAM::ServiceLinkedRole",
     "properties": {
@@ -6935,23 +6276,6 @@
       "description": {
         "type": "string",
         "description": "The description of the role."
-      }
-    }
-  },
-  "aws-native:iam:UserPolicy": {
-    "cfTypeName": "AWS::IAM::UserPolicy",
-    "properties": {
-      "policyDocument": {
-        "$ref": "pulumi.json#/Any",
-        "description": "The policy document.\n You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.\n The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:\n  +  Any printable ASCII character ranging from the space character (``\\u0020``) through the end of the ASCII character range\n  +  The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\\u00FF``)\n  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::UserPolicy` for more information about the expected schema for this property."
-      },
-      "policyName": {
-        "type": "string",
-        "description": "The name of the policy document.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
-      },
-      "userName": {
-        "type": "string",
-        "description": "The name of the user to associate the policy with.\n This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-"
       }
     }
   },
@@ -7148,77 +6472,6 @@
       }
     }
   },
-  "aws-native:iot:CustomMetric": {
-    "cfTypeName": "AWS::IoT::CustomMetric",
-    "properties": {
-      "displayName": {
-        "type": "string",
-        "description": "Field represents a friendly name in the console for the custom metric; it doesn't have to be unique. Don't use this name as the metric identifier in the device metric report. Can be updated once defined."
-      },
-      "metricName": {
-        "type": "string",
-        "description": "The name of the custom metric. This will be used in the metric report submitted from the device/thing. Shouldn't begin with aws: . Cannot be updated once defined."
-      },
-      "metricType": {
-        "$ref": "#/types/aws-native:iot:CustomMetricMetricType",
-        "description": "The type of the custom metric. Types include string-list, ip-address-list, number-list, and number."
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:iot:FleetMetric": {
-    "cfTypeName": "AWS::IoT::FleetMetric",
-    "properties": {
-      "aggregationField": {
-        "type": "string",
-        "description": "The aggregation field to perform aggregation and metric emission"
-      },
-      "aggregationType": {
-        "$ref": "#/types/aws-native:iot:FleetMetricAggregationType"
-      },
-      "description": {
-        "type": "string",
-        "description": "The description of a fleet metric"
-      },
-      "indexName": {
-        "type": "string",
-        "description": "The index name of a fleet metric"
-      },
-      "metricName": {
-        "type": "string",
-        "description": "The name of the fleet metric"
-      },
-      "period": {
-        "type": "integer",
-        "description": "The period of metric emission in seconds"
-      },
-      "queryString": {
-        "type": "string",
-        "description": "The Fleet Indexing query used by a fleet metric"
-      },
-      "queryVersion": {
-        "type": "string",
-        "description": "The version of a Fleet Indexing query used by a fleet metric"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource"
-      },
-      "unit": {
-        "type": "string",
-        "description": "The unit of data points emitted by a fleet metric"
-      }
-    }
-  },
   "aws-native:iot:JobTemplate": {
     "cfTypeName": "AWS::IoT::JobTemplate",
     "properties": {
@@ -7298,60 +6551,6 @@
       }
     }
   },
-  "aws-native:iot:MitigationAction": {
-    "cfTypeName": "AWS::IoT::MitigationAction",
-    "properties": {
-      "actionName": {
-        "type": "string",
-        "description": "A unique identifier for the mitigation action."
-      },
-      "actionParams": {
-        "$ref": "#/types/aws-native:iot:MitigationActionActionParams"
-      },
-      "roleArn": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:iot:ProvisioningTemplate": {
-    "cfTypeName": "AWS::IoT::ProvisioningTemplate",
-    "properties": {
-      "description": {
-        "type": "string"
-      },
-      "enabled": {
-        "type": "boolean"
-      },
-      "preProvisioningHook": {
-        "$ref": "#/types/aws-native:iot:ProvisioningTemplateProvisioningHook"
-      },
-      "provisioningRoleArn": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
-      },
-      "templateBody": {
-        "type": "string"
-      },
-      "templateName": {
-        "type": "string"
-      },
-      "templateType": {
-        "$ref": "#/types/aws-native:iot:ProvisioningTemplateTemplateType"
-      }
-    }
-  },
   "aws-native:iot:ResourceSpecificLogging": {
     "cfTypeName": "AWS::IoT::ResourceSpecificLogging",
     "properties": {
@@ -7391,68 +6590,6 @@
         "items": {
           "$ref": "#/types/aws-native:index:Tag"
         }
-      }
-    }
-  },
-  "aws-native:iot:SoftwarePackage": {
-    "cfTypeName": "AWS::IoT::SoftwarePackage",
-    "properties": {
-      "description": {
-        "type": "string"
-      },
-      "packageName": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:iot:SoftwarePackageVersion": {
-    "cfTypeName": "AWS::IoT::SoftwarePackageVersion",
-    "properties": {
-      "attributes": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "description": {
-        "type": "string"
-      },
-      "packageName": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      },
-      "versionName": {
-        "type": "string"
-      }
-    }
-  },
-  "aws-native:iot:TopicRule": {
-    "cfTypeName": "AWS::IoT::TopicRule",
-    "properties": {
-      "ruleName": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
-      },
-      "topicRulePayload": {
-        "$ref": "#/types/aws-native:iot:TopicRulePayload"
       }
     }
   },
@@ -8263,149 +7400,6 @@
       }
     }
   },
-  "aws-native:lightsail:LoadBalancerTlsCertificate": {
-    "cfTypeName": "AWS::Lightsail::LoadBalancerTlsCertificate",
-    "properties": {
-      "certificateAlternativeNames": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "An array of strings listing alternative domains and subdomains for your SSL/TLS certificate."
-      },
-      "certificateDomainName": {
-        "type": "string",
-        "description": "The domain name (e.g., example.com ) for your SSL/TLS certificate."
-      },
-      "certificateName": {
-        "type": "string",
-        "description": "The SSL/TLS certificate name."
-      },
-      "httpsRedirectionEnabled": {
-        "type": "boolean",
-        "description": "A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer."
-      },
-      "isAttached": {
-        "type": "boolean",
-        "description": "When true, the SSL/TLS certificate is attached to the Lightsail load balancer."
-      },
-      "loadBalancerName": {
-        "type": "string",
-        "description": "The name of your load balancer."
-      }
-    }
-  },
-  "aws-native:location:ApiKey": {
-    "cfTypeName": "AWS::Location::APIKey",
-    "properties": {
-      "description": {
-        "type": "string"
-      },
-      "expireTime": {
-        "type": "string"
-      },
-      "forceDelete": {
-        "type": "boolean"
-      },
-      "forceUpdate": {
-        "type": "boolean"
-      },
-      "keyName": {
-        "type": "string"
-      },
-      "noExpiry": {
-        "type": "boolean"
-      },
-      "restrictions": {
-        "$ref": "#/types/aws-native:location:ApiKeyRestrictions"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:location:GeofenceCollection": {
-    "cfTypeName": "AWS::Location::GeofenceCollection",
-    "properties": {
-      "collectionName": {
-        "type": "string"
-      },
-      "description": {
-        "type": "string"
-      },
-      "kmsKeyId": {
-        "type": "string"
-      },
-      "pricingPlan": {
-        "$ref": "#/types/aws-native:location:GeofenceCollectionPricingPlan"
-      },
-      "pricingPlanDataSource": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:location:PlaceIndex": {
-    "cfTypeName": "AWS::Location::PlaceIndex",
-    "properties": {
-      "dataSource": {
-        "type": "string"
-      },
-      "dataSourceConfiguration": {
-        "$ref": "#/types/aws-native:location:PlaceIndexDataSourceConfiguration"
-      },
-      "description": {
-        "type": "string"
-      },
-      "indexName": {
-        "type": "string"
-      },
-      "pricingPlan": {
-        "$ref": "#/types/aws-native:location:PlaceIndexPricingPlan"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:location:RouteCalculator": {
-    "cfTypeName": "AWS::Location::RouteCalculator",
-    "properties": {
-      "calculatorName": {
-        "type": "string"
-      },
-      "dataSource": {
-        "type": "string"
-      },
-      "description": {
-        "type": "string"
-      },
-      "pricingPlan": {
-        "$ref": "#/types/aws-native:location:RouteCalculatorPricingPlan"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
   "aws-native:location:TrackerConsumer": {
     "cfTypeName": "AWS::Location::TrackerConsumer",
     "properties": {
@@ -8414,31 +7408,6 @@
       },
       "trackerName": {
         "type": "string"
-      }
-    }
-  },
-  "aws-native:logs:AccountPolicy": {
-    "cfTypeName": "AWS::Logs::AccountPolicy",
-    "properties": {
-      "policyDocument": {
-        "type": "string",
-        "description": "The body of the policy document you want to use for this topic.\n\nYou can only add one policy per PolicyType.\n\nThe policy must be in JSON string format.\n\nLength Constraints: Maximum length of 30720"
-      },
-      "policyName": {
-        "type": "string",
-        "description": "The name of the account policy"
-      },
-      "policyType": {
-        "$ref": "#/types/aws-native:logs:AccountPolicyPolicyType",
-        "description": "Type of the policy."
-      },
-      "scope": {
-        "$ref": "#/types/aws-native:logs:AccountPolicyScope",
-        "description": "Scope for policy application"
-      },
-      "selectionCriteria": {
-        "type": "string",
-        "description": "Log group  selection criteria to apply policy only to a subset of log groups. SelectionCriteria string can be up to 25KB and cloudwatchlogs determines the length of selectionCriteria by using its UTF-8 bytes"
       }
     }
   },
@@ -8459,106 +7428,6 @@
           "$ref": "#/types/aws-native:index:Tag"
         },
         "description": "The tags that have been assigned to this delivery."
-      }
-    }
-  },
-  "aws-native:logs:LogAnomalyDetector": {
-    "cfTypeName": "AWS::Logs::LogAnomalyDetector",
-    "properties": {
-      "accountId": {
-        "type": "string",
-        "description": "Account ID for owner of detector"
-      },
-      "anomalyVisibilityTime": {
-        "type": "number"
-      },
-      "detectorName": {
-        "type": "string",
-        "description": "Name of detector"
-      },
-      "evaluationFrequency": {
-        "$ref": "#/types/aws-native:logs:LogAnomalyDetectorEvaluationFrequency",
-        "description": "How often log group is evaluated"
-      },
-      "filterPattern": {
-        "type": "string"
-      },
-      "kmsKeyId": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data."
-      },
-      "logGroupArnList": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "List of Arns for the given log group"
-      }
-    }
-  },
-  "aws-native:logs:MetricFilter": {
-    "cfTypeName": "AWS::Logs::MetricFilter",
-    "properties": {
-      "filterName": {
-        "type": "string",
-        "description": "A name for the metric filter."
-      },
-      "filterPattern": {
-        "type": "string",
-        "description": "Pattern that Logs follows to interpret each entry in a log."
-      },
-      "logGroupName": {
-        "type": "string",
-        "description": "Existing log group that you want to associate with this filter."
-      },
-      "metricTransformations": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:logs:MetricFilterMetricTransformation"
-        },
-        "description": "A collection of information that defines how metric data gets emitted."
-      }
-    }
-  },
-  "aws-native:logs:ResourcePolicy": {
-    "cfTypeName": "AWS::Logs::ResourcePolicy",
-    "properties": {
-      "policyDocument": {
-        "type": "string",
-        "description": "The policy document"
-      },
-      "policyName": {
-        "type": "string",
-        "description": "A name for resource policy"
-      }
-    }
-  },
-  "aws-native:logs:SubscriptionFilter": {
-    "cfTypeName": "AWS::Logs::SubscriptionFilter",
-    "properties": {
-      "destinationArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of the destination."
-      },
-      "distribution": {
-        "$ref": "#/types/aws-native:logs:SubscriptionFilterDistribution",
-        "description": "The method used to distribute log data to the destination. By default, log data is grouped by log stream, but the grouping can be set to random for a more even distribution. This property is only applicable when the destination is an Amazon Kinesis stream."
-      },
-      "filterName": {
-        "type": "string",
-        "description": "The name of the filter generated by resource."
-      },
-      "filterPattern": {
-        "type": "string",
-        "description": "The filtering expressions that restrict what gets delivered to the destination AWS resource."
-      },
-      "logGroupName": {
-        "type": "string",
-        "description": "Existing log group that you want to associate with this filter."
-      },
-      "roleArn": {
-        "type": "string",
-        "description": "The ARN of an IAM role that grants CloudWatch Logs permissions to deliver ingested log events to the destination stream. You don't need to provide the ARN when you are working with a logical destination for cross-account delivery."
       }
     }
   },
@@ -8873,30 +7742,6 @@
       "policy": {
         "$ref": "pulumi.json#/Any",
         "description": "A policy document containing permissions to add to the specified cluster.\n\nSearch the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::MSK::ClusterPolicy` for more information about the expected schema for this property."
-      }
-    }
-  },
-  "aws-native:msk:ServerlessCluster": {
-    "cfTypeName": "AWS::MSK::ServerlessCluster",
-    "properties": {
-      "clientAuthentication": {
-        "$ref": "#/types/aws-native:msk:ServerlessClusterClientAuthentication"
-      },
-      "clusterName": {
-        "type": "string"
-      },
-      "tags": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        },
-        "description": "A key-value pair to associate with a resource."
-      },
-      "vpcConfigs": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:msk:ServerlessClusterVpcConfig"
-        }
       }
     }
   },
@@ -9619,34 +8464,6 @@
       }
     }
   },
-  "aws-native:pinpoint:InAppTemplate": {
-    "cfTypeName": "AWS::Pinpoint::InAppTemplate",
-    "properties": {
-      "content": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:pinpoint:InAppTemplateInAppMessageContent"
-        }
-      },
-      "customConfig": {
-        "$ref": "pulumi.json#/Any",
-        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property."
-      },
-      "layout": {
-        "$ref": "#/types/aws-native:pinpoint:InAppTemplateLayout"
-      },
-      "tags": {
-        "$ref": "pulumi.json#/Any",
-        "description": "Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property."
-      },
-      "templateDescription": {
-        "type": "string"
-      },
-      "templateName": {
-        "type": "string"
-      }
-    }
-  },
   "aws-native:proton:EnvironmentAccountConnection": {
     "cfTypeName": "AWS::Proton::EnvironmentAccountConnection",
     "properties": {
@@ -10336,48 +9153,6 @@
       }
     }
   },
-  "aws-native:rds:EventSubscription": {
-    "cfTypeName": "AWS::RDS::EventSubscription",
-    "properties": {
-      "enabled": {
-        "type": "boolean",
-        "description": "A Boolean value; set to true to activate the subscription, set to false to create the subscription but not active it."
-      },
-      "eventCategories": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "A list of event categories for a SourceType that you want to subscribe to. You can see a list of the categories for a given SourceType in the Events topic in the Amazon RDS User Guide or by using the DescribeEventCategories action."
-      },
-      "snsTopicArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of the SNS topic created for event notification. The ARN is created by Amazon SNS when you create a topic and subscribe to it."
-      },
-      "sourceIds": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "The list of identifiers of the event sources for which events will be returned. If not specified, then all sources are included in the response. An identifier must begin with a letter and must contain only ASCII letters, digits, and hyphens; it cannot end with a hyphen or contain two consecutive hyphens."
-      },
-      "sourceType": {
-        "type": "string",
-        "description": "The type of source that will be generating the events. For example, if you want to be notified of events generated by a DB instance, you would set this parameter to db-instance. if this value is not specified, all events are returned."
-      },
-      "subscriptionName": {
-        "type": "string",
-        "description": "The name of the subscription."
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
   "aws-native:rds:GlobalCluster": {
     "cfTypeName": "AWS::RDS::GlobalCluster",
     "properties": {
@@ -10629,37 +9404,6 @@
       }
     }
   },
-  "aws-native:redshift:ClusterParameterGroup": {
-    "cfTypeName": "AWS::Redshift::ClusterParameterGroup",
-    "properties": {
-      "description": {
-        "type": "string",
-        "description": "A description of the parameter group."
-      },
-      "parameterGroupFamily": {
-        "type": "string",
-        "description": "The Amazon Redshift engine version to which the cluster parameter group applies. The cluster engine version determines the set of parameters."
-      },
-      "parameterGroupName": {
-        "type": "string",
-        "description": "The name of the cluster parameter group."
-      },
-      "parameters": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:redshift:ClusterParameterGroupParameter"
-        },
-        "description": "An array of parameters to be modified. A maximum of 20 parameters can be modified in a single request."
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
   "aws-native:redshift:ClusterSubnetGroup": {
     "cfTypeName": "AWS::Redshift::ClusterSubnetGroup",
     "properties": {
@@ -10735,52 +9479,6 @@
       }
     }
   },
-  "aws-native:redshift:EventSubscription": {
-    "cfTypeName": "AWS::Redshift::EventSubscription",
-    "properties": {
-      "enabled": {
-        "type": "boolean",
-        "description": "A boolean value; set to true to activate the subscription, and set to false to create the subscription but not activate it."
-      },
-      "eventCategories": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:redshift:EventSubscriptionEventCategoriesItem"
-        },
-        "description": "Specifies the Amazon Redshift event categories to be published by the event notification subscription."
-      },
-      "severity": {
-        "$ref": "#/types/aws-native:redshift:EventSubscriptionSeverity",
-        "description": "Specifies the Amazon Redshift event severity to be published by the event notification subscription."
-      },
-      "snsTopicArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications."
-      },
-      "sourceIds": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "A list of one or more identifiers of Amazon Redshift source objects."
-      },
-      "sourceType": {
-        "$ref": "#/types/aws-native:redshift:EventSubscriptionSourceType",
-        "description": "The type of source that will be generating the events."
-      },
-      "subscriptionName": {
-        "type": "string",
-        "description": "The name of the Amazon Redshift event notification subscription"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
   "aws-native:refactorspaces:Route": {
     "cfTypeName": "AWS::RefactorSpaces::Route",
     "properties": {
@@ -10823,39 +9521,6 @@
           "$ref": "#/types/aws-native:index:Tag"
         },
         "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:resiliencehub:ResiliencyPolicy": {
-    "cfTypeName": "AWS::ResilienceHub::ResiliencyPolicy",
-    "properties": {
-      "dataLocationConstraint": {
-        "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyDataLocationConstraint",
-        "description": "Data Location Constraint of the Policy."
-      },
-      "policy": {
-        "type": "object",
-        "additionalProperties": {
-          "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyFailurePolicy"
-        }
-      },
-      "policyDescription": {
-        "type": "string",
-        "description": "Description of Resiliency Policy."
-      },
-      "policyName": {
-        "type": "string",
-        "description": "Name of Resiliency Policy."
-      },
-      "tags": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "tier": {
-        "$ref": "#/types/aws-native:resiliencehub:ResiliencyPolicyTier",
-        "description": "Resiliency Policy Tier."
       }
     }
   },
@@ -11088,23 +9753,6 @@
       }
     }
   },
-  "aws-native:s3express:DirectoryBucket": {
-    "cfTypeName": "AWS::S3Express::DirectoryBucket",
-    "properties": {
-      "bucketName": {
-        "type": "string",
-        "description": "Specifies a name for the bucket. The bucket name must contain only lowercase letters, numbers, and hyphens (-). A directory bucket name must be unique in the chosen Availability Zone. The bucket name must also follow the format 'bucket_base_name--az_id--x-s3' (for example, 'DOC-EXAMPLE-BUCKET--usw2-az1--x-s3'). If you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the bucket name."
-      },
-      "dataRedundancy": {
-        "$ref": "#/types/aws-native:s3express:DirectoryBucketDataRedundancy",
-        "description": "Specifies the number of Availability Zone that's used for redundancy for the bucket."
-      },
-      "locationName": {
-        "type": "string",
-        "description": "Specifies the AZ ID of the Availability Zone where the directory bucket will be created. An example AZ ID value is 'use1-az5'."
-      }
-    }
-  },
   "aws-native:s3objectlambda:AccessPointPolicy": {
     "cfTypeName": "AWS::S3ObjectLambda::AccessPointPolicy",
     "properties": {
@@ -11157,49 +9805,6 @@
       "subnetId": {
         "type": "string",
         "description": "The ID of the subnet in the selected VPC. The subnet must belong to the Outpost."
-      }
-    }
-  },
-  "aws-native:sagemaker:DataQualityJobDefinition": {
-    "cfTypeName": "AWS::SageMaker::DataQualityJobDefinition",
-    "properties": {
-      "dataQualityAppSpecification": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityAppSpecification"
-      },
-      "dataQualityBaselineConfig": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityBaselineConfig"
-      },
-      "dataQualityJobInput": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionDataQualityJobInput"
-      },
-      "dataQualityJobOutputConfig": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionMonitoringOutputConfig"
-      },
-      "endpointName": {
-        "type": "string"
-      },
-      "jobDefinitionName": {
-        "type": "string"
-      },
-      "jobResources": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionMonitoringResources"
-      },
-      "networkConfig": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionNetworkConfig"
-      },
-      "roleArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
-      },
-      "stoppingCondition": {
-        "$ref": "#/types/aws-native:sagemaker:DataQualityJobDefinitionStoppingCondition"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:CreateOnlyTag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
       }
     }
   },
@@ -11269,172 +9874,6 @@
       }
     }
   },
-  "aws-native:sagemaker:ModelBiasJobDefinition": {
-    "cfTypeName": "AWS::SageMaker::ModelBiasJobDefinition",
-    "properties": {
-      "endpointName": {
-        "type": "string"
-      },
-      "jobDefinitionName": {
-        "type": "string"
-      },
-      "jobResources": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionMonitoringResources"
-      },
-      "modelBiasAppSpecification": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasAppSpecification"
-      },
-      "modelBiasBaselineConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasBaselineConfig"
-      },
-      "modelBiasJobInput": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionModelBiasJobInput"
-      },
-      "modelBiasJobOutputConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionMonitoringOutputConfig"
-      },
-      "networkConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionNetworkConfig"
-      },
-      "roleArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
-      },
-      "stoppingCondition": {
-        "$ref": "#/types/aws-native:sagemaker:ModelBiasJobDefinitionStoppingCondition"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:CreateOnlyTag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:sagemaker:ModelExplainabilityJobDefinition": {
-    "cfTypeName": "AWS::SageMaker::ModelExplainabilityJobDefinition",
-    "properties": {
-      "endpointName": {
-        "type": "string"
-      },
-      "jobDefinitionName": {
-        "type": "string"
-      },
-      "jobResources": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionMonitoringResources"
-      },
-      "modelExplainabilityAppSpecification": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityAppSpecification"
-      },
-      "modelExplainabilityBaselineConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityBaselineConfig"
-      },
-      "modelExplainabilityJobInput": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionModelExplainabilityJobInput"
-      },
-      "modelExplainabilityJobOutputConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionMonitoringOutputConfig"
-      },
-      "networkConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionNetworkConfig"
-      },
-      "roleArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
-      },
-      "stoppingCondition": {
-        "$ref": "#/types/aws-native:sagemaker:ModelExplainabilityJobDefinitionStoppingCondition"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:CreateOnlyTag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:sagemaker:ModelQualityJobDefinition": {
-    "cfTypeName": "AWS::SageMaker::ModelQualityJobDefinition",
-    "properties": {
-      "endpointName": {
-        "type": "string"
-      },
-      "jobDefinitionName": {
-        "type": "string"
-      },
-      "jobResources": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionMonitoringResources"
-      },
-      "modelQualityAppSpecification": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityAppSpecification"
-      },
-      "modelQualityBaselineConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityBaselineConfig"
-      },
-      "modelQualityJobInput": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionModelQualityJobInput"
-      },
-      "modelQualityJobOutputConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionMonitoringOutputConfig"
-      },
-      "networkConfig": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionNetworkConfig"
-      },
-      "roleArn": {
-        "type": "string",
-        "description": "The Amazon Resource Name (ARN) of an IAM role that Amazon SageMaker can assume to perform tasks on your behalf."
-      },
-      "stoppingCondition": {
-        "$ref": "#/types/aws-native:sagemaker:ModelQualityJobDefinitionStoppingCondition"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:CreateOnlyTag"
-        },
-        "description": "An array of key-value pairs to apply to this resource."
-      }
-    }
-  },
-  "aws-native:securityhub:AutomationRule": {
-    "cfTypeName": "AWS::SecurityHub::AutomationRule",
-    "properties": {
-      "actions": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:securityhub:AutomationRulesAction"
-        }
-      },
-      "criteria": {
-        "$ref": "#/types/aws-native:securityhub:AutomationRulesFindingFilters",
-        "description": "A set of [Security Finding Format (ASFF)](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format.html) finding field attributes and corresponding expected values that ASH uses to filter findings. If a rule is enabled and a finding matches the criteria specified in this parameter, ASH applies the rule action to the finding."
-      },
-      "description": {
-        "type": "string"
-      },
-      "isTerminal": {
-        "type": "boolean"
-      },
-      "ruleName": {
-        "type": "string"
-      },
-      "ruleOrder": {
-        "type": "integer"
-      },
-      "ruleStatus": {
-        "$ref": "#/types/aws-native:securityhub:AutomationRuleRuleStatus",
-        "description": "Whether the rule is active after it is created. If this parameter is equal to ``ENABLED``, ASH applies the rule to findings and finding updates after the rule is created."
-      },
-      "tags": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      }
-    }
-  },
   "aws-native:securityhub:Hub": {
     "cfTypeName": "AWS::SecurityHub::Hub",
     "properties": {
@@ -11471,56 +9910,6 @@
       "standardsArn": {
         "type": "string",
         "description": "The ARN of the standard that you want to enable. To view a list of available ASH standards and their ARNs, use the [DescribeStandards](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeStandards.html) API operation."
-      }
-    }
-  },
-  "aws-native:servicecatalog:CloudFormationProvisionedProduct": {
-    "cfTypeName": "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
-    "properties": {
-      "acceptLanguage": {
-        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductAcceptLanguage"
-      },
-      "notificationArns": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "pathId": {
-        "type": "string"
-      },
-      "pathName": {
-        "type": "string"
-      },
-      "productId": {
-        "type": "string"
-      },
-      "productName": {
-        "type": "string"
-      },
-      "provisionedProductName": {
-        "type": "string"
-      },
-      "provisioningArtifactId": {
-        "type": "string"
-      },
-      "provisioningArtifactName": {
-        "type": "string"
-      },
-      "provisioningParameters": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningParameter"
-        }
-      },
-      "provisioningPreferences": {
-        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningPreferences"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
       }
     }
   },
@@ -11578,19 +9967,6 @@
       "eventDestination": {
         "$ref": "#/types/aws-native:ses:ConfigurationSetEventDestinationEventDestination",
         "description": "The event destination object."
-      }
-    }
-  },
-  "aws-native:ses:DedicatedIpPool": {
-    "cfTypeName": "AWS::SES::DedicatedIpPool",
-    "properties": {
-      "poolName": {
-        "type": "string",
-        "description": "The name of the dedicated IP pool."
-      },
-      "scalingMode": {
-        "type": "string",
-        "description": "Specifies whether the dedicated IP pool is managed or not. The default value is STANDARD."
       }
     }
   },
@@ -11796,38 +10172,6 @@
       }
     }
   },
-  "aws-native:ssm:ResourceDataSync": {
-    "cfTypeName": "AWS::SSM::ResourceDataSync",
-    "properties": {
-      "bucketName": {
-        "type": "string"
-      },
-      "bucketPrefix": {
-        "type": "string"
-      },
-      "bucketRegion": {
-        "type": "string"
-      },
-      "kmsKeyArn": {
-        "type": "string"
-      },
-      "s3Destination": {
-        "$ref": "#/types/aws-native:ssm:ResourceDataSyncS3Destination"
-      },
-      "syncFormat": {
-        "type": "string"
-      },
-      "syncName": {
-        "type": "string"
-      },
-      "syncSource": {
-        "$ref": "#/types/aws-native:ssm:ResourceDataSyncSyncSource"
-      },
-      "syncType": {
-        "type": "string"
-      }
-    }
-  },
   "aws-native:ssm:ResourcePolicy": {
     "cfTypeName": "AWS::SSM::ResourcePolicy",
     "properties": {
@@ -11862,31 +10206,6 @@
       "type": {
         "$ref": "#/types/aws-native:ssmcontacts:ContactType",
         "description": "Contact type, which specify type of contact. Currently supported values: \"PERSONAL\", \"SHARED\", \"OTHER\"."
-      }
-    }
-  },
-  "aws-native:ssmcontacts:ContactChannel": {
-    "cfTypeName": "AWS::SSMContacts::ContactChannel",
-    "properties": {
-      "channelAddress": {
-        "type": "string",
-        "description": "The details that SSM Incident Manager uses when trying to engage the contact channel."
-      },
-      "channelName": {
-        "type": "string",
-        "description": "The device name. String of 6 to 50 alphabetical, numeric, dash, and underscore characters."
-      },
-      "channelType": {
-        "$ref": "#/types/aws-native:ssmcontacts:ContactChannelChannelType",
-        "description": "Device type, which specify notification channel. Currently supported values: \"SMS\", \"VOICE\", \"EMAIL\", \"CHATBOT."
-      },
-      "contactId": {
-        "type": "string",
-        "description": "ARN of the contact resource"
-      },
-      "deferActivation": {
-        "type": "boolean",
-        "description": "If you want to activate the channel at a later time, you can choose to defer activation. SSM Incident Manager can't engage your contact channel until it has been activated."
       }
     }
   },
@@ -12690,51 +11009,6 @@
       },
       "uploadAllowed": {
         "$ref": "#/types/aws-native:workspacesweb:UserSettingsEnabledType"
-      }
-    }
-  },
-  "aws-native:xray:ResourcePolicy": {
-    "cfTypeName": "AWS::XRay::ResourcePolicy",
-    "properties": {
-      "bypassPolicyLockoutCheck": {
-        "type": "boolean",
-        "description": "A flag to indicate whether to bypass the resource policy lockout safety check"
-      },
-      "policyDocument": {
-        "type": "string",
-        "description": "The resource policy document, which can be up to 5kb in size."
-      },
-      "policyName": {
-        "type": "string",
-        "description": "The name of the resource policy. Must be unique within a specific AWS account."
-      }
-    }
-  },
-  "aws-native:xray:SamplingRule": {
-    "cfTypeName": "AWS::XRay::SamplingRule",
-    "properties": {
-      "ruleName": {
-        "type": "string"
-      },
-      "samplingRule": {
-        "$ref": "#/types/aws-native:xray:SamplingRule",
-        "language": {
-          "csharp": {
-            "name": "SamplingRuleValue"
-          }
-        }
-      },
-      "samplingRuleRecord": {
-        "$ref": "#/types/aws-native:xray:SamplingRuleRecord"
-      },
-      "samplingRuleUpdate": {
-        "$ref": "#/types/aws-native:xray:SamplingRuleUpdate"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        }
       }
     }
   }

--- a/reports/missedAutonaming.json
+++ b/reports/missedAutonaming.json
@@ -1694,47 +1694,6 @@
       }
     }
   },
-  "aws-native:cognito:UserPoolUser": {
-    "cfTypeName": "AWS::Cognito::UserPoolUser",
-    "properties": {
-      "clientMetadata": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "desiredDeliveryMediums": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "forceAliasCreation": {
-        "type": "boolean"
-      },
-      "messageAction": {
-        "type": "string"
-      },
-      "userAttributes": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:cognito:UserPoolUserAttributeType"
-        }
-      },
-      "userPoolId": {
-        "type": "string"
-      },
-      "username": {
-        "type": "string"
-      },
-      "validationData": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:cognito:UserPoolUserAttributeType"
-        }
-      }
-    }
-  },
   "aws-native:cognito:UserPoolUserToGroupAttachment": {
     "cfTypeName": "AWS::Cognito::UserPoolUserToGroupAttachment",
     "properties": {
@@ -1932,64 +1891,6 @@
       },
       "key": {
         "type": "string"
-      }
-    }
-  },
-  "aws-native:connect:User": {
-    "cfTypeName": "AWS::Connect::User",
-    "properties": {
-      "directoryUserId": {
-        "type": "string",
-        "description": "The identifier of the user account in the directory used for identity management."
-      },
-      "hierarchyGroupArn": {
-        "type": "string",
-        "description": "The identifier of the hierarchy group for the user."
-      },
-      "identityInfo": {
-        "$ref": "#/types/aws-native:connect:UserIdentityInfo",
-        "description": "The information about the identity of the user."
-      },
-      "instanceArn": {
-        "type": "string",
-        "description": "The identifier of the Amazon Connect instance."
-      },
-      "password": {
-        "type": "string",
-        "description": "The password for the user account. A password is required if you are using Amazon Connect for identity management. Otherwise, it is an error to include a password."
-      },
-      "phoneConfig": {
-        "$ref": "#/types/aws-native:connect:UserPhoneConfig",
-        "description": "The phone settings for the user."
-      },
-      "routingProfileArn": {
-        "type": "string",
-        "description": "The identifier of the routing profile for the user."
-      },
-      "securityProfileArns": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        },
-        "description": "One or more security profile arns for the user"
-      },
-      "tags": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:index:Tag"
-        },
-        "description": "One or more tags."
-      },
-      "userProficiencies": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:connect:UserProficiency"
-        },
-        "description": "One or more predefined attributes assigned to a user, with a level that indicates how skilled they are."
-      },
-      "username": {
-        "type": "string",
-        "description": "The user name for the account."
       }
     }
   },
@@ -7444,42 +7345,6 @@
       }
     }
   },
-  "aws-native:medialive:Multiplexprogram": {
-    "cfTypeName": "AWS::MediaLive::Multiplexprogram",
-    "properties": {
-      "channelId": {
-        "type": "string",
-        "description": "The MediaLive channel associated with the program."
-      },
-      "multiplexId": {
-        "type": "string",
-        "description": "The ID of the multiplex that the program belongs to."
-      },
-      "multiplexProgramSettings": {
-        "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramSettings",
-        "description": "The settings for this multiplex program."
-      },
-      "packetIdentifiersMap": {
-        "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramPacketIdentifiersMap",
-        "description": "The packet identifier map for this multiplex program."
-      },
-      "pipelineDetails": {
-        "type": "array",
-        "items": {
-          "$ref": "#/types/aws-native:medialive:MultiplexprogramMultiplexProgramPipelineDetail"
-        },
-        "description": "Contains information about the current sources for the specified program in the specified multiplex. Keep in mind that each multiplex pipeline connects to both pipelines in a given source channel (the channel identified by the program). But only one of those channel pipelines is ever active at one time."
-      },
-      "preferredChannelPipeline": {
-        "$ref": "#/types/aws-native:medialive:MultiplexprogramPreferredChannelPipeline",
-        "description": "The settings for this multiplex program."
-      },
-      "programName": {
-        "type": "string",
-        "description": "The name of the multiplex program."
-      }
-    }
-  },
   "aws-native:mediapackage:Asset": {
     "cfTypeName": "AWS::MediaPackage::Asset",
     "properties": {
@@ -9910,6 +9775,56 @@
       "standardsArn": {
         "type": "string",
         "description": "The ARN of the standard that you want to enable. To view a list of available ASH standards and their ARNs, use the [DescribeStandards](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_DescribeStandards.html) API operation."
+      }
+    }
+  },
+  "aws-native:servicecatalog:CloudFormationProvisionedProduct": {
+    "cfTypeName": "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
+    "properties": {
+      "acceptLanguage": {
+        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductAcceptLanguage"
+      },
+      "notificationArns": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "pathId": {
+        "type": "string"
+      },
+      "pathName": {
+        "type": "string"
+      },
+      "productId": {
+        "type": "string"
+      },
+      "productName": {
+        "type": "string"
+      },
+      "provisionedProductName": {
+        "type": "string"
+      },
+      "provisioningArtifactId": {
+        "type": "string"
+      },
+      "provisioningArtifactName": {
+        "type": "string"
+      },
+      "provisioningParameters": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningParameter"
+        }
+      },
+      "provisioningPreferences": {
+        "$ref": "#/types/aws-native:servicecatalog:CloudFormationProvisionedProductProvisioningPreferences"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "$ref": "#/types/aws-native:index:Tag"
+        }
       }
     }
   },

--- a/sdk/dotnet/ApplicationAutoScaling/ScalingPolicy.cs
+++ b/sdk/dotnet/ApplicationAutoScaling/ScalingPolicy.cs
@@ -135,8 +135,8 @@ namespace Pulumi.AwsNative.ApplicationAutoScaling
         /// 
         /// Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         /// <summary>
         /// The scaling policy type.

--- a/sdk/dotnet/Athena/PreparedStatement.cs
+++ b/sdk/dotnet/Athena/PreparedStatement.cs
@@ -104,8 +104,8 @@ namespace Pulumi.AwsNative.Athena
         /// <summary>
         /// The name of the prepared statement.
         /// </summary>
-        [Input("statementName", required: true)]
-        public Input<string> StatementName { get; set; } = null!;
+        [Input("statementName")]
+        public Input<string>? StatementName { get; set; }
 
         /// <summary>
         /// The name of the workgroup to which the prepared statement belongs.

--- a/sdk/dotnet/Ce/AnomalyMonitor.cs
+++ b/sdk/dotnet/Ce/AnomalyMonitor.cs
@@ -477,8 +477,8 @@ namespace Pulumi.AwsNative.Ce
         /// <summary>
         /// The name of the monitor.
         /// </summary>
-        [Input("monitorName", required: true)]
-        public Input<string> MonitorName { get; set; } = null!;
+        [Input("monitorName")]
+        public Input<string>? MonitorName { get; set; }
 
         [Input("monitorSpecification")]
         public Input<string>? MonitorSpecification { get; set; }

--- a/sdk/dotnet/Ce/AnomalySubscription.cs
+++ b/sdk/dotnet/Ce/AnomalySubscription.cs
@@ -336,8 +336,8 @@ namespace Pulumi.AwsNative.Ce
         /// <summary>
         /// The name of the subscription.
         /// </summary>
-        [Input("subscriptionName", required: true)]
-        public Input<string> SubscriptionName { get; set; } = null!;
+        [Input("subscriptionName")]
+        public Input<string>? SubscriptionName { get; set; }
 
         /// <summary>
         /// The dollar value that triggers a notification if the threshold is exceeded. 

--- a/sdk/dotnet/Chatbot/MicrosoftTeamsChannelConfiguration.cs
+++ b/sdk/dotnet/Chatbot/MicrosoftTeamsChannelConfiguration.cs
@@ -129,8 +129,8 @@ namespace Pulumi.AwsNative.Chatbot
         /// <summary>
         /// The name of the configuration
         /// </summary>
-        [Input("configurationName", required: true)]
-        public Input<string> ConfigurationName { get; set; } = null!;
+        [Input("configurationName")]
+        public Input<string>? ConfigurationName { get; set; }
 
         [Input("guardrailPolicies")]
         private InputList<string>? _guardrailPolicies;

--- a/sdk/dotnet/Chatbot/SlackChannelConfiguration.cs
+++ b/sdk/dotnet/Chatbot/SlackChannelConfiguration.cs
@@ -122,8 +122,8 @@ namespace Pulumi.AwsNative.Chatbot
         /// <summary>
         /// The name of the configuration
         /// </summary>
-        [Input("configurationName", required: true)]
-        public Input<string> ConfigurationName { get; set; } = null!;
+        [Input("configurationName")]
+        public Input<string>? ConfigurationName { get; set; }
 
         [Input("guardrailPolicies")]
         private InputList<string>? _guardrailPolicies;

--- a/sdk/dotnet/Cognito/UserPoolIdentityProvider.cs
+++ b/sdk/dotnet/Cognito/UserPoolIdentityProvider.cs
@@ -113,8 +113,8 @@ namespace Pulumi.AwsNative.Cognito
         [Input("providerDetails")]
         public Input<object>? ProviderDetails { get; set; }
 
-        [Input("providerName", required: true)]
-        public Input<string> ProviderName { get; set; } = null!;
+        [Input("providerName")]
+        public Input<string>? ProviderName { get; set; }
 
         [Input("providerType", required: true)]
         public Input<string> ProviderType { get; set; } = null!;

--- a/sdk/dotnet/Configuration/StoredQuery.cs
+++ b/sdk/dotnet/Configuration/StoredQuery.cs
@@ -91,8 +91,8 @@ namespace Pulumi.AwsNative.Configuration
         [Input("queryExpression", required: true)]
         public Input<string> QueryExpression { get; set; } = null!;
 
-        [Input("queryName", required: true)]
-        public Input<string> QueryName { get; set; } = null!;
+        [Input("queryName")]
+        public Input<string>? QueryName { get; set; }
 
         [Input("tags")]
         private InputList<Pulumi.AwsNative.Inputs.TagArgs>? _tags;

--- a/sdk/dotnet/Connect/User.cs
+++ b/sdk/dotnet/Connect/User.cs
@@ -213,8 +213,8 @@ namespace Pulumi.AwsNative.Connect
         /// <summary>
         /// The user name for the account.
         /// </summary>
-        [Input("username", required: true)]
-        public Input<string> Username { get; set; } = null!;
+        [Input("username")]
+        public Input<string>? Username { get; set; }
 
         public UserArgs()
         {

--- a/sdk/dotnet/EntityResolution/IdMappingWorkflow.cs
+++ b/sdk/dotnet/EntityResolution/IdMappingWorkflow.cs
@@ -139,8 +139,8 @@ namespace Pulumi.AwsNative.EntityResolution
         /// <summary>
         /// The name of the IdMappingWorkflow
         /// </summary>
-        [Input("workflowName", required: true)]
-        public Input<string> WorkflowName { get; set; } = null!;
+        [Input("workflowName")]
+        public Input<string>? WorkflowName { get; set; }
 
         public IdMappingWorkflowArgs()
         {

--- a/sdk/dotnet/EntityResolution/MatchingWorkflow.cs
+++ b/sdk/dotnet/EntityResolution/MatchingWorkflow.cs
@@ -139,8 +139,8 @@ namespace Pulumi.AwsNative.EntityResolution
         /// <summary>
         /// The name of the MatchingWorkflow
         /// </summary>
-        [Input("workflowName", required: true)]
-        public Input<string> WorkflowName { get; set; } = null!;
+        [Input("workflowName")]
+        public Input<string>? WorkflowName { get; set; }
 
         public MatchingWorkflowArgs()
         {

--- a/sdk/dotnet/Iam/GroupPolicy.cs
+++ b/sdk/dotnet/Iam/GroupPolicy.cs
@@ -118,8 +118,8 @@ namespace Pulumi.AwsNative.Iam
         /// The name of the policy document.
         ///  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         public GroupPolicyArgs()
         {

--- a/sdk/dotnet/Iam/RolePolicy.cs
+++ b/sdk/dotnet/Iam/RolePolicy.cs
@@ -112,8 +112,8 @@ namespace Pulumi.AwsNative.Iam
         /// The name of the policy document.
         ///  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         /// <summary>
         /// The name of the role to associate the policy with.

--- a/sdk/dotnet/Iam/UserPolicy.cs
+++ b/sdk/dotnet/Iam/UserPolicy.cs
@@ -111,8 +111,8 @@ namespace Pulumi.AwsNative.Iam
         /// The name of the policy document.
         ///  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         /// <summary>
         /// The name of the user to associate the policy with.

--- a/sdk/dotnet/IoT/FleetMetric.cs
+++ b/sdk/dotnet/IoT/FleetMetric.cs
@@ -104,7 +104,7 @@ namespace Pulumi.AwsNative.IoT
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public FleetMetric(string name, FleetMetricArgs args, CustomResourceOptions? options = null)
+        public FleetMetric(string name, FleetMetricArgs? args = null, CustomResourceOptions? options = null)
             : base("aws-native:iot:FleetMetric", name, args ?? new FleetMetricArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -169,8 +169,8 @@ namespace Pulumi.AwsNative.IoT
         /// <summary>
         /// The name of the fleet metric
         /// </summary>
-        [Input("metricName", required: true)]
-        public Input<string> MetricName { get; set; } = null!;
+        [Input("metricName")]
+        public Input<string>? MetricName { get; set; }
 
         /// <summary>
         /// The period of metric emission in seconds

--- a/sdk/dotnet/Lightsail/LoadBalancerTlsCertificate.cs
+++ b/sdk/dotnet/Lightsail/LoadBalancerTlsCertificate.cs
@@ -133,8 +133,8 @@ namespace Pulumi.AwsNative.Lightsail
         /// <summary>
         /// The SSL/TLS certificate name.
         /// </summary>
-        [Input("certificateName", required: true)]
-        public Input<string> CertificateName { get; set; } = null!;
+        [Input("certificateName")]
+        public Input<string>? CertificateName { get; set; }
 
         /// <summary>
         /// A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer.

--- a/sdk/dotnet/Location/ApiKey.cs
+++ b/sdk/dotnet/Location/ApiKey.cs
@@ -115,8 +115,8 @@ namespace Pulumi.AwsNative.Location
         [Input("forceUpdate")]
         public Input<bool>? ForceUpdate { get; set; }
 
-        [Input("keyName", required: true)]
-        public Input<string> KeyName { get; set; } = null!;
+        [Input("keyName")]
+        public Input<string>? KeyName { get; set; }
 
         [Input("noExpiry")]
         public Input<bool>? NoExpiry { get; set; }

--- a/sdk/dotnet/Location/GeofenceCollection.cs
+++ b/sdk/dotnet/Location/GeofenceCollection.cs
@@ -56,7 +56,7 @@ namespace Pulumi.AwsNative.Location
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public GeofenceCollection(string name, GeofenceCollectionArgs args, CustomResourceOptions? options = null)
+        public GeofenceCollection(string name, GeofenceCollectionArgs? args = null, CustomResourceOptions? options = null)
             : base("aws-native:location:GeofenceCollection", name, args ?? new GeofenceCollectionArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -98,8 +98,8 @@ namespace Pulumi.AwsNative.Location
 
     public sealed class GeofenceCollectionArgs : global::Pulumi.ResourceArgs
     {
-        [Input("collectionName", required: true)]
-        public Input<string> CollectionName { get; set; } = null!;
+        [Input("collectionName")]
+        public Input<string>? CollectionName { get; set; }
 
         [Input("description")]
         public Input<string>? Description { get; set; }

--- a/sdk/dotnet/Location/PlaceIndex.cs
+++ b/sdk/dotnet/Location/PlaceIndex.cs
@@ -107,8 +107,8 @@ namespace Pulumi.AwsNative.Location
         [Input("description")]
         public Input<string>? Description { get; set; }
 
-        [Input("indexName", required: true)]
-        public Input<string> IndexName { get; set; } = null!;
+        [Input("indexName")]
+        public Input<string>? IndexName { get; set; }
 
         [Input("pricingPlan")]
         public Input<Pulumi.AwsNative.Location.PlaceIndexPricingPlan>? PricingPlan { get; set; }

--- a/sdk/dotnet/Location/RouteCalculator.cs
+++ b/sdk/dotnet/Location/RouteCalculator.cs
@@ -95,8 +95,8 @@ namespace Pulumi.AwsNative.Location
 
     public sealed class RouteCalculatorArgs : global::Pulumi.ResourceArgs
     {
-        [Input("calculatorName", required: true)]
-        public Input<string> CalculatorName { get; set; } = null!;
+        [Input("calculatorName")]
+        public Input<string>? CalculatorName { get; set; }
 
         [Input("dataSource", required: true)]
         public Input<string> DataSource { get; set; } = null!;

--- a/sdk/dotnet/Logs/AccountPolicy.cs
+++ b/sdk/dotnet/Logs/AccountPolicy.cs
@@ -166,8 +166,8 @@ namespace Pulumi.AwsNative.Logs
         /// <summary>
         /// The name of the account policy
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         /// <summary>
         /// Type of the policy.

--- a/sdk/dotnet/Logs/ResourcePolicy.cs
+++ b/sdk/dotnet/Logs/ResourcePolicy.cs
@@ -85,8 +85,8 @@ namespace Pulumi.AwsNative.Logs
         /// <summary>
         /// A name for resource policy
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         public ResourcePolicyArgs()
         {

--- a/sdk/dotnet/Msk/ServerlessCluster.cs
+++ b/sdk/dotnet/Msk/ServerlessCluster.cs
@@ -88,8 +88,8 @@ namespace Pulumi.AwsNative.Msk
         [Input("clientAuthentication", required: true)]
         public Input<Inputs.ServerlessClusterClientAuthenticationArgs> ClientAuthentication { get; set; } = null!;
 
-        [Input("clusterName", required: true)]
-        public Input<string> ClusterName { get; set; } = null!;
+        [Input("clusterName")]
+        public Input<string>? ClusterName { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Pinpoint/InAppTemplate.cs
+++ b/sdk/dotnet/Pinpoint/InAppTemplate.cs
@@ -50,7 +50,7 @@ namespace Pulumi.AwsNative.Pinpoint
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public InAppTemplate(string name, InAppTemplateArgs args, CustomResourceOptions? options = null)
+        public InAppTemplate(string name, InAppTemplateArgs? args = null, CustomResourceOptions? options = null)
             : base("aws-native:pinpoint:InAppTemplate", name, args ?? new InAppTemplateArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -117,8 +117,8 @@ namespace Pulumi.AwsNative.Pinpoint
         [Input("templateDescription")]
         public Input<string>? TemplateDescription { get; set; }
 
-        [Input("templateName", required: true)]
-        public Input<string> TemplateName { get; set; } = null!;
+        [Input("templateName")]
+        public Input<string>? TemplateName { get; set; }
 
         public InAppTemplateArgs()
         {

--- a/sdk/dotnet/Redshift/EventSubscription.cs
+++ b/sdk/dotnet/Redshift/EventSubscription.cs
@@ -107,7 +107,7 @@ namespace Pulumi.AwsNative.Redshift
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public EventSubscription(string name, EventSubscriptionArgs args, CustomResourceOptions? options = null)
+        public EventSubscription(string name, EventSubscriptionArgs? args = null, CustomResourceOptions? options = null)
             : base("aws-native:redshift:EventSubscription", name, args ?? new EventSubscriptionArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -199,8 +199,8 @@ namespace Pulumi.AwsNative.Redshift
         /// <summary>
         /// The name of the Amazon Redshift event notification subscription
         /// </summary>
-        [Input("subscriptionName", required: true)]
-        public Input<string> SubscriptionName { get; set; } = null!;
+        [Input("subscriptionName")]
+        public Input<string>? SubscriptionName { get; set; }
 
         [Input("tags")]
         private InputList<Pulumi.AwsNative.Inputs.TagArgs>? _tags;

--- a/sdk/dotnet/ResilienceHub/ResiliencyPolicy.cs
+++ b/sdk/dotnet/ResilienceHub/ResiliencyPolicy.cs
@@ -119,8 +119,8 @@ namespace Pulumi.AwsNative.ResilienceHub
         /// <summary>
         /// Name of Resiliency Policy.
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         [Input("tags")]
         private InputMap<string>? _tags;

--- a/sdk/dotnet/Ssm/ResourceDataSync.cs
+++ b/sdk/dotnet/Ssm/ResourceDataSync.cs
@@ -302,7 +302,7 @@ namespace Pulumi.AwsNative.Ssm
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public ResourceDataSync(string name, ResourceDataSyncArgs args, CustomResourceOptions? options = null)
+        public ResourceDataSync(string name, ResourceDataSyncArgs? args = null, CustomResourceOptions? options = null)
             : base("aws-native:ssm:ResourceDataSync", name, args ?? new ResourceDataSyncArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -368,8 +368,8 @@ namespace Pulumi.AwsNative.Ssm
         [Input("syncFormat")]
         public Input<string>? SyncFormat { get; set; }
 
-        [Input("syncName", required: true)]
-        public Input<string> SyncName { get; set; } = null!;
+        [Input("syncName")]
+        public Input<string>? SyncName { get; set; }
 
         [Input("syncSource")]
         public Input<Inputs.ResourceDataSyncSyncSourceArgs>? SyncSource { get; set; }

--- a/sdk/dotnet/XRay/ResourcePolicy.cs
+++ b/sdk/dotnet/XRay/ResourcePolicy.cs
@@ -139,8 +139,8 @@ namespace Pulumi.AwsNative.XRay
         /// <summary>
         /// The name of the resource policy. Must be unique within a specific AWS account.
         /// </summary>
-        [Input("policyName", required: true)]
-        public Input<string> PolicyName { get; set; } = null!;
+        [Input("policyName")]
+        public Input<string>? PolicyName { get; set; }
 
         public ResourcePolicyArgs()
         {

--- a/sdk/go/aws/applicationautoscaling/scalingPolicy.go
+++ b/sdk/go/aws/applicationautoscaling/scalingPolicy.go
@@ -51,9 +51,6 @@ func NewScalingPolicy(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	if args.PolicyType == nil {
 		return nil, errors.New("invalid value for required argument 'PolicyType'")
 	}
@@ -101,7 +98,7 @@ type scalingPolicyArgs struct {
 	// The name of the scaling policy.
 	//
 	// Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 	// The scaling policy type.
 	//
 	// The following policy types are supported:
@@ -129,7 +126,7 @@ type ScalingPolicyArgs struct {
 	// The name of the scaling policy.
 	//
 	// Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 	// The scaling policy type.
 	//
 	// The following policy types are supported:

--- a/sdk/go/aws/athena/preparedStatement.go
+++ b/sdk/go/aws/athena/preparedStatement.go
@@ -36,9 +36,6 @@ func NewPreparedStatement(ctx *pulumi.Context,
 	if args.QueryStatement == nil {
 		return nil, errors.New("invalid value for required argument 'QueryStatement'")
 	}
-	if args.StatementName == nil {
-		return nil, errors.New("invalid value for required argument 'StatementName'")
-	}
 	if args.WorkGroup == nil {
 		return nil, errors.New("invalid value for required argument 'WorkGroup'")
 	}
@@ -85,7 +82,7 @@ type preparedStatementArgs struct {
 	// The query string for the prepared statement.
 	QueryStatement string `pulumi:"queryStatement"`
 	// The name of the prepared statement.
-	StatementName string `pulumi:"statementName"`
+	StatementName *string `pulumi:"statementName"`
 	// The name of the workgroup to which the prepared statement belongs.
 	WorkGroup string `pulumi:"workGroup"`
 }
@@ -97,7 +94,7 @@ type PreparedStatementArgs struct {
 	// The query string for the prepared statement.
 	QueryStatement pulumi.StringInput
 	// The name of the prepared statement.
-	StatementName pulumi.StringInput
+	StatementName pulumi.StringPtrInput
 	// The name of the workgroup to which the prepared statement belongs.
 	WorkGroup pulumi.StringInput
 }

--- a/sdk/go/aws/ce/anomalyMonitor.go
+++ b/sdk/go/aws/ce/anomalyMonitor.go
@@ -472,9 +472,6 @@ func NewAnomalyMonitor(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.MonitorName == nil {
-		return nil, errors.New("invalid value for required argument 'MonitorName'")
-	}
 	if args.MonitorType == nil {
 		return nil, errors.New("invalid value for required argument 'MonitorType'")
 	}
@@ -521,7 +518,7 @@ type anomalyMonitorArgs struct {
 	// The dimensions to evaluate
 	MonitorDimension *AnomalyMonitorMonitorDimension `pulumi:"monitorDimension"`
 	// The name of the monitor.
-	MonitorName          string                    `pulumi:"monitorName"`
+	MonitorName          *string                   `pulumi:"monitorName"`
 	MonitorSpecification *string                   `pulumi:"monitorSpecification"`
 	MonitorType          AnomalyMonitorMonitorType `pulumi:"monitorType"`
 	// Tags to assign to monitor.
@@ -533,7 +530,7 @@ type AnomalyMonitorArgs struct {
 	// The dimensions to evaluate
 	MonitorDimension AnomalyMonitorMonitorDimensionPtrInput
 	// The name of the monitor.
-	MonitorName          pulumi.StringInput
+	MonitorName          pulumi.StringPtrInput
 	MonitorSpecification pulumi.StringPtrInput
 	MonitorType          AnomalyMonitorMonitorTypeInput
 	// Tags to assign to monitor.

--- a/sdk/go/aws/ce/anomalySubscription.go
+++ b/sdk/go/aws/ce/anomalySubscription.go
@@ -257,9 +257,6 @@ func NewAnomalySubscription(ctx *pulumi.Context,
 	if args.Subscribers == nil {
 		return nil, errors.New("invalid value for required argument 'Subscribers'")
 	}
-	if args.SubscriptionName == nil {
-		return nil, errors.New("invalid value for required argument 'SubscriptionName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"resourceTags[*]",
 	})
@@ -306,7 +303,7 @@ type anomalySubscriptionArgs struct {
 	// A list of subscriber
 	Subscribers []AnomalySubscriptionSubscriber `pulumi:"subscribers"`
 	// The name of the subscription.
-	SubscriptionName string `pulumi:"subscriptionName"`
+	SubscriptionName *string `pulumi:"subscriptionName"`
 	// The dollar value that triggers a notification if the threshold is exceeded.
 	Threshold *float64 `pulumi:"threshold"`
 	// An Expression object in JSON String format used to specify the anomalies that you want to generate alerts for.
@@ -324,7 +321,7 @@ type AnomalySubscriptionArgs struct {
 	// A list of subscriber
 	Subscribers AnomalySubscriptionSubscriberArrayInput
 	// The name of the subscription.
-	SubscriptionName pulumi.StringInput
+	SubscriptionName pulumi.StringPtrInput
 	// The dollar value that triggers a notification if the threshold is exceeded.
 	Threshold pulumi.Float64PtrInput
 	// An Expression object in JSON String format used to specify the anomalies that you want to generate alerts for.

--- a/sdk/go/aws/chatbot/microsoftTeamsChannelConfiguration.go
+++ b/sdk/go/aws/chatbot/microsoftTeamsChannelConfiguration.go
@@ -45,9 +45,6 @@ func NewMicrosoftTeamsChannelConfiguration(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.ConfigurationName == nil {
-		return nil, errors.New("invalid value for required argument 'ConfigurationName'")
-	}
 	if args.IamRoleArn == nil {
 		return nil, errors.New("invalid value for required argument 'IamRoleArn'")
 	}
@@ -100,7 +97,7 @@ func (MicrosoftTeamsChannelConfigurationState) ElementType() reflect.Type {
 
 type microsoftTeamsChannelConfigurationArgs struct {
 	// The name of the configuration
-	ConfigurationName string `pulumi:"configurationName"`
+	ConfigurationName *string `pulumi:"configurationName"`
 	// The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
 	GuardrailPolicies []string `pulumi:"guardrailPolicies"`
 	// The ARN of the IAM role that defines the permissions for AWS Chatbot
@@ -122,7 +119,7 @@ type microsoftTeamsChannelConfigurationArgs struct {
 // The set of arguments for constructing a MicrosoftTeamsChannelConfiguration resource.
 type MicrosoftTeamsChannelConfigurationArgs struct {
 	// The name of the configuration
-	ConfigurationName pulumi.StringInput
+	ConfigurationName pulumi.StringPtrInput
 	// The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
 	GuardrailPolicies pulumi.StringArrayInput
 	// The ARN of the IAM role that defines the permissions for AWS Chatbot

--- a/sdk/go/aws/chatbot/slackChannelConfiguration.go
+++ b/sdk/go/aws/chatbot/slackChannelConfiguration.go
@@ -43,9 +43,6 @@ func NewSlackChannelConfiguration(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.ConfigurationName == nil {
-		return nil, errors.New("invalid value for required argument 'ConfigurationName'")
-	}
 	if args.IamRoleArn == nil {
 		return nil, errors.New("invalid value for required argument 'IamRoleArn'")
 	}
@@ -94,7 +91,7 @@ func (SlackChannelConfigurationState) ElementType() reflect.Type {
 
 type slackChannelConfigurationArgs struct {
 	// The name of the configuration
-	ConfigurationName string `pulumi:"configurationName"`
+	ConfigurationName *string `pulumi:"configurationName"`
 	// The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
 	GuardrailPolicies []string `pulumi:"guardrailPolicies"`
 	// The ARN of the IAM role that defines the permissions for AWS Chatbot
@@ -114,7 +111,7 @@ type slackChannelConfigurationArgs struct {
 // The set of arguments for constructing a SlackChannelConfiguration resource.
 type SlackChannelConfigurationArgs struct {
 	// The name of the configuration
-	ConfigurationName pulumi.StringInput
+	ConfigurationName pulumi.StringPtrInput
 	// The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
 	GuardrailPolicies pulumi.StringArrayInput
 	// The ARN of the IAM role that defines the permissions for AWS Chatbot

--- a/sdk/go/aws/cognito/userPoolIdentityProvider.go
+++ b/sdk/go/aws/cognito/userPoolIdentityProvider.go
@@ -34,9 +34,6 @@ func NewUserPoolIdentityProvider(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.ProviderName == nil {
-		return nil, errors.New("invalid value for required argument 'ProviderName'")
-	}
 	if args.ProviderType == nil {
 		return nil, errors.New("invalid value for required argument 'ProviderType'")
 	}
@@ -87,7 +84,7 @@ type userPoolIdentityProviderArgs struct {
 	IdpIdentifiers   []string    `pulumi:"idpIdentifiers"`
 	// Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property.
 	ProviderDetails interface{} `pulumi:"providerDetails"`
-	ProviderName    string      `pulumi:"providerName"`
+	ProviderName    *string     `pulumi:"providerName"`
 	ProviderType    string      `pulumi:"providerType"`
 	UserPoolId      string      `pulumi:"userPoolId"`
 }
@@ -99,7 +96,7 @@ type UserPoolIdentityProviderArgs struct {
 	IdpIdentifiers   pulumi.StringArrayInput
 	// Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property.
 	ProviderDetails pulumi.Input
-	ProviderName    pulumi.StringInput
+	ProviderName    pulumi.StringPtrInput
 	ProviderType    pulumi.StringInput
 	UserPoolId      pulumi.StringInput
 }

--- a/sdk/go/aws/configuration/storedQuery.go
+++ b/sdk/go/aws/configuration/storedQuery.go
@@ -36,9 +36,6 @@ func NewStoredQuery(ctx *pulumi.Context,
 	if args.QueryExpression == nil {
 		return nil, errors.New("invalid value for required argument 'QueryExpression'")
 	}
-	if args.QueryName == nil {
-		return nil, errors.New("invalid value for required argument 'QueryName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"queryName",
 	})
@@ -78,7 +75,7 @@ func (StoredQueryState) ElementType() reflect.Type {
 type storedQueryArgs struct {
 	QueryDescription *string `pulumi:"queryDescription"`
 	QueryExpression  string  `pulumi:"queryExpression"`
-	QueryName        string  `pulumi:"queryName"`
+	QueryName        *string `pulumi:"queryName"`
 	// The tags for the stored query.
 	Tags []aws.Tag `pulumi:"tags"`
 }
@@ -87,7 +84,7 @@ type storedQueryArgs struct {
 type StoredQueryArgs struct {
 	QueryDescription pulumi.StringPtrInput
 	QueryExpression  pulumi.StringInput
-	QueryName        pulumi.StringInput
+	QueryName        pulumi.StringPtrInput
 	// The tags for the stored query.
 	Tags aws.TagArrayInput
 }

--- a/sdk/go/aws/connect/user.go
+++ b/sdk/go/aws/connect/user.go
@@ -62,9 +62,6 @@ func NewUser(ctx *pulumi.Context,
 	if args.SecurityProfileArns == nil {
 		return nil, errors.New("invalid value for required argument 'SecurityProfileArns'")
 	}
-	if args.Username == nil {
-		return nil, errors.New("invalid value for required argument 'Username'")
-	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource User
 	err := ctx.RegisterResource("aws-native:connect:User", name, args, &resource, opts...)
@@ -119,7 +116,7 @@ type userArgs struct {
 	// One or more predefined attributes assigned to a user, with a level that indicates how skilled they are.
 	UserProficiencies []UserProficiency `pulumi:"userProficiencies"`
 	// The user name for the account.
-	Username string `pulumi:"username"`
+	Username *string `pulumi:"username"`
 }
 
 // The set of arguments for constructing a User resource.
@@ -145,7 +142,7 @@ type UserArgs struct {
 	// One or more predefined attributes assigned to a user, with a level that indicates how skilled they are.
 	UserProficiencies UserProficiencyArrayInput
 	// The user name for the account.
-	Username pulumi.StringInput
+	Username pulumi.StringPtrInput
 }
 
 func (UserArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/entityresolution/idMappingWorkflow.go
+++ b/sdk/go/aws/entityresolution/idMappingWorkflow.go
@@ -50,9 +50,6 @@ func NewIdMappingWorkflow(ctx *pulumi.Context,
 	if args.RoleArn == nil {
 		return nil, errors.New("invalid value for required argument 'RoleArn'")
 	}
-	if args.WorkflowName == nil {
-		return nil, errors.New("invalid value for required argument 'WorkflowName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"workflowName",
 	})
@@ -98,7 +95,7 @@ type idMappingWorkflowArgs struct {
 	RoleArn             string                               `pulumi:"roleArn"`
 	Tags                []aws.Tag                            `pulumi:"tags"`
 	// The name of the IdMappingWorkflow
-	WorkflowName string `pulumi:"workflowName"`
+	WorkflowName *string `pulumi:"workflowName"`
 }
 
 // The set of arguments for constructing a IdMappingWorkflow resource.
@@ -111,7 +108,7 @@ type IdMappingWorkflowArgs struct {
 	RoleArn             pulumi.StringInput
 	Tags                aws.TagArrayInput
 	// The name of the IdMappingWorkflow
-	WorkflowName pulumi.StringInput
+	WorkflowName pulumi.StringPtrInput
 }
 
 func (IdMappingWorkflowArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/entityresolution/matchingWorkflow.go
+++ b/sdk/go/aws/entityresolution/matchingWorkflow.go
@@ -50,9 +50,6 @@ func NewMatchingWorkflow(ctx *pulumi.Context,
 	if args.RoleArn == nil {
 		return nil, errors.New("invalid value for required argument 'RoleArn'")
 	}
-	if args.WorkflowName == nil {
-		return nil, errors.New("invalid value for required argument 'WorkflowName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"workflowName",
 	})
@@ -98,7 +95,7 @@ type matchingWorkflowArgs struct {
 	RoleArn              string                               `pulumi:"roleArn"`
 	Tags                 []aws.Tag                            `pulumi:"tags"`
 	// The name of the MatchingWorkflow
-	WorkflowName string `pulumi:"workflowName"`
+	WorkflowName *string `pulumi:"workflowName"`
 }
 
 // The set of arguments for constructing a MatchingWorkflow resource.
@@ -111,7 +108,7 @@ type MatchingWorkflowArgs struct {
 	RoleArn              pulumi.StringInput
 	Tags                 aws.TagArrayInput
 	// The name of the MatchingWorkflow
-	WorkflowName pulumi.StringInput
+	WorkflowName pulumi.StringPtrInput
 }
 
 func (MatchingWorkflowArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iam/groupPolicy.go
+++ b/sdk/go/aws/iam/groupPolicy.go
@@ -46,9 +46,6 @@ func NewGroupPolicy(ctx *pulumi.Context,
 	if args.GroupName == nil {
 		return nil, errors.New("invalid value for required argument 'GroupName'")
 	}
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"groupName",
 		"policyName",
@@ -101,7 +98,7 @@ type groupPolicyArgs struct {
 	PolicyDocument interface{} `pulumi:"policyDocument"`
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 }
 
 // The set of arguments for constructing a GroupPolicy resource.
@@ -120,7 +117,7 @@ type GroupPolicyArgs struct {
 	PolicyDocument pulumi.Input
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 }
 
 func (GroupPolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/iam/rolePolicy.go
+++ b/sdk/go/aws/iam/rolePolicy.go
@@ -44,9 +44,6 @@ func NewRolePolicy(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	if args.RoleName == nil {
 		return nil, errors.New("invalid value for required argument 'RoleName'")
 	}
@@ -99,7 +96,7 @@ type rolePolicyArgs struct {
 	PolicyDocument interface{} `pulumi:"policyDocument"`
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 	// The name of the role to associate the policy with.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
 	RoleName string `pulumi:"roleName"`
@@ -118,7 +115,7 @@ type RolePolicyArgs struct {
 	PolicyDocument pulumi.Input
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 	// The name of the role to associate the policy with.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
 	RoleName pulumi.StringInput

--- a/sdk/go/aws/iam/userPolicy.go
+++ b/sdk/go/aws/iam/userPolicy.go
@@ -43,9 +43,6 @@ func NewUserPolicy(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	if args.UserName == nil {
 		return nil, errors.New("invalid value for required argument 'UserName'")
 	}
@@ -98,7 +95,7 @@ type userPolicyArgs struct {
 	PolicyDocument interface{} `pulumi:"policyDocument"`
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 	// The name of the user to associate the policy with.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName string `pulumi:"userName"`
@@ -117,7 +114,7 @@ type UserPolicyArgs struct {
 	PolicyDocument pulumi.Input
 	// The name of the policy document.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 	// The name of the user to associate the policy with.
 	//  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
 	UserName pulumi.StringInput

--- a/sdk/go/aws/iot/fleetMetric.go
+++ b/sdk/go/aws/iot/fleetMetric.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -50,12 +49,9 @@ type FleetMetric struct {
 func NewFleetMetric(ctx *pulumi.Context,
 	name string, args *FleetMetricArgs, opts ...pulumi.ResourceOption) (*FleetMetric, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &FleetMetricArgs{}
 	}
 
-	if args.MetricName == nil {
-		return nil, errors.New("invalid value for required argument 'MetricName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"metricName",
 	})
@@ -101,7 +97,7 @@ type fleetMetricArgs struct {
 	// The index name of a fleet metric
 	IndexName *string `pulumi:"indexName"`
 	// The name of the fleet metric
-	MetricName string `pulumi:"metricName"`
+	MetricName *string `pulumi:"metricName"`
 	// The period of metric emission in seconds
 	Period *int `pulumi:"period"`
 	// The Fleet Indexing query used by a fleet metric
@@ -124,7 +120,7 @@ type FleetMetricArgs struct {
 	// The index name of a fleet metric
 	IndexName pulumi.StringPtrInput
 	// The name of the fleet metric
-	MetricName pulumi.StringInput
+	MetricName pulumi.StringPtrInput
 	// The period of metric emission in seconds
 	Period pulumi.IntPtrInput
 	// The Fleet Indexing query used by a fleet metric

--- a/sdk/go/aws/lightsail/loadBalancerTlsCertificate.go
+++ b/sdk/go/aws/lightsail/loadBalancerTlsCertificate.go
@@ -43,9 +43,6 @@ func NewLoadBalancerTlsCertificate(ctx *pulumi.Context,
 	if args.CertificateDomainName == nil {
 		return nil, errors.New("invalid value for required argument 'CertificateDomainName'")
 	}
-	if args.CertificateName == nil {
-		return nil, errors.New("invalid value for required argument 'CertificateName'")
-	}
 	if args.LoadBalancerName == nil {
 		return nil, errors.New("invalid value for required argument 'LoadBalancerName'")
 	}
@@ -94,7 +91,7 @@ type loadBalancerTlsCertificateArgs struct {
 	// The domain name (e.g., example.com ) for your SSL/TLS certificate.
 	CertificateDomainName string `pulumi:"certificateDomainName"`
 	// The SSL/TLS certificate name.
-	CertificateName string `pulumi:"certificateName"`
+	CertificateName *string `pulumi:"certificateName"`
 	// A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer.
 	HttpsRedirectionEnabled *bool `pulumi:"httpsRedirectionEnabled"`
 	// When true, the SSL/TLS certificate is attached to the Lightsail load balancer.
@@ -110,7 +107,7 @@ type LoadBalancerTlsCertificateArgs struct {
 	// The domain name (e.g., example.com ) for your SSL/TLS certificate.
 	CertificateDomainName pulumi.StringInput
 	// The SSL/TLS certificate name.
-	CertificateName pulumi.StringInput
+	CertificateName pulumi.StringPtrInput
 	// A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer.
 	HttpsRedirectionEnabled pulumi.BoolPtrInput
 	// When true, the SSL/TLS certificate is attached to the Lightsail load balancer.

--- a/sdk/go/aws/location/apiKey.go
+++ b/sdk/go/aws/location/apiKey.go
@@ -39,9 +39,6 @@ func NewApiKey(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.KeyName == nil {
-		return nil, errors.New("invalid value for required argument 'KeyName'")
-	}
 	if args.Restrictions == nil {
 		return nil, errors.New("invalid value for required argument 'Restrictions'")
 	}
@@ -86,7 +83,7 @@ type apiKeyArgs struct {
 	ExpireTime   *string            `pulumi:"expireTime"`
 	ForceDelete  *bool              `pulumi:"forceDelete"`
 	ForceUpdate  *bool              `pulumi:"forceUpdate"`
-	KeyName      string             `pulumi:"keyName"`
+	KeyName      *string            `pulumi:"keyName"`
 	NoExpiry     *bool              `pulumi:"noExpiry"`
 	Restrictions ApiKeyRestrictions `pulumi:"restrictions"`
 	// An array of key-value pairs to apply to this resource.
@@ -99,7 +96,7 @@ type ApiKeyArgs struct {
 	ExpireTime   pulumi.StringPtrInput
 	ForceDelete  pulumi.BoolPtrInput
 	ForceUpdate  pulumi.BoolPtrInput
-	KeyName      pulumi.StringInput
+	KeyName      pulumi.StringPtrInput
 	NoExpiry     pulumi.BoolPtrInput
 	Restrictions ApiKeyRestrictionsInput
 	// An array of key-value pairs to apply to this resource.

--- a/sdk/go/aws/location/geofenceCollection.go
+++ b/sdk/go/aws/location/geofenceCollection.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -34,12 +33,9 @@ type GeofenceCollection struct {
 func NewGeofenceCollection(ctx *pulumi.Context,
 	name string, args *GeofenceCollectionArgs, opts ...pulumi.ResourceOption) (*GeofenceCollection, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &GeofenceCollectionArgs{}
 	}
 
-	if args.CollectionName == nil {
-		return nil, errors.New("invalid value for required argument 'CollectionName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"collectionName",
 		"kmsKeyId",
@@ -78,7 +74,7 @@ func (GeofenceCollectionState) ElementType() reflect.Type {
 }
 
 type geofenceCollectionArgs struct {
-	CollectionName        string                         `pulumi:"collectionName"`
+	CollectionName        *string                        `pulumi:"collectionName"`
 	Description           *string                        `pulumi:"description"`
 	KmsKeyId              *string                        `pulumi:"kmsKeyId"`
 	PricingPlan           *GeofenceCollectionPricingPlan `pulumi:"pricingPlan"`
@@ -89,7 +85,7 @@ type geofenceCollectionArgs struct {
 
 // The set of arguments for constructing a GeofenceCollection resource.
 type GeofenceCollectionArgs struct {
-	CollectionName        pulumi.StringInput
+	CollectionName        pulumi.StringPtrInput
 	Description           pulumi.StringPtrInput
 	KmsKeyId              pulumi.StringPtrInput
 	PricingPlan           GeofenceCollectionPricingPlanPtrInput

--- a/sdk/go/aws/location/placeIndex.go
+++ b/sdk/go/aws/location/placeIndex.go
@@ -40,9 +40,6 @@ func NewPlaceIndex(ctx *pulumi.Context,
 	if args.DataSource == nil {
 		return nil, errors.New("invalid value for required argument 'DataSource'")
 	}
-	if args.IndexName == nil {
-		return nil, errors.New("invalid value for required argument 'IndexName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"dataSource",
 		"indexName",
@@ -84,7 +81,7 @@ type placeIndexArgs struct {
 	DataSource              string                             `pulumi:"dataSource"`
 	DataSourceConfiguration *PlaceIndexDataSourceConfiguration `pulumi:"dataSourceConfiguration"`
 	Description             *string                            `pulumi:"description"`
-	IndexName               string                             `pulumi:"indexName"`
+	IndexName               *string                            `pulumi:"indexName"`
 	PricingPlan             *PlaceIndexPricingPlan             `pulumi:"pricingPlan"`
 	// An array of key-value pairs to apply to this resource.
 	Tags []aws.Tag `pulumi:"tags"`
@@ -95,7 +92,7 @@ type PlaceIndexArgs struct {
 	DataSource              pulumi.StringInput
 	DataSourceConfiguration PlaceIndexDataSourceConfigurationPtrInput
 	Description             pulumi.StringPtrInput
-	IndexName               pulumi.StringInput
+	IndexName               pulumi.StringPtrInput
 	PricingPlan             PlaceIndexPricingPlanPtrInput
 	// An array of key-value pairs to apply to this resource.
 	Tags aws.TagArrayInput

--- a/sdk/go/aws/location/routeCalculator.go
+++ b/sdk/go/aws/location/routeCalculator.go
@@ -36,9 +36,6 @@ func NewRouteCalculator(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.CalculatorName == nil {
-		return nil, errors.New("invalid value for required argument 'CalculatorName'")
-	}
 	if args.DataSource == nil {
 		return nil, errors.New("invalid value for required argument 'DataSource'")
 	}
@@ -80,7 +77,7 @@ func (RouteCalculatorState) ElementType() reflect.Type {
 }
 
 type routeCalculatorArgs struct {
-	CalculatorName string                      `pulumi:"calculatorName"`
+	CalculatorName *string                     `pulumi:"calculatorName"`
 	DataSource     string                      `pulumi:"dataSource"`
 	Description    *string                     `pulumi:"description"`
 	PricingPlan    *RouteCalculatorPricingPlan `pulumi:"pricingPlan"`
@@ -90,7 +87,7 @@ type routeCalculatorArgs struct {
 
 // The set of arguments for constructing a RouteCalculator resource.
 type RouteCalculatorArgs struct {
-	CalculatorName pulumi.StringInput
+	CalculatorName pulumi.StringPtrInput
 	DataSource     pulumi.StringInput
 	Description    pulumi.StringPtrInput
 	PricingPlan    RouteCalculatorPricingPlanPtrInput

--- a/sdk/go/aws/logs/accountPolicy.go
+++ b/sdk/go/aws/logs/accountPolicy.go
@@ -104,9 +104,6 @@ func NewAccountPolicy(ctx *pulumi.Context,
 	if args.PolicyDocument == nil {
 		return nil, errors.New("invalid value for required argument 'PolicyDocument'")
 	}
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	if args.PolicyType == nil {
 		return nil, errors.New("invalid value for required argument 'PolicyType'")
 	}
@@ -157,7 +154,7 @@ type accountPolicyArgs struct {
 	// Length Constraints: Maximum length of 30720
 	PolicyDocument string `pulumi:"policyDocument"`
 	// The name of the account policy
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 	// Type of the policy.
 	PolicyType AccountPolicyPolicyType `pulumi:"policyType"`
 	// Scope for policy application
@@ -177,7 +174,7 @@ type AccountPolicyArgs struct {
 	// Length Constraints: Maximum length of 30720
 	PolicyDocument pulumi.StringInput
 	// The name of the account policy
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 	// Type of the policy.
 	PolicyType AccountPolicyPolicyTypeInput
 	// Scope for policy application

--- a/sdk/go/aws/logs/resourcePolicy.go
+++ b/sdk/go/aws/logs/resourcePolicy.go
@@ -32,9 +32,6 @@ func NewResourcePolicy(ctx *pulumi.Context,
 	if args.PolicyDocument == nil {
 		return nil, errors.New("invalid value for required argument 'PolicyDocument'")
 	}
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"policyName",
 	})
@@ -75,7 +72,7 @@ type resourcePolicyArgs struct {
 	// The policy document
 	PolicyDocument string `pulumi:"policyDocument"`
 	// A name for resource policy
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 }
 
 // The set of arguments for constructing a ResourcePolicy resource.
@@ -83,7 +80,7 @@ type ResourcePolicyArgs struct {
 	// The policy document
 	PolicyDocument pulumi.StringInput
 	// A name for resource policy
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 }
 
 func (ResourcePolicyArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/msk/serverlessCluster.go
+++ b/sdk/go/aws/msk/serverlessCluster.go
@@ -34,9 +34,6 @@ func NewServerlessCluster(ctx *pulumi.Context,
 	if args.ClientAuthentication == nil {
 		return nil, errors.New("invalid value for required argument 'ClientAuthentication'")
 	}
-	if args.ClusterName == nil {
-		return nil, errors.New("invalid value for required argument 'ClusterName'")
-	}
 	if args.VpcConfigs == nil {
 		return nil, errors.New("invalid value for required argument 'VpcConfigs'")
 	}
@@ -81,7 +78,7 @@ func (ServerlessClusterState) ElementType() reflect.Type {
 
 type serverlessClusterArgs struct {
 	ClientAuthentication ServerlessClusterClientAuthentication `pulumi:"clientAuthentication"`
-	ClusterName          string                                `pulumi:"clusterName"`
+	ClusterName          *string                               `pulumi:"clusterName"`
 	// A key-value pair to associate with a resource.
 	Tags       map[string]string            `pulumi:"tags"`
 	VpcConfigs []ServerlessClusterVpcConfig `pulumi:"vpcConfigs"`
@@ -90,7 +87,7 @@ type serverlessClusterArgs struct {
 // The set of arguments for constructing a ServerlessCluster resource.
 type ServerlessClusterArgs struct {
 	ClientAuthentication ServerlessClusterClientAuthenticationInput
-	ClusterName          pulumi.StringInput
+	ClusterName          pulumi.StringPtrInput
 	// A key-value pair to associate with a resource.
 	Tags       pulumi.StringMapInput
 	VpcConfigs ServerlessClusterVpcConfigArrayInput

--- a/sdk/go/aws/pinpoint/inAppTemplate.go
+++ b/sdk/go/aws/pinpoint/inAppTemplate.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -31,12 +30,9 @@ type InAppTemplate struct {
 func NewInAppTemplate(ctx *pulumi.Context,
 	name string, args *InAppTemplateArgs, opts ...pulumi.ResourceOption) (*InAppTemplate, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &InAppTemplateArgs{}
 	}
 
-	if args.TemplateName == nil {
-		return nil, errors.New("invalid value for required argument 'TemplateName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"templateName",
 	})
@@ -81,7 +77,7 @@ type inAppTemplateArgs struct {
 	// Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property.
 	Tags                interface{} `pulumi:"tags"`
 	TemplateDescription *string     `pulumi:"templateDescription"`
-	TemplateName        string      `pulumi:"templateName"`
+	TemplateName        *string     `pulumi:"templateName"`
 }
 
 // The set of arguments for constructing a InAppTemplate resource.
@@ -93,7 +89,7 @@ type InAppTemplateArgs struct {
 	// Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property.
 	Tags                pulumi.Input
 	TemplateDescription pulumi.StringPtrInput
-	TemplateName        pulumi.StringInput
+	TemplateName        pulumi.StringPtrInput
 }
 
 func (InAppTemplateArgs) ElementType() reflect.Type {

--- a/sdk/go/aws/redshift/eventSubscription.go
+++ b/sdk/go/aws/redshift/eventSubscription.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -51,12 +50,9 @@ type EventSubscription struct {
 func NewEventSubscription(ctx *pulumi.Context,
 	name string, args *EventSubscriptionArgs, opts ...pulumi.ResourceOption) (*EventSubscription, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &EventSubscriptionArgs{}
 	}
 
-	if args.SubscriptionName == nil {
-		return nil, errors.New("invalid value for required argument 'SubscriptionName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"subscriptionName",
 	})
@@ -107,7 +103,7 @@ type eventSubscriptionArgs struct {
 	// The type of source that will be generating the events.
 	SourceType *EventSubscriptionSourceType `pulumi:"sourceType"`
 	// The name of the Amazon Redshift event notification subscription
-	SubscriptionName string `pulumi:"subscriptionName"`
+	SubscriptionName *string `pulumi:"subscriptionName"`
 	// An array of key-value pairs to apply to this resource.
 	Tags []aws.Tag `pulumi:"tags"`
 }
@@ -127,7 +123,7 @@ type EventSubscriptionArgs struct {
 	// The type of source that will be generating the events.
 	SourceType EventSubscriptionSourceTypePtrInput
 	// The name of the Amazon Redshift event notification subscription
-	SubscriptionName pulumi.StringInput
+	SubscriptionName pulumi.StringPtrInput
 	// An array of key-value pairs to apply to this resource.
 	Tags aws.TagArrayInput
 }

--- a/sdk/go/aws/resiliencehub/resiliencyPolicy.go
+++ b/sdk/go/aws/resiliencehub/resiliencyPolicy.go
@@ -40,9 +40,6 @@ func NewResiliencyPolicy(ctx *pulumi.Context,
 	if args.Policy == nil {
 		return nil, errors.New("invalid value for required argument 'Policy'")
 	}
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	if args.Tier == nil {
 		return nil, errors.New("invalid value for required argument 'Tier'")
 	}
@@ -85,7 +82,7 @@ type resiliencyPolicyArgs struct {
 	// Description of Resiliency Policy.
 	PolicyDescription *string `pulumi:"policyDescription"`
 	// Name of Resiliency Policy.
-	PolicyName string            `pulumi:"policyName"`
+	PolicyName *string           `pulumi:"policyName"`
 	Tags       map[string]string `pulumi:"tags"`
 	// Resiliency Policy Tier.
 	Tier ResiliencyPolicyTier `pulumi:"tier"`
@@ -99,7 +96,7 @@ type ResiliencyPolicyArgs struct {
 	// Description of Resiliency Policy.
 	PolicyDescription pulumi.StringPtrInput
 	// Name of Resiliency Policy.
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 	Tags       pulumi.StringMapInput
 	// Resiliency Policy Tier.
 	Tier ResiliencyPolicyTierInput

--- a/sdk/go/aws/ssm/resourceDataSync.go
+++ b/sdk/go/aws/ssm/resourceDataSync.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"errors"
 	"github.com/pulumi/pulumi-aws-native/sdk/go/aws/internal"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -319,12 +318,9 @@ type ResourceDataSync struct {
 func NewResourceDataSync(ctx *pulumi.Context,
 	name string, args *ResourceDataSyncArgs, opts ...pulumi.ResourceOption) (*ResourceDataSync, error) {
 	if args == nil {
-		return nil, errors.New("missing one or more required arguments")
+		args = &ResourceDataSyncArgs{}
 	}
 
-	if args.SyncName == nil {
-		return nil, errors.New("invalid value for required argument 'SyncName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"bucketName",
 		"bucketPrefix",
@@ -375,7 +371,7 @@ type resourceDataSyncArgs struct {
 	KmsKeyArn     *string                        `pulumi:"kmsKeyArn"`
 	S3Destination *ResourceDataSyncS3Destination `pulumi:"s3Destination"`
 	SyncFormat    *string                        `pulumi:"syncFormat"`
-	SyncName      string                         `pulumi:"syncName"`
+	SyncName      *string                        `pulumi:"syncName"`
 	SyncSource    *ResourceDataSyncSyncSource    `pulumi:"syncSource"`
 	SyncType      *string                        `pulumi:"syncType"`
 }
@@ -388,7 +384,7 @@ type ResourceDataSyncArgs struct {
 	KmsKeyArn     pulumi.StringPtrInput
 	S3Destination ResourceDataSyncS3DestinationPtrInput
 	SyncFormat    pulumi.StringPtrInput
-	SyncName      pulumi.StringInput
+	SyncName      pulumi.StringPtrInput
 	SyncSource    ResourceDataSyncSyncSourcePtrInput
 	SyncType      pulumi.StringPtrInput
 }

--- a/sdk/go/aws/xray/resourcePolicy.go
+++ b/sdk/go/aws/xray/resourcePolicy.go
@@ -90,9 +90,6 @@ func NewResourcePolicy(ctx *pulumi.Context,
 	if args.PolicyDocument == nil {
 		return nil, errors.New("invalid value for required argument 'PolicyDocument'")
 	}
-	if args.PolicyName == nil {
-		return nil, errors.New("invalid value for required argument 'PolicyName'")
-	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
 		"policyName",
 	})
@@ -135,7 +132,7 @@ type resourcePolicyArgs struct {
 	// The resource policy document, which can be up to 5kb in size.
 	PolicyDocument string `pulumi:"policyDocument"`
 	// The name of the resource policy. Must be unique within a specific AWS account.
-	PolicyName string `pulumi:"policyName"`
+	PolicyName *string `pulumi:"policyName"`
 }
 
 // The set of arguments for constructing a ResourcePolicy resource.
@@ -145,7 +142,7 @@ type ResourcePolicyArgs struct {
 	// The resource policy document, which can be up to 5kb in size.
 	PolicyDocument pulumi.StringInput
 	// The name of the resource policy. Must be unique within a specific AWS account.
-	PolicyName pulumi.StringInput
+	PolicyName pulumi.StringPtrInput
 }
 
 func (ResourcePolicyArgs) ElementType() reflect.Type {

--- a/sdk/nodejs/applicationautoscaling/scalingPolicy.ts
+++ b/sdk/nodejs/applicationautoscaling/scalingPolicy.ts
@@ -93,9 +93,6 @@ export class ScalingPolicy extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             if ((!args || args.policyType === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policyType'");
             }
@@ -135,7 +132,7 @@ export interface ScalingPolicyArgs {
      *
      * Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
     /**
      * The scaling policy type.
      *

--- a/sdk/nodejs/athena/preparedStatement.ts
+++ b/sdk/nodejs/athena/preparedStatement.ts
@@ -65,9 +65,6 @@ export class PreparedStatement extends pulumi.CustomResource {
             if ((!args || args.queryStatement === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'queryStatement'");
             }
-            if ((!args || args.statementName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'statementName'");
-            }
             if ((!args || args.workGroup === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'workGroup'");
             }
@@ -103,7 +100,7 @@ export interface PreparedStatementArgs {
     /**
      * The name of the prepared statement.
      */
-    statementName: pulumi.Input<string>;
+    statementName?: pulumi.Input<string>;
     /**
      * The name of the workgroup to which the prepared statement belongs.
      */

--- a/sdk/nodejs/ce/anomalyMonitor.ts
+++ b/sdk/nodejs/ce/anomalyMonitor.ts
@@ -310,9 +310,6 @@ export class AnomalyMonitor extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.monitorName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'monitorName'");
-            }
             if ((!args || args.monitorType === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'monitorType'");
             }
@@ -356,7 +353,7 @@ export interface AnomalyMonitorArgs {
     /**
      * The name of the monitor.
      */
-    monitorName: pulumi.Input<string>;
+    monitorName?: pulumi.Input<string>;
     monitorSpecification?: pulumi.Input<string>;
     monitorType: pulumi.Input<enums.ce.AnomalyMonitorMonitorType>;
     /**

--- a/sdk/nodejs/ce/anomalySubscription.ts
+++ b/sdk/nodejs/ce/anomalySubscription.ts
@@ -201,9 +201,6 @@ export class AnomalySubscription extends pulumi.CustomResource {
             if ((!args || args.subscribers === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'subscribers'");
             }
-            if ((!args || args.subscriptionName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'subscriptionName'");
-            }
             resourceInputs["frequency"] = args ? args.frequency : undefined;
             resourceInputs["monitorArnList"] = args ? args.monitorArnList : undefined;
             resourceInputs["resourceTags"] = args ? args.resourceTags : undefined;
@@ -254,7 +251,7 @@ export interface AnomalySubscriptionArgs {
     /**
      * The name of the subscription.
      */
-    subscriptionName: pulumi.Input<string>;
+    subscriptionName?: pulumi.Input<string>;
     /**
      * The dollar value that triggers a notification if the threshold is exceeded. 
      */

--- a/sdk/nodejs/chatbot/microsoftTeamsChannelConfiguration.ts
+++ b/sdk/nodejs/chatbot/microsoftTeamsChannelConfiguration.ts
@@ -86,9 +86,6 @@ export class MicrosoftTeamsChannelConfiguration extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.configurationName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'configurationName'");
-            }
             if ((!args || args.iamRoleArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'iamRoleArn'");
             }
@@ -137,7 +134,7 @@ export interface MicrosoftTeamsChannelConfigurationArgs {
     /**
      * The name of the configuration
      */
-    configurationName: pulumi.Input<string>;
+    configurationName?: pulumi.Input<string>;
     /**
      * The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
      */

--- a/sdk/nodejs/chatbot/slackChannelConfiguration.ts
+++ b/sdk/nodejs/chatbot/slackChannelConfiguration.ts
@@ -82,9 +82,6 @@ export class SlackChannelConfiguration extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.configurationName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'configurationName'");
-            }
             if ((!args || args.iamRoleArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'iamRoleArn'");
             }
@@ -128,7 +125,7 @@ export interface SlackChannelConfigurationArgs {
     /**
      * The name of the configuration
      */
-    configurationName: pulumi.Input<string>;
+    configurationName?: pulumi.Input<string>;
     /**
      * The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
      */

--- a/sdk/nodejs/cognito/userPoolIdentityProvider.ts
+++ b/sdk/nodejs/cognito/userPoolIdentityProvider.ts
@@ -59,9 +59,6 @@ export class UserPoolIdentityProvider extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.providerName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'providerName'");
-            }
             if ((!args || args.providerType === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'providerType'");
             }
@@ -104,7 +101,7 @@ export interface UserPoolIdentityProviderArgs {
      * Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property.
      */
     providerDetails?: any;
-    providerName: pulumi.Input<string>;
+    providerName?: pulumi.Input<string>;
     providerType: pulumi.Input<string>;
     userPoolId: pulumi.Input<string>;
 }

--- a/sdk/nodejs/configuration/storedQuery.ts
+++ b/sdk/nodejs/configuration/storedQuery.ts
@@ -61,9 +61,6 @@ export class StoredQuery extends pulumi.CustomResource {
             if ((!args || args.queryExpression === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'queryExpression'");
             }
-            if ((!args || args.queryName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'queryName'");
-            }
             resourceInputs["queryDescription"] = args ? args.queryDescription : undefined;
             resourceInputs["queryExpression"] = args ? args.queryExpression : undefined;
             resourceInputs["queryName"] = args ? args.queryName : undefined;
@@ -91,7 +88,7 @@ export class StoredQuery extends pulumi.CustomResource {
 export interface StoredQueryArgs {
     queryDescription?: pulumi.Input<string>;
     queryExpression: pulumi.Input<string>;
-    queryName: pulumi.Input<string>;
+    queryName?: pulumi.Input<string>;
     /**
      * The tags for the stored query.
      */

--- a/sdk/nodejs/connect/user.ts
+++ b/sdk/nodejs/connect/user.ts
@@ -109,9 +109,6 @@ export class User extends pulumi.CustomResource {
             if ((!args || args.securityProfileArns === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'securityProfileArns'");
             }
-            if ((!args || args.username === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'username'");
-            }
             resourceInputs["directoryUserId"] = args ? args.directoryUserId : undefined;
             resourceInputs["hierarchyGroupArn"] = args ? args.hierarchyGroupArn : undefined;
             resourceInputs["identityInfo"] = args ? args.identityInfo : undefined;
@@ -190,5 +187,5 @@ export interface UserArgs {
     /**
      * The user name for the account.
      */
-    username: pulumi.Input<string>;
+    username?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/entityresolution/idMappingWorkflow.ts
+++ b/sdk/nodejs/entityresolution/idMappingWorkflow.ts
@@ -77,9 +77,6 @@ export class IdMappingWorkflow extends pulumi.CustomResource {
             if ((!args || args.roleArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'roleArn'");
             }
-            if ((!args || args.workflowName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'workflowName'");
-            }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["idMappingTechniques"] = args ? args.idMappingTechniques : undefined;
             resourceInputs["inputSourceConfig"] = args ? args.inputSourceConfig : undefined;
@@ -125,5 +122,5 @@ export interface IdMappingWorkflowArgs {
     /**
      * The name of the IdMappingWorkflow
      */
-    workflowName: pulumi.Input<string>;
+    workflowName?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/entityresolution/matchingWorkflow.ts
+++ b/sdk/nodejs/entityresolution/matchingWorkflow.ts
@@ -77,9 +77,6 @@ export class MatchingWorkflow extends pulumi.CustomResource {
             if ((!args || args.roleArn === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'roleArn'");
             }
-            if ((!args || args.workflowName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'workflowName'");
-            }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["inputSourceConfig"] = args ? args.inputSourceConfig : undefined;
             resourceInputs["outputSourceConfig"] = args ? args.outputSourceConfig : undefined;
@@ -125,5 +122,5 @@ export interface MatchingWorkflowArgs {
     /**
      * The name of the MatchingWorkflow
      */
-    workflowName: pulumi.Input<string>;
+    workflowName?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iam/groupPolicy.ts
+++ b/sdk/nodejs/iam/groupPolicy.ts
@@ -72,9 +72,6 @@ export class GroupPolicy extends pulumi.CustomResource {
             if ((!args || args.groupName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'groupName'");
             }
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             resourceInputs["groupName"] = args ? args.groupName : undefined;
             resourceInputs["policyDocument"] = args ? args.policyDocument : undefined;
             resourceInputs["policyName"] = args ? args.policyName : undefined;
@@ -114,5 +111,5 @@ export interface GroupPolicyArgs {
      * The name of the policy document.
      *  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/iam/rolePolicy.ts
+++ b/sdk/nodejs/iam/rolePolicy.ts
@@ -70,9 +70,6 @@ export class RolePolicy extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             if ((!args || args.roleName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'roleName'");
             }
@@ -110,7 +107,7 @@ export interface RolePolicyArgs {
      * The name of the policy document.
      *  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
     /**
      * The name of the role to associate the policy with.
      *  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-

--- a/sdk/nodejs/iam/userPolicy.ts
+++ b/sdk/nodejs/iam/userPolicy.ts
@@ -69,9 +69,6 @@ export class UserPolicy extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             if ((!args || args.userName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'userName'");
             }
@@ -109,7 +106,7 @@ export interface UserPolicyArgs {
      * The name of the policy document.
      *  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
     /**
      * The name of the user to associate the policy with.
      *  This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-

--- a/sdk/nodejs/iot/fleetMetric.ts
+++ b/sdk/nodejs/iot/fleetMetric.ts
@@ -98,13 +98,10 @@ export class FleetMetric extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: FleetMetricArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args?: FleetMetricArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.metricName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'metricName'");
-            }
             resourceInputs["aggregationField"] = args ? args.aggregationField : undefined;
             resourceInputs["aggregationType"] = args ? args.aggregationType : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
@@ -162,7 +159,7 @@ export interface FleetMetricArgs {
     /**
      * The name of the fleet metric
      */
-    metricName: pulumi.Input<string>;
+    metricName?: pulumi.Input<string>;
     /**
      * The period of metric emission in seconds
      */

--- a/sdk/nodejs/lightsail/loadBalancerTlsCertificate.ts
+++ b/sdk/nodejs/lightsail/loadBalancerTlsCertificate.ts
@@ -78,9 +78,6 @@ export class LoadBalancerTlsCertificate extends pulumi.CustomResource {
             if ((!args || args.certificateDomainName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'certificateDomainName'");
             }
-            if ((!args || args.certificateName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'certificateName'");
-            }
             if ((!args || args.loadBalancerName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'loadBalancerName'");
             }
@@ -124,7 +121,7 @@ export interface LoadBalancerTlsCertificateArgs {
     /**
      * The SSL/TLS certificate name.
      */
-    certificateName: pulumi.Input<string>;
+    certificateName?: pulumi.Input<string>;
     /**
      * A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer.
      */

--- a/sdk/nodejs/location/apiKey.ts
+++ b/sdk/nodejs/location/apiKey.ts
@@ -64,9 +64,6 @@ export class ApiKey extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.keyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'keyName'");
-            }
             if ((!args || args.restrictions === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'restrictions'");
             }
@@ -111,7 +108,7 @@ export interface ApiKeyArgs {
     expireTime?: pulumi.Input<string>;
     forceDelete?: pulumi.Input<boolean>;
     forceUpdate?: pulumi.Input<boolean>;
-    keyName: pulumi.Input<string>;
+    keyName?: pulumi.Input<string>;
     noExpiry?: pulumi.Input<boolean>;
     restrictions: pulumi.Input<inputs.location.ApiKeyRestrictionsArgs>;
     /**

--- a/sdk/nodejs/location/geofenceCollection.ts
+++ b/sdk/nodejs/location/geofenceCollection.ts
@@ -58,13 +58,10 @@ export class GeofenceCollection extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: GeofenceCollectionArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args?: GeofenceCollectionArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.collectionName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'collectionName'");
-            }
             resourceInputs["collectionName"] = args ? args.collectionName : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["kmsKeyId"] = args ? args.kmsKeyId : undefined;
@@ -98,7 +95,7 @@ export class GeofenceCollection extends pulumi.CustomResource {
  * The set of arguments for constructing a GeofenceCollection resource.
  */
 export interface GeofenceCollectionArgs {
-    collectionName: pulumi.Input<string>;
+    collectionName?: pulumi.Input<string>;
     description?: pulumi.Input<string>;
     kmsKeyId?: pulumi.Input<string>;
     pricingPlan?: pulumi.Input<enums.location.GeofenceCollectionPricingPlan>;

--- a/sdk/nodejs/location/placeIndex.ts
+++ b/sdk/nodejs/location/placeIndex.ts
@@ -65,9 +65,6 @@ export class PlaceIndex extends pulumi.CustomResource {
             if ((!args || args.dataSource === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'dataSource'");
             }
-            if ((!args || args.indexName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'indexName'");
-            }
             resourceInputs["dataSource"] = args ? args.dataSource : undefined;
             resourceInputs["dataSourceConfiguration"] = args ? args.dataSourceConfiguration : undefined;
             resourceInputs["description"] = args ? args.description : undefined;
@@ -104,7 +101,7 @@ export interface PlaceIndexArgs {
     dataSource: pulumi.Input<string>;
     dataSourceConfiguration?: pulumi.Input<inputs.location.PlaceIndexDataSourceConfigurationArgs>;
     description?: pulumi.Input<string>;
-    indexName: pulumi.Input<string>;
+    indexName?: pulumi.Input<string>;
     pricingPlan?: pulumi.Input<enums.location.PlaceIndexPricingPlan>;
     /**
      * An array of key-value pairs to apply to this resource.

--- a/sdk/nodejs/location/routeCalculator.ts
+++ b/sdk/nodejs/location/routeCalculator.ts
@@ -61,9 +61,6 @@ export class RouteCalculator extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.calculatorName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'calculatorName'");
-            }
             if ((!args || args.dataSource === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'dataSource'");
             }
@@ -98,7 +95,7 @@ export class RouteCalculator extends pulumi.CustomResource {
  * The set of arguments for constructing a RouteCalculator resource.
  */
 export interface RouteCalculatorArgs {
-    calculatorName: pulumi.Input<string>;
+    calculatorName?: pulumi.Input<string>;
     dataSource: pulumi.Input<string>;
     description?: pulumi.Input<string>;
     pricingPlan?: pulumi.Input<enums.location.RouteCalculatorPricingPlan>;

--- a/sdk/nodejs/logs/accountPolicy.ts
+++ b/sdk/nodejs/logs/accountPolicy.ts
@@ -112,9 +112,6 @@ export class AccountPolicy extends pulumi.CustomResource {
             if ((!args || args.policyDocument === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policyDocument'");
             }
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             if ((!args || args.policyType === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policyType'");
             }
@@ -156,7 +153,7 @@ export interface AccountPolicyArgs {
     /**
      * The name of the account policy
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
     /**
      * Type of the policy.
      */

--- a/sdk/nodejs/logs/resourcePolicy.ts
+++ b/sdk/nodejs/logs/resourcePolicy.ts
@@ -57,9 +57,6 @@ export class ResourcePolicy extends pulumi.CustomResource {
             if ((!args || args.policyDocument === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policyDocument'");
             }
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             resourceInputs["policyDocument"] = args ? args.policyDocument : undefined;
             resourceInputs["policyName"] = args ? args.policyName : undefined;
         } else {
@@ -84,5 +81,5 @@ export interface ResourcePolicyArgs {
     /**
      * A name for resource policy
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/msk/serverlessCluster.ts
+++ b/sdk/nodejs/msk/serverlessCluster.ts
@@ -60,9 +60,6 @@ export class ServerlessCluster extends pulumi.CustomResource {
             if ((!args || args.clientAuthentication === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'clientAuthentication'");
             }
-            if ((!args || args.clusterName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'clusterName'");
-            }
             if ((!args || args.vpcConfigs === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'vpcConfigs'");
             }
@@ -90,7 +87,7 @@ export class ServerlessCluster extends pulumi.CustomResource {
  */
 export interface ServerlessClusterArgs {
     clientAuthentication: pulumi.Input<inputs.msk.ServerlessClusterClientAuthenticationArgs>;
-    clusterName: pulumi.Input<string>;
+    clusterName?: pulumi.Input<string>;
     /**
      * A key-value pair to associate with a resource.
      */

--- a/sdk/nodejs/pinpoint/inAppTemplate.ts
+++ b/sdk/nodejs/pinpoint/inAppTemplate.ts
@@ -58,13 +58,10 @@ export class InAppTemplate extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: InAppTemplateArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args?: InAppTemplateArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.templateName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'templateName'");
-            }
             resourceInputs["content"] = args ? args.content : undefined;
             resourceInputs["customConfig"] = args ? args.customConfig : undefined;
             resourceInputs["layout"] = args ? args.layout : undefined;
@@ -103,5 +100,5 @@ export interface InAppTemplateArgs {
      */
     tags?: any;
     templateDescription?: pulumi.Input<string>;
-    templateName: pulumi.Input<string>;
+    templateName?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/redshift/eventSubscription.ts
+++ b/sdk/nodejs/redshift/eventSubscription.ts
@@ -101,13 +101,10 @@ export class EventSubscription extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: EventSubscriptionArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args?: EventSubscriptionArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.subscriptionName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'subscriptionName'");
-            }
             resourceInputs["enabled"] = args ? args.enabled : undefined;
             resourceInputs["eventCategories"] = args ? args.eventCategories : undefined;
             resourceInputs["severity"] = args ? args.severity : undefined;
@@ -176,7 +173,7 @@ export interface EventSubscriptionArgs {
     /**
      * The name of the Amazon Redshift event notification subscription
      */
-    subscriptionName: pulumi.Input<string>;
+    subscriptionName?: pulumi.Input<string>;
     /**
      * An array of key-value pairs to apply to this resource.
      */

--- a/sdk/nodejs/resiliencehub/resiliencyPolicy.ts
+++ b/sdk/nodejs/resiliencehub/resiliencyPolicy.ts
@@ -74,9 +74,6 @@ export class ResiliencyPolicy extends pulumi.CustomResource {
             if ((!args || args.policy === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policy'");
             }
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             if ((!args || args.tier === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'tier'");
             }
@@ -117,7 +114,7 @@ export interface ResiliencyPolicyArgs {
     /**
      * Name of Resiliency Policy.
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
     tags?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Resiliency Policy Tier.

--- a/sdk/nodejs/ssm/resourceDataSync.ts
+++ b/sdk/nodejs/ssm/resourceDataSync.ts
@@ -218,13 +218,10 @@ export class ResourceDataSync extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: ResourceDataSyncArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args?: ResourceDataSyncArgs, opts?: pulumi.CustomResourceOptions) {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.syncName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'syncName'");
-            }
             resourceInputs["bucketName"] = args ? args.bucketName : undefined;
             resourceInputs["bucketPrefix"] = args ? args.bucketPrefix : undefined;
             resourceInputs["bucketRegion"] = args ? args.bucketRegion : undefined;
@@ -262,7 +259,7 @@ export interface ResourceDataSyncArgs {
     kmsKeyArn?: pulumi.Input<string>;
     s3Destination?: pulumi.Input<inputs.ssm.ResourceDataSyncS3DestinationArgs>;
     syncFormat?: pulumi.Input<string>;
-    syncName: pulumi.Input<string>;
+    syncName?: pulumi.Input<string>;
     syncSource?: pulumi.Input<inputs.ssm.ResourceDataSyncSyncSourceArgs>;
     syncType?: pulumi.Input<string>;
 }

--- a/sdk/nodejs/xray/resourcePolicy.ts
+++ b/sdk/nodejs/xray/resourcePolicy.ts
@@ -89,9 +89,6 @@ export class ResourcePolicy extends pulumi.CustomResource {
             if ((!args || args.policyDocument === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'policyDocument'");
             }
-            if ((!args || args.policyName === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'policyName'");
-            }
             resourceInputs["bypassPolicyLockoutCheck"] = args ? args.bypassPolicyLockoutCheck : undefined;
             resourceInputs["policyDocument"] = args ? args.policyDocument : undefined;
             resourceInputs["policyName"] = args ? args.policyName : undefined;
@@ -122,5 +119,5 @@ export interface ResourcePolicyArgs {
     /**
      * The name of the resource policy. Must be unique within a specific AWS account.
      */
-    policyName: pulumi.Input<string>;
+    policyName?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_aws_native/applicationautoscaling/scaling_policy.py
+++ b/sdk/python/pulumi_aws_native/applicationautoscaling/scaling_policy.py
@@ -16,8 +16,8 @@ __all__ = ['ScalingPolicyArgs', 'ScalingPolicy']
 @pulumi.input_type
 class ScalingPolicyArgs:
     def __init__(__self__, *,
-                 policy_name: pulumi.Input[str],
                  policy_type: pulumi.Input[str],
+                 policy_name: Optional[pulumi.Input[str]] = None,
                  resource_id: Optional[pulumi.Input[str]] = None,
                  scalable_dimension: Optional[pulumi.Input[str]] = None,
                  scaling_target_id: Optional[pulumi.Input[str]] = None,
@@ -26,9 +26,6 @@ class ScalingPolicyArgs:
                  target_tracking_scaling_policy_configuration: Optional[pulumi.Input['ScalingPolicyTargetTrackingScalingPolicyConfigurationArgs']] = None):
         """
         The set of arguments for constructing a ScalingPolicy resource.
-        :param pulumi.Input[str] policy_name: The name of the scaling policy.
-               
-               Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
         :param pulumi.Input[str] policy_type: The scaling policy type.
                
                The following policy types are supported:
@@ -36,6 +33,9 @@ class ScalingPolicyArgs:
                TargetTrackingScaling Not supported for Amazon EMR
                
                StepScaling Not supported for DynamoDB, Amazon Comprehend, Lambda, Amazon Keyspaces, Amazon MSK, Amazon ElastiCache, or Neptune.
+        :param pulumi.Input[str] policy_name: The name of the scaling policy.
+               
+               Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
         :param pulumi.Input[str] resource_id: The identifier of the resource associated with the scaling policy. This string consists of the resource type and unique identifier.
         :param pulumi.Input[str] scalable_dimension: The scalable dimension. This string consists of the service namespace, resource type, and scaling property.
         :param pulumi.Input[str] scaling_target_id: The CloudFormation-generated ID of an Application Auto Scaling scalable target. For more information about the ID, see the Return Value section of the AWS::ApplicationAutoScaling::ScalableTarget resource.
@@ -43,8 +43,9 @@ class ScalingPolicyArgs:
         :param pulumi.Input['ScalingPolicyStepScalingPolicyConfigurationArgs'] step_scaling_policy_configuration: A step scaling policy.
         :param pulumi.Input['ScalingPolicyTargetTrackingScalingPolicyConfigurationArgs'] target_tracking_scaling_policy_configuration: A target tracking scaling policy.
         """
-        pulumi.set(__self__, "policy_name", policy_name)
         pulumi.set(__self__, "policy_type", policy_type)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
         if resource_id is not None:
             pulumi.set(__self__, "resource_id", resource_id)
         if scalable_dimension is not None:
@@ -57,20 +58,6 @@ class ScalingPolicyArgs:
             pulumi.set(__self__, "step_scaling_policy_configuration", step_scaling_policy_configuration)
         if target_tracking_scaling_policy_configuration is not None:
             pulumi.set(__self__, "target_tracking_scaling_policy_configuration", target_tracking_scaling_policy_configuration)
-
-    @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the scaling policy.
-
-        Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter(name="policyType")
@@ -89,6 +76,20 @@ class ScalingPolicyArgs:
     @policy_type.setter
     def policy_type(self, value: pulumi.Input[str]):
         pulumi.set(self, "policy_type", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the scaling policy.
+
+        Updates to the name of a target tracking scaling policy are not supported, unless you also update the metric used for scaling. To change only a target tracking scaling policy's name, first delete the policy by removing the existing AWS::ApplicationAutoScaling::ScalingPolicy resource from the template and updating the stack. Then, recreate the resource with the same settings and a different name.
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter(name="resourceId")
@@ -240,8 +241,6 @@ class ScalingPolicy(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ScalingPolicyArgs.__new__(ScalingPolicyArgs)
 
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
             if policy_type is None and not opts.urn:
                 raise TypeError("Missing required property 'policy_type'")

--- a/sdk/python/pulumi_aws_native/athena/prepared_statement.py
+++ b/sdk/python/pulumi_aws_native/athena/prepared_statement.py
@@ -15,21 +15,22 @@ __all__ = ['PreparedStatementArgs', 'PreparedStatement']
 class PreparedStatementArgs:
     def __init__(__self__, *,
                  query_statement: pulumi.Input[str],
-                 statement_name: pulumi.Input[str],
                  work_group: pulumi.Input[str],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 statement_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a PreparedStatement resource.
         :param pulumi.Input[str] query_statement: The query string for the prepared statement.
-        :param pulumi.Input[str] statement_name: The name of the prepared statement.
         :param pulumi.Input[str] work_group: The name of the workgroup to which the prepared statement belongs.
         :param pulumi.Input[str] description: The description of the prepared statement.
+        :param pulumi.Input[str] statement_name: The name of the prepared statement.
         """
         pulumi.set(__self__, "query_statement", query_statement)
-        pulumi.set(__self__, "statement_name", statement_name)
         pulumi.set(__self__, "work_group", work_group)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if statement_name is not None:
+            pulumi.set(__self__, "statement_name", statement_name)
 
     @property
     @pulumi.getter(name="queryStatement")
@@ -42,18 +43,6 @@ class PreparedStatementArgs:
     @query_statement.setter
     def query_statement(self, value: pulumi.Input[str]):
         pulumi.set(self, "query_statement", value)
-
-    @property
-    @pulumi.getter(name="statementName")
-    def statement_name(self) -> pulumi.Input[str]:
-        """
-        The name of the prepared statement.
-        """
-        return pulumi.get(self, "statement_name")
-
-    @statement_name.setter
-    def statement_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "statement_name", value)
 
     @property
     @pulumi.getter(name="workGroup")
@@ -78,6 +67,18 @@ class PreparedStatementArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="statementName")
+    def statement_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the prepared statement.
+        """
+        return pulumi.get(self, "statement_name")
+
+    @statement_name.setter
+    def statement_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "statement_name", value)
 
 
 class PreparedStatement(pulumi.CustomResource):
@@ -141,8 +142,6 @@ class PreparedStatement(pulumi.CustomResource):
             if query_statement is None and not opts.urn:
                 raise TypeError("Missing required property 'query_statement'")
             __props__.__dict__["query_statement"] = query_statement
-            if statement_name is None and not opts.urn:
-                raise TypeError("Missing required property 'statement_name'")
             __props__.__dict__["statement_name"] = statement_name
             if work_group is None and not opts.urn:
                 raise TypeError("Missing required property 'work_group'")

--- a/sdk/python/pulumi_aws_native/ce/anomaly_monitor.py
+++ b/sdk/python/pulumi_aws_native/ce/anomaly_monitor.py
@@ -17,37 +17,26 @@ __all__ = ['AnomalyMonitorArgs', 'AnomalyMonitor']
 @pulumi.input_type
 class AnomalyMonitorArgs:
     def __init__(__self__, *,
-                 monitor_name: pulumi.Input[str],
                  monitor_type: pulumi.Input['AnomalyMonitorMonitorType'],
                  monitor_dimension: Optional[pulumi.Input['AnomalyMonitorMonitorDimension']] = None,
+                 monitor_name: Optional[pulumi.Input[str]] = None,
                  monitor_specification: Optional[pulumi.Input[str]] = None,
                  resource_tags: Optional[pulumi.Input[Sequence[pulumi.Input['AnomalyMonitorResourceTagArgs']]]] = None):
         """
         The set of arguments for constructing a AnomalyMonitor resource.
-        :param pulumi.Input[str] monitor_name: The name of the monitor.
         :param pulumi.Input['AnomalyMonitorMonitorDimension'] monitor_dimension: The dimensions to evaluate
+        :param pulumi.Input[str] monitor_name: The name of the monitor.
         :param pulumi.Input[Sequence[pulumi.Input['AnomalyMonitorResourceTagArgs']]] resource_tags: Tags to assign to monitor.
         """
-        pulumi.set(__self__, "monitor_name", monitor_name)
         pulumi.set(__self__, "monitor_type", monitor_type)
         if monitor_dimension is not None:
             pulumi.set(__self__, "monitor_dimension", monitor_dimension)
+        if monitor_name is not None:
+            pulumi.set(__self__, "monitor_name", monitor_name)
         if monitor_specification is not None:
             pulumi.set(__self__, "monitor_specification", monitor_specification)
         if resource_tags is not None:
             pulumi.set(__self__, "resource_tags", resource_tags)
-
-    @property
-    @pulumi.getter(name="monitorName")
-    def monitor_name(self) -> pulumi.Input[str]:
-        """
-        The name of the monitor.
-        """
-        return pulumi.get(self, "monitor_name")
-
-    @monitor_name.setter
-    def monitor_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "monitor_name", value)
 
     @property
     @pulumi.getter(name="monitorType")
@@ -69,6 +58,18 @@ class AnomalyMonitorArgs:
     @monitor_dimension.setter
     def monitor_dimension(self, value: Optional[pulumi.Input['AnomalyMonitorMonitorDimension']]):
         pulumi.set(self, "monitor_dimension", value)
+
+    @property
+    @pulumi.getter(name="monitorName")
+    def monitor_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the monitor.
+        """
+        return pulumi.get(self, "monitor_name")
+
+    @monitor_name.setter
+    def monitor_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "monitor_name", value)
 
     @property
     @pulumi.getter(name="monitorSpecification")
@@ -571,8 +572,6 @@ class AnomalyMonitor(pulumi.CustomResource):
             __props__ = AnomalyMonitorArgs.__new__(AnomalyMonitorArgs)
 
             __props__.__dict__["monitor_dimension"] = monitor_dimension
-            if monitor_name is None and not opts.urn:
-                raise TypeError("Missing required property 'monitor_name'")
             __props__.__dict__["monitor_name"] = monitor_name
             __props__.__dict__["monitor_specification"] = monitor_specification
             if monitor_type is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/ce/anomaly_subscription.py
+++ b/sdk/python/pulumi_aws_native/ce/anomaly_subscription.py
@@ -20,8 +20,8 @@ class AnomalySubscriptionArgs:
                  frequency: pulumi.Input['AnomalySubscriptionFrequency'],
                  monitor_arn_list: pulumi.Input[Sequence[pulumi.Input[str]]],
                  subscribers: pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionSubscriberArgs']]],
-                 subscription_name: pulumi.Input[str],
                  resource_tags: Optional[pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionResourceTagArgs']]]] = None,
+                 subscription_name: Optional[pulumi.Input[str]] = None,
                  threshold: Optional[pulumi.Input[float]] = None,
                  threshold_expression: Optional[pulumi.Input[str]] = None):
         """
@@ -29,17 +29,18 @@ class AnomalySubscriptionArgs:
         :param pulumi.Input['AnomalySubscriptionFrequency'] frequency: The frequency at which anomaly reports are sent over email. 
         :param pulumi.Input[Sequence[pulumi.Input[str]]] monitor_arn_list: A list of cost anomaly monitors.
         :param pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionSubscriberArgs']]] subscribers: A list of subscriber
-        :param pulumi.Input[str] subscription_name: The name of the subscription.
         :param pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionResourceTagArgs']]] resource_tags: Tags to assign to subscription.
+        :param pulumi.Input[str] subscription_name: The name of the subscription.
         :param pulumi.Input[float] threshold: The dollar value that triggers a notification if the threshold is exceeded. 
         :param pulumi.Input[str] threshold_expression: An Expression object in JSON String format used to specify the anomalies that you want to generate alerts for.
         """
         pulumi.set(__self__, "frequency", frequency)
         pulumi.set(__self__, "monitor_arn_list", monitor_arn_list)
         pulumi.set(__self__, "subscribers", subscribers)
-        pulumi.set(__self__, "subscription_name", subscription_name)
         if resource_tags is not None:
             pulumi.set(__self__, "resource_tags", resource_tags)
+        if subscription_name is not None:
+            pulumi.set(__self__, "subscription_name", subscription_name)
         if threshold is not None:
             pulumi.set(__self__, "threshold", threshold)
         if threshold_expression is not None:
@@ -82,18 +83,6 @@ class AnomalySubscriptionArgs:
         pulumi.set(self, "subscribers", value)
 
     @property
-    @pulumi.getter(name="subscriptionName")
-    def subscription_name(self) -> pulumi.Input[str]:
-        """
-        The name of the subscription.
-        """
-        return pulumi.get(self, "subscription_name")
-
-    @subscription_name.setter
-    def subscription_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "subscription_name", value)
-
-    @property
     @pulumi.getter(name="resourceTags")
     def resource_tags(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionResourceTagArgs']]]]:
         """
@@ -104,6 +93,18 @@ class AnomalySubscriptionArgs:
     @resource_tags.setter
     def resource_tags(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['AnomalySubscriptionResourceTagArgs']]]]):
         pulumi.set(self, "resource_tags", value)
+
+    @property
+    @pulumi.getter(name="subscriptionName")
+    def subscription_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the subscription.
+        """
+        return pulumi.get(self, "subscription_name")
+
+    @subscription_name.setter
+    def subscription_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "subscription_name", value)
 
     @property
     @pulumi.getter
@@ -414,8 +415,6 @@ class AnomalySubscription(pulumi.CustomResource):
             if subscribers is None and not opts.urn:
                 raise TypeError("Missing required property 'subscribers'")
             __props__.__dict__["subscribers"] = subscribers
-            if subscription_name is None and not opts.urn:
-                raise TypeError("Missing required property 'subscription_name'")
             __props__.__dict__["subscription_name"] = subscription_name
             __props__.__dict__["threshold"] = threshold
             __props__.__dict__["threshold_expression"] = threshold_expression

--- a/sdk/python/pulumi_aws_native/chatbot/microsoft_teams_channel_configuration.py
+++ b/sdk/python/pulumi_aws_native/chatbot/microsoft_teams_channel_configuration.py
@@ -14,32 +14,33 @@ __all__ = ['MicrosoftTeamsChannelConfigurationArgs', 'MicrosoftTeamsChannelConfi
 @pulumi.input_type
 class MicrosoftTeamsChannelConfigurationArgs:
     def __init__(__self__, *,
-                 configuration_name: pulumi.Input[str],
                  iam_role_arn: pulumi.Input[str],
                  team_id: pulumi.Input[str],
                  teams_channel_id: pulumi.Input[str],
                  teams_tenant_id: pulumi.Input[str],
+                 configuration_name: Optional[pulumi.Input[str]] = None,
                  guardrail_policies: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  logging_level: Optional[pulumi.Input[str]] = None,
                  sns_topic_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  user_role_required: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a MicrosoftTeamsChannelConfiguration resource.
-        :param pulumi.Input[str] configuration_name: The name of the configuration
         :param pulumi.Input[str] iam_role_arn: The ARN of the IAM role that defines the permissions for AWS Chatbot
         :param pulumi.Input[str] team_id: The id of the Microsoft Teams team
         :param pulumi.Input[str] teams_channel_id: The id of the Microsoft Teams channel
         :param pulumi.Input[str] teams_tenant_id: The id of the Microsoft Teams tenant
+        :param pulumi.Input[str] configuration_name: The name of the configuration
         :param pulumi.Input[Sequence[pulumi.Input[str]]] guardrail_policies: The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
         :param pulumi.Input[str] logging_level: Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs
         :param pulumi.Input[Sequence[pulumi.Input[str]]] sns_topic_arns: ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications.
         :param pulumi.Input[bool] user_role_required: Enables use of a user role requirement in your chat configuration
         """
-        pulumi.set(__self__, "configuration_name", configuration_name)
         pulumi.set(__self__, "iam_role_arn", iam_role_arn)
         pulumi.set(__self__, "team_id", team_id)
         pulumi.set(__self__, "teams_channel_id", teams_channel_id)
         pulumi.set(__self__, "teams_tenant_id", teams_tenant_id)
+        if configuration_name is not None:
+            pulumi.set(__self__, "configuration_name", configuration_name)
         if guardrail_policies is not None:
             pulumi.set(__self__, "guardrail_policies", guardrail_policies)
         if logging_level is not None:
@@ -48,18 +49,6 @@ class MicrosoftTeamsChannelConfigurationArgs:
             pulumi.set(__self__, "sns_topic_arns", sns_topic_arns)
         if user_role_required is not None:
             pulumi.set(__self__, "user_role_required", user_role_required)
-
-    @property
-    @pulumi.getter(name="configurationName")
-    def configuration_name(self) -> pulumi.Input[str]:
-        """
-        The name of the configuration
-        """
-        return pulumi.get(self, "configuration_name")
-
-    @configuration_name.setter
-    def configuration_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "configuration_name", value)
 
     @property
     @pulumi.getter(name="iamRoleArn")
@@ -108,6 +97,18 @@ class MicrosoftTeamsChannelConfigurationArgs:
     @teams_tenant_id.setter
     def teams_tenant_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "teams_tenant_id", value)
+
+    @property
+    @pulumi.getter(name="configurationName")
+    def configuration_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the configuration
+        """
+        return pulumi.get(self, "configuration_name")
+
+    @configuration_name.setter
+    def configuration_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "configuration_name", value)
 
     @property
     @pulumi.getter(name="guardrailPolicies")
@@ -230,8 +231,6 @@ class MicrosoftTeamsChannelConfiguration(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = MicrosoftTeamsChannelConfigurationArgs.__new__(MicrosoftTeamsChannelConfigurationArgs)
 
-            if configuration_name is None and not opts.urn:
-                raise TypeError("Missing required property 'configuration_name'")
             __props__.__dict__["configuration_name"] = configuration_name
             __props__.__dict__["guardrail_policies"] = guardrail_policies
             if iam_role_arn is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/chatbot/slack_channel_configuration.py
+++ b/sdk/python/pulumi_aws_native/chatbot/slack_channel_configuration.py
@@ -14,29 +14,30 @@ __all__ = ['SlackChannelConfigurationArgs', 'SlackChannelConfiguration']
 @pulumi.input_type
 class SlackChannelConfigurationArgs:
     def __init__(__self__, *,
-                 configuration_name: pulumi.Input[str],
                  iam_role_arn: pulumi.Input[str],
                  slack_channel_id: pulumi.Input[str],
                  slack_workspace_id: pulumi.Input[str],
+                 configuration_name: Optional[pulumi.Input[str]] = None,
                  guardrail_policies: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  logging_level: Optional[pulumi.Input[str]] = None,
                  sns_topic_arns: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  user_role_required: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a SlackChannelConfiguration resource.
-        :param pulumi.Input[str] configuration_name: The name of the configuration
         :param pulumi.Input[str] iam_role_arn: The ARN of the IAM role that defines the permissions for AWS Chatbot
         :param pulumi.Input[str] slack_channel_id: The id of the Slack channel
         :param pulumi.Input[str] slack_workspace_id: The id of the Slack workspace
+        :param pulumi.Input[str] configuration_name: The name of the configuration
         :param pulumi.Input[Sequence[pulumi.Input[str]]] guardrail_policies: The list of IAM policy ARNs that are applied as channel guardrails. The AWS managed 'AdministratorAccess' policy is applied as a default if this is not set.
         :param pulumi.Input[str] logging_level: Specifies the logging level for this configuration:ERROR,INFO or NONE. This property affects the log entries pushed to Amazon CloudWatch logs
         :param pulumi.Input[Sequence[pulumi.Input[str]]] sns_topic_arns: ARNs of SNS topics which delivers notifications to AWS Chatbot, for example CloudWatch alarm notifications.
         :param pulumi.Input[bool] user_role_required: Enables use of a user role requirement in your chat configuration
         """
-        pulumi.set(__self__, "configuration_name", configuration_name)
         pulumi.set(__self__, "iam_role_arn", iam_role_arn)
         pulumi.set(__self__, "slack_channel_id", slack_channel_id)
         pulumi.set(__self__, "slack_workspace_id", slack_workspace_id)
+        if configuration_name is not None:
+            pulumi.set(__self__, "configuration_name", configuration_name)
         if guardrail_policies is not None:
             pulumi.set(__self__, "guardrail_policies", guardrail_policies)
         if logging_level is not None:
@@ -45,18 +46,6 @@ class SlackChannelConfigurationArgs:
             pulumi.set(__self__, "sns_topic_arns", sns_topic_arns)
         if user_role_required is not None:
             pulumi.set(__self__, "user_role_required", user_role_required)
-
-    @property
-    @pulumi.getter(name="configurationName")
-    def configuration_name(self) -> pulumi.Input[str]:
-        """
-        The name of the configuration
-        """
-        return pulumi.get(self, "configuration_name")
-
-    @configuration_name.setter
-    def configuration_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "configuration_name", value)
 
     @property
     @pulumi.getter(name="iamRoleArn")
@@ -93,6 +82,18 @@ class SlackChannelConfigurationArgs:
     @slack_workspace_id.setter
     def slack_workspace_id(self, value: pulumi.Input[str]):
         pulumi.set(self, "slack_workspace_id", value)
+
+    @property
+    @pulumi.getter(name="configurationName")
+    def configuration_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the configuration
+        """
+        return pulumi.get(self, "configuration_name")
+
+    @configuration_name.setter
+    def configuration_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "configuration_name", value)
 
     @property
     @pulumi.getter(name="guardrailPolicies")
@@ -212,8 +213,6 @@ class SlackChannelConfiguration(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = SlackChannelConfigurationArgs.__new__(SlackChannelConfigurationArgs)
 
-            if configuration_name is None and not opts.urn:
-                raise TypeError("Missing required property 'configuration_name'")
             __props__.__dict__["configuration_name"] = configuration_name
             __props__.__dict__["guardrail_policies"] = guardrail_policies
             if iam_role_arn is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/cognito/user_pool_identity_provider.py
+++ b/sdk/python/pulumi_aws_native/cognito/user_pool_identity_provider.py
@@ -14,18 +14,17 @@ __all__ = ['UserPoolIdentityProviderArgs', 'UserPoolIdentityProvider']
 @pulumi.input_type
 class UserPoolIdentityProviderArgs:
     def __init__(__self__, *,
-                 provider_name: pulumi.Input[str],
                  provider_type: pulumi.Input[str],
                  user_pool_id: pulumi.Input[str],
                  attribute_mapping: Optional[Any] = None,
                  idp_identifiers: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 provider_details: Optional[Any] = None):
+                 provider_details: Optional[Any] = None,
+                 provider_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a UserPoolIdentityProvider resource.
         :param Any attribute_mapping: Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property.
         :param Any provider_details: Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Cognito::UserPoolIdentityProvider` for more information about the expected schema for this property.
         """
-        pulumi.set(__self__, "provider_name", provider_name)
         pulumi.set(__self__, "provider_type", provider_type)
         pulumi.set(__self__, "user_pool_id", user_pool_id)
         if attribute_mapping is not None:
@@ -34,15 +33,8 @@ class UserPoolIdentityProviderArgs:
             pulumi.set(__self__, "idp_identifiers", idp_identifiers)
         if provider_details is not None:
             pulumi.set(__self__, "provider_details", provider_details)
-
-    @property
-    @pulumi.getter(name="providerName")
-    def provider_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "provider_name")
-
-    @provider_name.setter
-    def provider_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "provider_name", value)
+        if provider_name is not None:
+            pulumi.set(__self__, "provider_name", provider_name)
 
     @property
     @pulumi.getter(name="providerType")
@@ -94,6 +86,15 @@ class UserPoolIdentityProviderArgs:
     @provider_details.setter
     def provider_details(self, value: Optional[Any]):
         pulumi.set(self, "provider_details", value)
+
+    @property
+    @pulumi.getter(name="providerName")
+    def provider_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "provider_name")
+
+    @provider_name.setter
+    def provider_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "provider_name", value)
 
 
 class UserPoolIdentityProvider(pulumi.CustomResource):
@@ -158,8 +159,6 @@ class UserPoolIdentityProvider(pulumi.CustomResource):
             __props__.__dict__["attribute_mapping"] = attribute_mapping
             __props__.__dict__["idp_identifiers"] = idp_identifiers
             __props__.__dict__["provider_details"] = provider_details
-            if provider_name is None and not opts.urn:
-                raise TypeError("Missing required property 'provider_name'")
             __props__.__dict__["provider_name"] = provider_name
             if provider_type is None and not opts.urn:
                 raise TypeError("Missing required property 'provider_type'")

--- a/sdk/python/pulumi_aws_native/configuration/stored_query.py
+++ b/sdk/python/pulumi_aws_native/configuration/stored_query.py
@@ -17,17 +17,18 @@ __all__ = ['StoredQueryArgs', 'StoredQuery']
 class StoredQueryArgs:
     def __init__(__self__, *,
                  query_expression: pulumi.Input[str],
-                 query_name: pulumi.Input[str],
                  query_description: Optional[pulumi.Input[str]] = None,
+                 query_name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
         """
         The set of arguments for constructing a StoredQuery resource.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: The tags for the stored query.
         """
         pulumi.set(__self__, "query_expression", query_expression)
-        pulumi.set(__self__, "query_name", query_name)
         if query_description is not None:
             pulumi.set(__self__, "query_description", query_description)
+        if query_name is not None:
+            pulumi.set(__self__, "query_name", query_name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -41,15 +42,6 @@ class StoredQueryArgs:
         pulumi.set(self, "query_expression", value)
 
     @property
-    @pulumi.getter(name="queryName")
-    def query_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "query_name")
-
-    @query_name.setter
-    def query_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "query_name", value)
-
-    @property
     @pulumi.getter(name="queryDescription")
     def query_description(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "query_description")
@@ -57,6 +49,15 @@ class StoredQueryArgs:
     @query_description.setter
     def query_description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "query_description", value)
+
+    @property
+    @pulumi.getter(name="queryName")
+    def query_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "query_name")
+
+    @query_name.setter
+    def query_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "query_name", value)
 
     @property
     @pulumi.getter
@@ -129,8 +130,6 @@ class StoredQuery(pulumi.CustomResource):
             if query_expression is None and not opts.urn:
                 raise TypeError("Missing required property 'query_expression'")
             __props__.__dict__["query_expression"] = query_expression
-            if query_name is None and not opts.urn:
-                raise TypeError("Missing required property 'query_name'")
             __props__.__dict__["query_name"] = query_name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["query_arn"] = None

--- a/sdk/python/pulumi_aws_native/connect/user.py
+++ b/sdk/python/pulumi_aws_native/connect/user.py
@@ -23,32 +23,31 @@ class UserArgs:
                  phone_config: pulumi.Input['UserPhoneConfigArgs'],
                  routing_profile_arn: pulumi.Input[str],
                  security_profile_arns: pulumi.Input[Sequence[pulumi.Input[str]]],
-                 username: pulumi.Input[str],
                  directory_user_id: Optional[pulumi.Input[str]] = None,
                  hierarchy_group_arn: Optional[pulumi.Input[str]] = None,
                  identity_info: Optional[pulumi.Input['UserIdentityInfoArgs']] = None,
                  password: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None,
-                 user_proficiencies: Optional[pulumi.Input[Sequence[pulumi.Input['UserProficiencyArgs']]]] = None):
+                 user_proficiencies: Optional[pulumi.Input[Sequence[pulumi.Input['UserProficiencyArgs']]]] = None,
+                 username: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a User resource.
         :param pulumi.Input[str] instance_arn: The identifier of the Amazon Connect instance.
         :param pulumi.Input['UserPhoneConfigArgs'] phone_config: The phone settings for the user.
         :param pulumi.Input[str] routing_profile_arn: The identifier of the routing profile for the user.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] security_profile_arns: One or more security profile arns for the user
-        :param pulumi.Input[str] username: The user name for the account.
         :param pulumi.Input[str] directory_user_id: The identifier of the user account in the directory used for identity management.
         :param pulumi.Input[str] hierarchy_group_arn: The identifier of the hierarchy group for the user.
         :param pulumi.Input['UserIdentityInfoArgs'] identity_info: The information about the identity of the user.
         :param pulumi.Input[str] password: The password for the user account. A password is required if you are using Amazon Connect for identity management. Otherwise, it is an error to include a password.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: One or more tags.
         :param pulumi.Input[Sequence[pulumi.Input['UserProficiencyArgs']]] user_proficiencies: One or more predefined attributes assigned to a user, with a level that indicates how skilled they are.
+        :param pulumi.Input[str] username: The user name for the account.
         """
         pulumi.set(__self__, "instance_arn", instance_arn)
         pulumi.set(__self__, "phone_config", phone_config)
         pulumi.set(__self__, "routing_profile_arn", routing_profile_arn)
         pulumi.set(__self__, "security_profile_arns", security_profile_arns)
-        pulumi.set(__self__, "username", username)
         if directory_user_id is not None:
             pulumi.set(__self__, "directory_user_id", directory_user_id)
         if hierarchy_group_arn is not None:
@@ -61,6 +60,8 @@ class UserArgs:
             pulumi.set(__self__, "tags", tags)
         if user_proficiencies is not None:
             pulumi.set(__self__, "user_proficiencies", user_proficiencies)
+        if username is not None:
+            pulumi.set(__self__, "username", username)
 
     @property
     @pulumi.getter(name="instanceArn")
@@ -109,18 +110,6 @@ class UserArgs:
     @security_profile_arns.setter
     def security_profile_arns(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "security_profile_arns", value)
-
-    @property
-    @pulumi.getter
-    def username(self) -> pulumi.Input[str]:
-        """
-        The user name for the account.
-        """
-        return pulumi.get(self, "username")
-
-    @username.setter
-    def username(self, value: pulumi.Input[str]):
-        pulumi.set(self, "username", value)
 
     @property
     @pulumi.getter(name="directoryUserId")
@@ -193,6 +182,18 @@ class UserArgs:
     @user_proficiencies.setter
     def user_proficiencies(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['UserProficiencyArgs']]]]):
         pulumi.set(self, "user_proficiencies", value)
+
+    @property
+    @pulumi.getter
+    def username(self) -> Optional[pulumi.Input[str]]:
+        """
+        The user name for the account.
+        """
+        return pulumi.get(self, "username")
+
+    @username.setter
+    def username(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "username", value)
 
 
 class User(pulumi.CustomResource):
@@ -291,8 +292,6 @@ class User(pulumi.CustomResource):
             __props__.__dict__["security_profile_arns"] = security_profile_arns
             __props__.__dict__["tags"] = tags
             __props__.__dict__["user_proficiencies"] = user_proficiencies
-            if username is None and not opts.urn:
-                raise TypeError("Missing required property 'username'")
             __props__.__dict__["username"] = username
             __props__.__dict__["user_arn"] = None
         super(User, __self__).__init__(

--- a/sdk/python/pulumi_aws_native/entityresolution/id_mapping_workflow.py
+++ b/sdk/python/pulumi_aws_native/entityresolution/id_mapping_workflow.py
@@ -23,23 +23,24 @@ class IdMappingWorkflowArgs:
                  input_source_config: pulumi.Input[Sequence[pulumi.Input['IdMappingWorkflowInputSourceArgs']]],
                  output_source_config: pulumi.Input[Sequence[pulumi.Input['IdMappingWorkflowOutputSourceArgs']]],
                  role_arn: pulumi.Input[str],
-                 workflow_name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
-                 tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
+                 tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None,
+                 workflow_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a IdMappingWorkflow resource.
-        :param pulumi.Input[str] workflow_name: The name of the IdMappingWorkflow
         :param pulumi.Input[str] description: The description of the IdMappingWorkflow
+        :param pulumi.Input[str] workflow_name: The name of the IdMappingWorkflow
         """
         pulumi.set(__self__, "id_mapping_techniques", id_mapping_techniques)
         pulumi.set(__self__, "input_source_config", input_source_config)
         pulumi.set(__self__, "output_source_config", output_source_config)
         pulumi.set(__self__, "role_arn", role_arn)
-        pulumi.set(__self__, "workflow_name", workflow_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if workflow_name is not None:
+            pulumi.set(__self__, "workflow_name", workflow_name)
 
     @property
     @pulumi.getter(name="idMappingTechniques")
@@ -78,18 +79,6 @@ class IdMappingWorkflowArgs:
         pulumi.set(self, "role_arn", value)
 
     @property
-    @pulumi.getter(name="workflowName")
-    def workflow_name(self) -> pulumi.Input[str]:
-        """
-        The name of the IdMappingWorkflow
-        """
-        return pulumi.get(self, "workflow_name")
-
-    @workflow_name.setter
-    def workflow_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "workflow_name", value)
-
-    @property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[str]]:
         """
@@ -109,6 +98,18 @@ class IdMappingWorkflowArgs:
     @tags.setter
     def tags(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]]):
         pulumi.set(self, "tags", value)
+
+    @property
+    @pulumi.getter(name="workflowName")
+    def workflow_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the IdMappingWorkflow
+        """
+        return pulumi.get(self, "workflow_name")
+
+    @workflow_name.setter
+    def workflow_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "workflow_name", value)
 
 
 class IdMappingWorkflow(pulumi.CustomResource):
@@ -186,8 +187,6 @@ class IdMappingWorkflow(pulumi.CustomResource):
                 raise TypeError("Missing required property 'role_arn'")
             __props__.__dict__["role_arn"] = role_arn
             __props__.__dict__["tags"] = tags
-            if workflow_name is None and not opts.urn:
-                raise TypeError("Missing required property 'workflow_name'")
             __props__.__dict__["workflow_name"] = workflow_name
             __props__.__dict__["created_at"] = None
             __props__.__dict__["updated_at"] = None

--- a/sdk/python/pulumi_aws_native/entityresolution/matching_workflow.py
+++ b/sdk/python/pulumi_aws_native/entityresolution/matching_workflow.py
@@ -23,23 +23,24 @@ class MatchingWorkflowArgs:
                  output_source_config: pulumi.Input[Sequence[pulumi.Input['MatchingWorkflowOutputSourceArgs']]],
                  resolution_techniques: pulumi.Input['MatchingWorkflowResolutionTechniquesArgs'],
                  role_arn: pulumi.Input[str],
-                 workflow_name: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
-                 tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
+                 tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None,
+                 workflow_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a MatchingWorkflow resource.
-        :param pulumi.Input[str] workflow_name: The name of the MatchingWorkflow
         :param pulumi.Input[str] description: The description of the MatchingWorkflow
+        :param pulumi.Input[str] workflow_name: The name of the MatchingWorkflow
         """
         pulumi.set(__self__, "input_source_config", input_source_config)
         pulumi.set(__self__, "output_source_config", output_source_config)
         pulumi.set(__self__, "resolution_techniques", resolution_techniques)
         pulumi.set(__self__, "role_arn", role_arn)
-        pulumi.set(__self__, "workflow_name", workflow_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
+        if workflow_name is not None:
+            pulumi.set(__self__, "workflow_name", workflow_name)
 
     @property
     @pulumi.getter(name="inputSourceConfig")
@@ -78,18 +79,6 @@ class MatchingWorkflowArgs:
         pulumi.set(self, "role_arn", value)
 
     @property
-    @pulumi.getter(name="workflowName")
-    def workflow_name(self) -> pulumi.Input[str]:
-        """
-        The name of the MatchingWorkflow
-        """
-        return pulumi.get(self, "workflow_name")
-
-    @workflow_name.setter
-    def workflow_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "workflow_name", value)
-
-    @property
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[str]]:
         """
@@ -109,6 +98,18 @@ class MatchingWorkflowArgs:
     @tags.setter
     def tags(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]]):
         pulumi.set(self, "tags", value)
+
+    @property
+    @pulumi.getter(name="workflowName")
+    def workflow_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the MatchingWorkflow
+        """
+        return pulumi.get(self, "workflow_name")
+
+    @workflow_name.setter
+    def workflow_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "workflow_name", value)
 
 
 class MatchingWorkflow(pulumi.CustomResource):
@@ -186,8 +187,6 @@ class MatchingWorkflow(pulumi.CustomResource):
                 raise TypeError("Missing required property 'role_arn'")
             __props__.__dict__["role_arn"] = role_arn
             __props__.__dict__["tags"] = tags
-            if workflow_name is None and not opts.urn:
-                raise TypeError("Missing required property 'workflow_name'")
             __props__.__dict__["workflow_name"] = workflow_name
             __props__.__dict__["created_at"] = None
             __props__.__dict__["updated_at"] = None

--- a/sdk/python/pulumi_aws_native/iam/group_policy.py
+++ b/sdk/python/pulumi_aws_native/iam/group_policy.py
@@ -15,14 +15,12 @@ __all__ = ['GroupPolicyInitArgs', 'GroupPolicy']
 class GroupPolicyInitArgs:
     def __init__(__self__, *,
                  group_name: pulumi.Input[str],
-                 policy_name: pulumi.Input[str],
-                 policy_document: Optional[Any] = None):
+                 policy_document: Optional[Any] = None,
+                 policy_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a GroupPolicy resource.
         :param pulumi.Input[str] group_name: The name of the group to associate the policy with.
                 This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-.
-        :param pulumi.Input[str] policy_name: The name of the policy document.
-                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         :param Any policy_document: The policy document.
                 You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM.
                 The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following:
@@ -31,11 +29,14 @@ class GroupPolicyInitArgs:
                  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)
                
                Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::GroupPolicy` for more information about the expected schema for this property.
+        :param pulumi.Input[str] policy_name: The name of the policy document.
+                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         """
         pulumi.set(__self__, "group_name", group_name)
-        pulumi.set(__self__, "policy_name", policy_name)
         if policy_document is not None:
             pulumi.set(__self__, "policy_document", policy_document)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
 
     @property
     @pulumi.getter(name="groupName")
@@ -49,19 +50,6 @@ class GroupPolicyInitArgs:
     @group_name.setter
     def group_name(self, value: pulumi.Input[str]):
         pulumi.set(self, "group_name", value)
-
-    @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the policy document.
-         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter(name="policyDocument")
@@ -81,6 +69,19 @@ class GroupPolicyInitArgs:
     @policy_document.setter
     def policy_document(self, value: Optional[Any]):
         pulumi.set(self, "policy_document", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the policy document.
+         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
 
 class GroupPolicy(pulumi.CustomResource):
@@ -154,8 +155,6 @@ class GroupPolicy(pulumi.CustomResource):
                 raise TypeError("Missing required property 'group_name'")
             __props__.__dict__["group_name"] = group_name
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["groupName", "policyName"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)

--- a/sdk/python/pulumi_aws_native/iam/role_policy.py
+++ b/sdk/python/pulumi_aws_native/iam/role_policy.py
@@ -14,13 +14,11 @@ __all__ = ['RolePolicyInitArgs', 'RolePolicy']
 @pulumi.input_type
 class RolePolicyInitArgs:
     def __init__(__self__, *,
-                 policy_name: pulumi.Input[str],
                  role_name: pulumi.Input[str],
-                 policy_document: Optional[Any] = None):
+                 policy_document: Optional[Any] = None,
+                 policy_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a RolePolicy resource.
-        :param pulumi.Input[str] policy_name: The name of the policy document.
-                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         :param pulumi.Input[str] role_name: The name of the role to associate the policy with.
                 This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         :param Any policy_document: The policy document.
@@ -31,24 +29,14 @@ class RolePolicyInitArgs:
                  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)
                
                Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::RolePolicy` for more information about the expected schema for this property.
+        :param pulumi.Input[str] policy_name: The name of the policy document.
+                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         """
-        pulumi.set(__self__, "policy_name", policy_name)
         pulumi.set(__self__, "role_name", role_name)
         if policy_document is not None:
             pulumi.set(__self__, "policy_document", policy_document)
-
-    @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the policy document.
-         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
 
     @property
     @pulumi.getter(name="roleName")
@@ -81,6 +69,19 @@ class RolePolicyInitArgs:
     @policy_document.setter
     def policy_document(self, value: Optional[Any]):
         pulumi.set(self, "policy_document", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the policy document.
+         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
 
 class RolePolicy(pulumi.CustomResource):
@@ -153,8 +154,6 @@ class RolePolicy(pulumi.CustomResource):
             __props__ = RolePolicyInitArgs.__new__(RolePolicyInitArgs)
 
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
             if role_name is None and not opts.urn:
                 raise TypeError("Missing required property 'role_name'")

--- a/sdk/python/pulumi_aws_native/iam/user_policy.py
+++ b/sdk/python/pulumi_aws_native/iam/user_policy.py
@@ -14,13 +14,11 @@ __all__ = ['UserPolicyInitArgs', 'UserPolicy']
 @pulumi.input_type
 class UserPolicyInitArgs:
     def __init__(__self__, *,
-                 policy_name: pulumi.Input[str],
                  user_name: pulumi.Input[str],
-                 policy_document: Optional[Any] = None):
+                 policy_document: Optional[Any] = None,
+                 policy_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a UserPolicy resource.
-        :param pulumi.Input[str] policy_name: The name of the policy document.
-                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         :param pulumi.Input[str] user_name: The name of the user to associate the policy with.
                 This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         :param Any policy_document: The policy document.
@@ -31,24 +29,14 @@ class UserPolicyInitArgs:
                  +  The special characters tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``)
                
                Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::IAM::UserPolicy` for more information about the expected schema for this property.
+        :param pulumi.Input[str] policy_name: The name of the policy document.
+                This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
         """
-        pulumi.set(__self__, "policy_name", policy_name)
         pulumi.set(__self__, "user_name", user_name)
         if policy_document is not None:
             pulumi.set(__self__, "policy_document", policy_document)
-
-    @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the policy document.
-         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
 
     @property
     @pulumi.getter(name="userName")
@@ -81,6 +69,19 @@ class UserPolicyInitArgs:
     @policy_document.setter
     def policy_document(self, value: Optional[Any]):
         pulumi.set(self, "policy_document", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the policy document.
+         This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: _+=,.@-
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
 
 class UserPolicy(pulumi.CustomResource):
@@ -151,8 +152,6 @@ class UserPolicy(pulumi.CustomResource):
             __props__ = UserPolicyInitArgs.__new__(UserPolicyInitArgs)
 
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
             if user_name is None and not opts.urn:
                 raise TypeError("Missing required property 'user_name'")

--- a/sdk/python/pulumi_aws_native/iot/fleet_metric.py
+++ b/sdk/python/pulumi_aws_native/iot/fleet_metric.py
@@ -18,11 +18,11 @@ __all__ = ['FleetMetricArgs', 'FleetMetric']
 @pulumi.input_type
 class FleetMetricArgs:
     def __init__(__self__, *,
-                 metric_name: pulumi.Input[str],
                  aggregation_field: Optional[pulumi.Input[str]] = None,
                  aggregation_type: Optional[pulumi.Input['FleetMetricAggregationTypeArgs']] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  index_name: Optional[pulumi.Input[str]] = None,
+                 metric_name: Optional[pulumi.Input[str]] = None,
                  period: Optional[pulumi.Input[int]] = None,
                  query_string: Optional[pulumi.Input[str]] = None,
                  query_version: Optional[pulumi.Input[str]] = None,
@@ -30,17 +30,16 @@ class FleetMetricArgs:
                  unit: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a FleetMetric resource.
-        :param pulumi.Input[str] metric_name: The name of the fleet metric
         :param pulumi.Input[str] aggregation_field: The aggregation field to perform aggregation and metric emission
         :param pulumi.Input[str] description: The description of a fleet metric
         :param pulumi.Input[str] index_name: The index name of a fleet metric
+        :param pulumi.Input[str] metric_name: The name of the fleet metric
         :param pulumi.Input[int] period: The period of metric emission in seconds
         :param pulumi.Input[str] query_string: The Fleet Indexing query used by a fleet metric
         :param pulumi.Input[str] query_version: The version of a Fleet Indexing query used by a fleet metric
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource
         :param pulumi.Input[str] unit: The unit of data points emitted by a fleet metric
         """
-        pulumi.set(__self__, "metric_name", metric_name)
         if aggregation_field is not None:
             pulumi.set(__self__, "aggregation_field", aggregation_field)
         if aggregation_type is not None:
@@ -49,6 +48,8 @@ class FleetMetricArgs:
             pulumi.set(__self__, "description", description)
         if index_name is not None:
             pulumi.set(__self__, "index_name", index_name)
+        if metric_name is not None:
+            pulumi.set(__self__, "metric_name", metric_name)
         if period is not None:
             pulumi.set(__self__, "period", period)
         if query_string is not None:
@@ -59,18 +60,6 @@ class FleetMetricArgs:
             pulumi.set(__self__, "tags", tags)
         if unit is not None:
             pulumi.set(__self__, "unit", unit)
-
-    @property
-    @pulumi.getter(name="metricName")
-    def metric_name(self) -> pulumi.Input[str]:
-        """
-        The name of the fleet metric
-        """
-        return pulumi.get(self, "metric_name")
-
-    @metric_name.setter
-    def metric_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "metric_name", value)
 
     @property
     @pulumi.getter(name="aggregationField")
@@ -116,6 +105,18 @@ class FleetMetricArgs:
     @index_name.setter
     def index_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "index_name", value)
+
+    @property
+    @pulumi.getter(name="metricName")
+    def metric_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the fleet metric
+        """
+        return pulumi.get(self, "metric_name")
+
+    @metric_name.setter
+    def metric_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "metric_name", value)
 
     @property
     @pulumi.getter
@@ -213,7 +214,7 @@ class FleetMetric(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: FleetMetricArgs,
+                 args: Optional[FleetMetricArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         An aggregated metric of certain devices in your fleet
@@ -256,8 +257,6 @@ class FleetMetric(pulumi.CustomResource):
             __props__.__dict__["aggregation_type"] = aggregation_type
             __props__.__dict__["description"] = description
             __props__.__dict__["index_name"] = index_name
-            if metric_name is None and not opts.urn:
-                raise TypeError("Missing required property 'metric_name'")
             __props__.__dict__["metric_name"] = metric_name
             __props__.__dict__["period"] = period
             __props__.__dict__["query_string"] = query_string

--- a/sdk/python/pulumi_aws_native/lightsail/load_balancer_tls_certificate.py
+++ b/sdk/python/pulumi_aws_native/lightsail/load_balancer_tls_certificate.py
@@ -15,25 +15,26 @@ __all__ = ['LoadBalancerTlsCertificateArgs', 'LoadBalancerTlsCertificate']
 class LoadBalancerTlsCertificateArgs:
     def __init__(__self__, *,
                  certificate_domain_name: pulumi.Input[str],
-                 certificate_name: pulumi.Input[str],
                  load_balancer_name: pulumi.Input[str],
                  certificate_alternative_names: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 certificate_name: Optional[pulumi.Input[str]] = None,
                  https_redirection_enabled: Optional[pulumi.Input[bool]] = None,
                  is_attached: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a LoadBalancerTlsCertificate resource.
         :param pulumi.Input[str] certificate_domain_name: The domain name (e.g., example.com ) for your SSL/TLS certificate.
-        :param pulumi.Input[str] certificate_name: The SSL/TLS certificate name.
         :param pulumi.Input[str] load_balancer_name: The name of your load balancer.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] certificate_alternative_names: An array of strings listing alternative domains and subdomains for your SSL/TLS certificate.
+        :param pulumi.Input[str] certificate_name: The SSL/TLS certificate name.
         :param pulumi.Input[bool] https_redirection_enabled: A Boolean value that indicates whether HTTPS redirection is enabled for the load balancer.
         :param pulumi.Input[bool] is_attached: When true, the SSL/TLS certificate is attached to the Lightsail load balancer.
         """
         pulumi.set(__self__, "certificate_domain_name", certificate_domain_name)
-        pulumi.set(__self__, "certificate_name", certificate_name)
         pulumi.set(__self__, "load_balancer_name", load_balancer_name)
         if certificate_alternative_names is not None:
             pulumi.set(__self__, "certificate_alternative_names", certificate_alternative_names)
+        if certificate_name is not None:
+            pulumi.set(__self__, "certificate_name", certificate_name)
         if https_redirection_enabled is not None:
             pulumi.set(__self__, "https_redirection_enabled", https_redirection_enabled)
         if is_attached is not None:
@@ -50,18 +51,6 @@ class LoadBalancerTlsCertificateArgs:
     @certificate_domain_name.setter
     def certificate_domain_name(self, value: pulumi.Input[str]):
         pulumi.set(self, "certificate_domain_name", value)
-
-    @property
-    @pulumi.getter(name="certificateName")
-    def certificate_name(self) -> pulumi.Input[str]:
-        """
-        The SSL/TLS certificate name.
-        """
-        return pulumi.get(self, "certificate_name")
-
-    @certificate_name.setter
-    def certificate_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "certificate_name", value)
 
     @property
     @pulumi.getter(name="loadBalancerName")
@@ -86,6 +75,18 @@ class LoadBalancerTlsCertificateArgs:
     @certificate_alternative_names.setter
     def certificate_alternative_names(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "certificate_alternative_names", value)
+
+    @property
+    @pulumi.getter(name="certificateName")
+    def certificate_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The SSL/TLS certificate name.
+        """
+        return pulumi.get(self, "certificate_name")
+
+    @certificate_name.setter
+    def certificate_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "certificate_name", value)
 
     @property
     @pulumi.getter(name="httpsRedirectionEnabled")
@@ -179,8 +180,6 @@ class LoadBalancerTlsCertificate(pulumi.CustomResource):
             if certificate_domain_name is None and not opts.urn:
                 raise TypeError("Missing required property 'certificate_domain_name'")
             __props__.__dict__["certificate_domain_name"] = certificate_domain_name
-            if certificate_name is None and not opts.urn:
-                raise TypeError("Missing required property 'certificate_name'")
             __props__.__dict__["certificate_name"] = certificate_name
             __props__.__dict__["https_redirection_enabled"] = https_redirection_enabled
             __props__.__dict__["is_attached"] = is_attached

--- a/sdk/python/pulumi_aws_native/location/api_key.py
+++ b/sdk/python/pulumi_aws_native/location/api_key.py
@@ -18,19 +18,18 @@ __all__ = ['ApiKeyArgs', 'ApiKey']
 @pulumi.input_type
 class ApiKeyArgs:
     def __init__(__self__, *,
-                 key_name: pulumi.Input[str],
                  restrictions: pulumi.Input['ApiKeyRestrictionsArgs'],
                  description: Optional[pulumi.Input[str]] = None,
                  expire_time: Optional[pulumi.Input[str]] = None,
                  force_delete: Optional[pulumi.Input[bool]] = None,
                  force_update: Optional[pulumi.Input[bool]] = None,
+                 key_name: Optional[pulumi.Input[str]] = None,
                  no_expiry: Optional[pulumi.Input[bool]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
         """
         The set of arguments for constructing a ApiKey resource.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
-        pulumi.set(__self__, "key_name", key_name)
         pulumi.set(__self__, "restrictions", restrictions)
         if description is not None:
             pulumi.set(__self__, "description", description)
@@ -40,19 +39,12 @@ class ApiKeyArgs:
             pulumi.set(__self__, "force_delete", force_delete)
         if force_update is not None:
             pulumi.set(__self__, "force_update", force_update)
+        if key_name is not None:
+            pulumi.set(__self__, "key_name", key_name)
         if no_expiry is not None:
             pulumi.set(__self__, "no_expiry", no_expiry)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter(name="keyName")
-    def key_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "key_name")
-
-    @key_name.setter
-    def key_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "key_name", value)
 
     @property
     @pulumi.getter
@@ -98,6 +90,15 @@ class ApiKeyArgs:
     @force_update.setter
     def force_update(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "force_update", value)
+
+    @property
+    @pulumi.getter(name="keyName")
+    def key_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "key_name")
+
+    @key_name.setter
+    def key_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "key_name", value)
 
     @property
     @pulumi.getter(name="noExpiry")
@@ -187,8 +188,6 @@ class ApiKey(pulumi.CustomResource):
             __props__.__dict__["expire_time"] = expire_time
             __props__.__dict__["force_delete"] = force_delete
             __props__.__dict__["force_update"] = force_update
-            if key_name is None and not opts.urn:
-                raise TypeError("Missing required property 'key_name'")
             __props__.__dict__["key_name"] = key_name
             __props__.__dict__["no_expiry"] = no_expiry
             if restrictions is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/location/geofence_collection.py
+++ b/sdk/python/pulumi_aws_native/location/geofence_collection.py
@@ -17,7 +17,7 @@ __all__ = ['GeofenceCollectionArgs', 'GeofenceCollection']
 @pulumi.input_type
 class GeofenceCollectionArgs:
     def __init__(__self__, *,
-                 collection_name: pulumi.Input[str],
+                 collection_name: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  kms_key_id: Optional[pulumi.Input[str]] = None,
                  pricing_plan: Optional[pulumi.Input['GeofenceCollectionPricingPlan']] = None,
@@ -27,7 +27,8 @@ class GeofenceCollectionArgs:
         The set of arguments for constructing a GeofenceCollection resource.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
-        pulumi.set(__self__, "collection_name", collection_name)
+        if collection_name is not None:
+            pulumi.set(__self__, "collection_name", collection_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if kms_key_id is not None:
@@ -41,11 +42,11 @@ class GeofenceCollectionArgs:
 
     @property
     @pulumi.getter(name="collectionName")
-    def collection_name(self) -> pulumi.Input[str]:
+    def collection_name(self) -> Optional[pulumi.Input[str]]:
         return pulumi.get(self, "collection_name")
 
     @collection_name.setter
-    def collection_name(self, value: pulumi.Input[str]):
+    def collection_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "collection_name", value)
 
     @property
@@ -120,7 +121,7 @@ class GeofenceCollection(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: GeofenceCollectionArgs,
+                 args: Optional[GeofenceCollectionArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Definition of AWS::Location::GeofenceCollection Resource Type
@@ -155,8 +156,6 @@ class GeofenceCollection(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = GeofenceCollectionArgs.__new__(GeofenceCollectionArgs)
 
-            if collection_name is None and not opts.urn:
-                raise TypeError("Missing required property 'collection_name'")
             __props__.__dict__["collection_name"] = collection_name
             __props__.__dict__["description"] = description
             __props__.__dict__["kms_key_id"] = kms_key_id

--- a/sdk/python/pulumi_aws_native/location/place_index.py
+++ b/sdk/python/pulumi_aws_native/location/place_index.py
@@ -20,9 +20,9 @@ __all__ = ['PlaceIndexArgs', 'PlaceIndex']
 class PlaceIndexArgs:
     def __init__(__self__, *,
                  data_source: pulumi.Input[str],
-                 index_name: pulumi.Input[str],
                  data_source_configuration: Optional[pulumi.Input['PlaceIndexDataSourceConfigurationArgs']] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 index_name: Optional[pulumi.Input[str]] = None,
                  pricing_plan: Optional[pulumi.Input['PlaceIndexPricingPlan']] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
         """
@@ -30,11 +30,12 @@ class PlaceIndexArgs:
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
         pulumi.set(__self__, "data_source", data_source)
-        pulumi.set(__self__, "index_name", index_name)
         if data_source_configuration is not None:
             pulumi.set(__self__, "data_source_configuration", data_source_configuration)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if index_name is not None:
+            pulumi.set(__self__, "index_name", index_name)
         if pricing_plan is not None:
             pulumi.set(__self__, "pricing_plan", pricing_plan)
         if tags is not None:
@@ -48,15 +49,6 @@ class PlaceIndexArgs:
     @data_source.setter
     def data_source(self, value: pulumi.Input[str]):
         pulumi.set(self, "data_source", value)
-
-    @property
-    @pulumi.getter(name="indexName")
-    def index_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "index_name")
-
-    @index_name.setter
-    def index_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "index_name", value)
 
     @property
     @pulumi.getter(name="dataSourceConfiguration")
@@ -75,6 +67,15 @@ class PlaceIndexArgs:
     @description.setter
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
+
+    @property
+    @pulumi.getter(name="indexName")
+    def index_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "index_name")
+
+    @index_name.setter
+    def index_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "index_name", value)
 
     @property
     @pulumi.getter(name="pricingPlan")
@@ -161,8 +162,6 @@ class PlaceIndex(pulumi.CustomResource):
             __props__.__dict__["data_source"] = data_source
             __props__.__dict__["data_source_configuration"] = data_source_configuration
             __props__.__dict__["description"] = description
-            if index_name is None and not opts.urn:
-                raise TypeError("Missing required property 'index_name'")
             __props__.__dict__["index_name"] = index_name
             __props__.__dict__["pricing_plan"] = pricing_plan
             __props__.__dict__["tags"] = tags

--- a/sdk/python/pulumi_aws_native/location/route_calculator.py
+++ b/sdk/python/pulumi_aws_native/location/route_calculator.py
@@ -17,8 +17,8 @@ __all__ = ['RouteCalculatorArgs', 'RouteCalculator']
 @pulumi.input_type
 class RouteCalculatorArgs:
     def __init__(__self__, *,
-                 calculator_name: pulumi.Input[str],
                  data_source: pulumi.Input[str],
+                 calculator_name: Optional[pulumi.Input[str]] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  pricing_plan: Optional[pulumi.Input['RouteCalculatorPricingPlan']] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
@@ -26,23 +26,15 @@ class RouteCalculatorArgs:
         The set of arguments for constructing a RouteCalculator resource.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
-        pulumi.set(__self__, "calculator_name", calculator_name)
         pulumi.set(__self__, "data_source", data_source)
+        if calculator_name is not None:
+            pulumi.set(__self__, "calculator_name", calculator_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if pricing_plan is not None:
             pulumi.set(__self__, "pricing_plan", pricing_plan)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter(name="calculatorName")
-    def calculator_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "calculator_name")
-
-    @calculator_name.setter
-    def calculator_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "calculator_name", value)
 
     @property
     @pulumi.getter(name="dataSource")
@@ -52,6 +44,15 @@ class RouteCalculatorArgs:
     @data_source.setter
     def data_source(self, value: pulumi.Input[str]):
         pulumi.set(self, "data_source", value)
+
+    @property
+    @pulumi.getter(name="calculatorName")
+    def calculator_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "calculator_name")
+
+    @calculator_name.setter
+    def calculator_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "calculator_name", value)
 
     @property
     @pulumi.getter
@@ -140,8 +141,6 @@ class RouteCalculator(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RouteCalculatorArgs.__new__(RouteCalculatorArgs)
 
-            if calculator_name is None and not opts.urn:
-                raise TypeError("Missing required property 'calculator_name'")
             __props__.__dict__["calculator_name"] = calculator_name
             if data_source is None and not opts.urn:
                 raise TypeError("Missing required property 'data_source'")

--- a/sdk/python/pulumi_aws_native/logs/account_policy.py
+++ b/sdk/python/pulumi_aws_native/logs/account_policy.py
@@ -16,8 +16,8 @@ __all__ = ['AccountPolicyArgs', 'AccountPolicy']
 class AccountPolicyArgs:
     def __init__(__self__, *,
                  policy_document: pulumi.Input[str],
-                 policy_name: pulumi.Input[str],
                  policy_type: pulumi.Input['AccountPolicyPolicyType'],
+                 policy_name: Optional[pulumi.Input[str]] = None,
                  scope: Optional[pulumi.Input['AccountPolicyScope']] = None,
                  selection_criteria: Optional[pulumi.Input[str]] = None):
         """
@@ -29,14 +29,15 @@ class AccountPolicyArgs:
                The policy must be in JSON string format.
                
                Length Constraints: Maximum length of 30720
-        :param pulumi.Input[str] policy_name: The name of the account policy
         :param pulumi.Input['AccountPolicyPolicyType'] policy_type: Type of the policy.
+        :param pulumi.Input[str] policy_name: The name of the account policy
         :param pulumi.Input['AccountPolicyScope'] scope: Scope for policy application
         :param pulumi.Input[str] selection_criteria: Log group  selection criteria to apply policy only to a subset of log groups. SelectionCriteria string can be up to 25KB and cloudwatchlogs determines the length of selectionCriteria by using its UTF-8 bytes
         """
         pulumi.set(__self__, "policy_document", policy_document)
-        pulumi.set(__self__, "policy_name", policy_name)
         pulumi.set(__self__, "policy_type", policy_type)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
         if scope is not None:
             pulumi.set(__self__, "scope", scope)
         if selection_criteria is not None:
@@ -61,18 +62,6 @@ class AccountPolicyArgs:
         pulumi.set(self, "policy_document", value)
 
     @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the account policy
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
-
-    @property
     @pulumi.getter(name="policyType")
     def policy_type(self) -> pulumi.Input['AccountPolicyPolicyType']:
         """
@@ -83,6 +72,18 @@ class AccountPolicyArgs:
     @policy_type.setter
     def policy_type(self, value: pulumi.Input['AccountPolicyPolicyType']):
         pulumi.set(self, "policy_type", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the account policy
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter
@@ -234,8 +235,6 @@ class AccountPolicy(pulumi.CustomResource):
             if policy_document is None and not opts.urn:
                 raise TypeError("Missing required property 'policy_document'")
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
             if policy_type is None and not opts.urn:
                 raise TypeError("Missing required property 'policy_type'")

--- a/sdk/python/pulumi_aws_native/logs/resource_policy.py
+++ b/sdk/python/pulumi_aws_native/logs/resource_policy.py
@@ -15,14 +15,15 @@ __all__ = ['ResourcePolicyArgs', 'ResourcePolicy']
 class ResourcePolicyArgs:
     def __init__(__self__, *,
                  policy_document: pulumi.Input[str],
-                 policy_name: pulumi.Input[str]):
+                 policy_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ResourcePolicy resource.
         :param pulumi.Input[str] policy_document: The policy document
         :param pulumi.Input[str] policy_name: A name for resource policy
         """
         pulumi.set(__self__, "policy_document", policy_document)
-        pulumi.set(__self__, "policy_name", policy_name)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
 
     @property
     @pulumi.getter(name="policyDocument")
@@ -38,14 +39,14 @@ class ResourcePolicyArgs:
 
     @property
     @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
         """
         A name for resource policy
         """
         return pulumi.get(self, "policy_name")
 
     @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "policy_name", value)
 
 
@@ -103,8 +104,6 @@ class ResourcePolicy(pulumi.CustomResource):
             if policy_document is None and not opts.urn:
                 raise TypeError("Missing required property 'policy_document'")
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["policyName"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)

--- a/sdk/python/pulumi_aws_native/msk/serverless_cluster.py
+++ b/sdk/python/pulumi_aws_native/msk/serverless_cluster.py
@@ -17,16 +17,17 @@ __all__ = ['ServerlessClusterArgs', 'ServerlessCluster']
 class ServerlessClusterArgs:
     def __init__(__self__, *,
                  client_authentication: pulumi.Input['ServerlessClusterClientAuthenticationArgs'],
-                 cluster_name: pulumi.Input[str],
                  vpc_configs: pulumi.Input[Sequence[pulumi.Input['ServerlessClusterVpcConfigArgs']]],
+                 cluster_name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a ServerlessCluster resource.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] tags: A key-value pair to associate with a resource.
         """
         pulumi.set(__self__, "client_authentication", client_authentication)
-        pulumi.set(__self__, "cluster_name", cluster_name)
         pulumi.set(__self__, "vpc_configs", vpc_configs)
+        if cluster_name is not None:
+            pulumi.set(__self__, "cluster_name", cluster_name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -40,15 +41,6 @@ class ServerlessClusterArgs:
         pulumi.set(self, "client_authentication", value)
 
     @property
-    @pulumi.getter(name="clusterName")
-    def cluster_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "cluster_name")
-
-    @cluster_name.setter
-    def cluster_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "cluster_name", value)
-
-    @property
     @pulumi.getter(name="vpcConfigs")
     def vpc_configs(self) -> pulumi.Input[Sequence[pulumi.Input['ServerlessClusterVpcConfigArgs']]]:
         return pulumi.get(self, "vpc_configs")
@@ -56,6 +48,15 @@ class ServerlessClusterArgs:
     @vpc_configs.setter
     def vpc_configs(self, value: pulumi.Input[Sequence[pulumi.Input['ServerlessClusterVpcConfigArgs']]]):
         pulumi.set(self, "vpc_configs", value)
+
+    @property
+    @pulumi.getter(name="clusterName")
+    def cluster_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "cluster_name")
+
+    @cluster_name.setter
+    def cluster_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "cluster_name", value)
 
     @property
     @pulumi.getter
@@ -127,8 +128,6 @@ class ServerlessCluster(pulumi.CustomResource):
             if client_authentication is None and not opts.urn:
                 raise TypeError("Missing required property 'client_authentication'")
             __props__.__dict__["client_authentication"] = client_authentication
-            if cluster_name is None and not opts.urn:
-                raise TypeError("Missing required property 'cluster_name'")
             __props__.__dict__["cluster_name"] = cluster_name
             __props__.__dict__["tags"] = tags
             if vpc_configs is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/pinpoint/in_app_template.py
+++ b/sdk/python/pulumi_aws_native/pinpoint/in_app_template.py
@@ -17,18 +17,17 @@ __all__ = ['InAppTemplateArgs', 'InAppTemplate']
 @pulumi.input_type
 class InAppTemplateArgs:
     def __init__(__self__, *,
-                 template_name: pulumi.Input[str],
                  content: Optional[pulumi.Input[Sequence[pulumi.Input['InAppTemplateInAppMessageContentArgs']]]] = None,
                  custom_config: Optional[Any] = None,
                  layout: Optional[pulumi.Input['InAppTemplateLayout']] = None,
                  tags: Optional[Any] = None,
-                 template_description: Optional[pulumi.Input[str]] = None):
+                 template_description: Optional[pulumi.Input[str]] = None,
+                 template_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a InAppTemplate resource.
         :param Any custom_config: Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property.
         :param Any tags: Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `AWS::Pinpoint::InAppTemplate` for more information about the expected schema for this property.
         """
-        pulumi.set(__self__, "template_name", template_name)
         if content is not None:
             pulumi.set(__self__, "content", content)
         if custom_config is not None:
@@ -39,15 +38,8 @@ class InAppTemplateArgs:
             pulumi.set(__self__, "tags", tags)
         if template_description is not None:
             pulumi.set(__self__, "template_description", template_description)
-
-    @property
-    @pulumi.getter(name="templateName")
-    def template_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "template_name")
-
-    @template_name.setter
-    def template_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "template_name", value)
+        if template_name is not None:
+            pulumi.set(__self__, "template_name", template_name)
 
     @property
     @pulumi.getter
@@ -100,6 +92,15 @@ class InAppTemplateArgs:
     def template_description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "template_description", value)
 
+    @property
+    @pulumi.getter(name="templateName")
+    def template_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "template_name")
+
+    @template_name.setter
+    def template_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "template_name", value)
+
 
 class InAppTemplate(pulumi.CustomResource):
     @overload
@@ -125,7 +126,7 @@ class InAppTemplate(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: InAppTemplateArgs,
+                 args: Optional[InAppTemplateArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource Type definition for AWS::Pinpoint::InAppTemplate
@@ -165,8 +166,6 @@ class InAppTemplate(pulumi.CustomResource):
             __props__.__dict__["layout"] = layout
             __props__.__dict__["tags"] = tags
             __props__.__dict__["template_description"] = template_description
-            if template_name is None and not opts.urn:
-                raise TypeError("Missing required property 'template_name'")
             __props__.__dict__["template_name"] = template_name
             __props__.__dict__["arn"] = None
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["templateName"])

--- a/sdk/python/pulumi_aws_native/redshift/event_subscription.py
+++ b/sdk/python/pulumi_aws_native/redshift/event_subscription.py
@@ -17,26 +17,25 @@ __all__ = ['EventSubscriptionArgs', 'EventSubscription']
 @pulumi.input_type
 class EventSubscriptionArgs:
     def __init__(__self__, *,
-                 subscription_name: pulumi.Input[str],
                  enabled: Optional[pulumi.Input[bool]] = None,
                  event_categories: Optional[pulumi.Input[Sequence[pulumi.Input['EventSubscriptionEventCategoriesItem']]]] = None,
                  severity: Optional[pulumi.Input['EventSubscriptionSeverity']] = None,
                  sns_topic_arn: Optional[pulumi.Input[str]] = None,
                  source_ids: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  source_type: Optional[pulumi.Input['EventSubscriptionSourceType']] = None,
+                 subscription_name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
         """
         The set of arguments for constructing a EventSubscription resource.
-        :param pulumi.Input[str] subscription_name: The name of the Amazon Redshift event notification subscription
         :param pulumi.Input[bool] enabled: A boolean value; set to true to activate the subscription, and set to false to create the subscription but not activate it.
         :param pulumi.Input[Sequence[pulumi.Input['EventSubscriptionEventCategoriesItem']]] event_categories: Specifies the Amazon Redshift event categories to be published by the event notification subscription.
         :param pulumi.Input['EventSubscriptionSeverity'] severity: Specifies the Amazon Redshift event severity to be published by the event notification subscription.
         :param pulumi.Input[str] sns_topic_arn: The Amazon Resource Name (ARN) of the Amazon SNS topic used to transmit the event notifications.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] source_ids: A list of one or more identifiers of Amazon Redshift source objects.
         :param pulumi.Input['EventSubscriptionSourceType'] source_type: The type of source that will be generating the events.
+        :param pulumi.Input[str] subscription_name: The name of the Amazon Redshift event notification subscription
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: An array of key-value pairs to apply to this resource.
         """
-        pulumi.set(__self__, "subscription_name", subscription_name)
         if enabled is not None:
             pulumi.set(__self__, "enabled", enabled)
         if event_categories is not None:
@@ -49,20 +48,10 @@ class EventSubscriptionArgs:
             pulumi.set(__self__, "source_ids", source_ids)
         if source_type is not None:
             pulumi.set(__self__, "source_type", source_type)
+        if subscription_name is not None:
+            pulumi.set(__self__, "subscription_name", subscription_name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
-
-    @property
-    @pulumi.getter(name="subscriptionName")
-    def subscription_name(self) -> pulumi.Input[str]:
-        """
-        The name of the Amazon Redshift event notification subscription
-        """
-        return pulumi.get(self, "subscription_name")
-
-    @subscription_name.setter
-    def subscription_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "subscription_name", value)
 
     @property
     @pulumi.getter
@@ -137,6 +126,18 @@ class EventSubscriptionArgs:
         pulumi.set(self, "source_type", value)
 
     @property
+    @pulumi.getter(name="subscriptionName")
+    def subscription_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the Amazon Redshift event notification subscription
+        """
+        return pulumi.get(self, "subscription_name")
+
+    @subscription_name.setter
+    def subscription_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "subscription_name", value)
+
+    @property
     @pulumi.getter
     def tags(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]]]:
         """
@@ -181,7 +182,7 @@ class EventSubscription(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: EventSubscriptionArgs,
+                 args: Optional[EventSubscriptionArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The `AWS::Redshift::EventSubscription` resource creates an Amazon Redshift Event Subscription.
@@ -224,8 +225,6 @@ class EventSubscription(pulumi.CustomResource):
             __props__.__dict__["sns_topic_arn"] = sns_topic_arn
             __props__.__dict__["source_ids"] = source_ids
             __props__.__dict__["source_type"] = source_type
-            if subscription_name is None and not opts.urn:
-                raise TypeError("Missing required property 'subscription_name'")
             __props__.__dict__["subscription_name"] = subscription_name
             __props__.__dict__["tags"] = tags
             __props__.__dict__["cust_subscription_id"] = None

--- a/sdk/python/pulumi_aws_native/resiliencehub/resiliency_policy.py
+++ b/sdk/python/pulumi_aws_native/resiliencehub/resiliency_policy.py
@@ -18,25 +18,26 @@ __all__ = ['ResiliencyPolicyArgs', 'ResiliencyPolicy']
 class ResiliencyPolicyArgs:
     def __init__(__self__, *,
                  policy: pulumi.Input[Mapping[str, pulumi.Input['ResiliencyPolicyFailurePolicyArgs']]],
-                 policy_name: pulumi.Input[str],
                  tier: pulumi.Input['ResiliencyPolicyTier'],
                  data_location_constraint: Optional[pulumi.Input['ResiliencyPolicyDataLocationConstraint']] = None,
                  policy_description: Optional[pulumi.Input[str]] = None,
+                 policy_name: Optional[pulumi.Input[str]] = None,
                  tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a ResiliencyPolicy resource.
-        :param pulumi.Input[str] policy_name: Name of Resiliency Policy.
         :param pulumi.Input['ResiliencyPolicyTier'] tier: Resiliency Policy Tier.
         :param pulumi.Input['ResiliencyPolicyDataLocationConstraint'] data_location_constraint: Data Location Constraint of the Policy.
         :param pulumi.Input[str] policy_description: Description of Resiliency Policy.
+        :param pulumi.Input[str] policy_name: Name of Resiliency Policy.
         """
         pulumi.set(__self__, "policy", policy)
-        pulumi.set(__self__, "policy_name", policy_name)
         pulumi.set(__self__, "tier", tier)
         if data_location_constraint is not None:
             pulumi.set(__self__, "data_location_constraint", data_location_constraint)
         if policy_description is not None:
             pulumi.set(__self__, "policy_description", policy_description)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
         if tags is not None:
             pulumi.set(__self__, "tags", tags)
 
@@ -48,18 +49,6 @@ class ResiliencyPolicyArgs:
     @policy.setter
     def policy(self, value: pulumi.Input[Mapping[str, pulumi.Input['ResiliencyPolicyFailurePolicyArgs']]]):
         pulumi.set(self, "policy", value)
-
-    @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        Name of Resiliency Policy.
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter
@@ -96,6 +85,18 @@ class ResiliencyPolicyArgs:
     @policy_description.setter
     def policy_description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "policy_description", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of Resiliency Policy.
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
     @property
     @pulumi.getter
@@ -173,8 +174,6 @@ class ResiliencyPolicy(pulumi.CustomResource):
                 raise TypeError("Missing required property 'policy'")
             __props__.__dict__["policy"] = policy
             __props__.__dict__["policy_description"] = policy_description
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
             __props__.__dict__["tags"] = tags
             if tier is None and not opts.urn:

--- a/sdk/python/pulumi_aws_native/ssm/resource_data_sync.py
+++ b/sdk/python/pulumi_aws_native/ssm/resource_data_sync.py
@@ -16,19 +16,18 @@ __all__ = ['ResourceDataSyncArgs', 'ResourceDataSync']
 @pulumi.input_type
 class ResourceDataSyncArgs:
     def __init__(__self__, *,
-                 sync_name: pulumi.Input[str],
                  bucket_name: Optional[pulumi.Input[str]] = None,
                  bucket_prefix: Optional[pulumi.Input[str]] = None,
                  bucket_region: Optional[pulumi.Input[str]] = None,
                  kms_key_arn: Optional[pulumi.Input[str]] = None,
                  s3_destination: Optional[pulumi.Input['ResourceDataSyncS3DestinationArgs']] = None,
                  sync_format: Optional[pulumi.Input[str]] = None,
+                 sync_name: Optional[pulumi.Input[str]] = None,
                  sync_source: Optional[pulumi.Input['ResourceDataSyncSyncSourceArgs']] = None,
                  sync_type: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ResourceDataSync resource.
         """
-        pulumi.set(__self__, "sync_name", sync_name)
         if bucket_name is not None:
             pulumi.set(__self__, "bucket_name", bucket_name)
         if bucket_prefix is not None:
@@ -41,19 +40,12 @@ class ResourceDataSyncArgs:
             pulumi.set(__self__, "s3_destination", s3_destination)
         if sync_format is not None:
             pulumi.set(__self__, "sync_format", sync_format)
+        if sync_name is not None:
+            pulumi.set(__self__, "sync_name", sync_name)
         if sync_source is not None:
             pulumi.set(__self__, "sync_source", sync_source)
         if sync_type is not None:
             pulumi.set(__self__, "sync_type", sync_type)
-
-    @property
-    @pulumi.getter(name="syncName")
-    def sync_name(self) -> pulumi.Input[str]:
-        return pulumi.get(self, "sync_name")
-
-    @sync_name.setter
-    def sync_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "sync_name", value)
 
     @property
     @pulumi.getter(name="bucketName")
@@ -108,6 +100,15 @@ class ResourceDataSyncArgs:
     @sync_format.setter
     def sync_format(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "sync_format", value)
+
+    @property
+    @pulumi.getter(name="syncName")
+    def sync_name(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "sync_name")
+
+    @sync_name.setter
+    def sync_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "sync_name", value)
 
     @property
     @pulumi.getter(name="syncSource")
@@ -309,7 +310,7 @@ class ResourceDataSync(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: ResourceDataSyncArgs,
+                 args: Optional[ResourceDataSyncArgs] = None,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Resource Type definition for AWS::SSM::ResourceDataSync
@@ -509,8 +510,6 @@ class ResourceDataSync(pulumi.CustomResource):
             __props__.__dict__["kms_key_arn"] = kms_key_arn
             __props__.__dict__["s3_destination"] = s3_destination
             __props__.__dict__["sync_format"] = sync_format
-            if sync_name is None and not opts.urn:
-                raise TypeError("Missing required property 'sync_name'")
             __props__.__dict__["sync_name"] = sync_name
             __props__.__dict__["sync_source"] = sync_source
             __props__.__dict__["sync_type"] = sync_type

--- a/sdk/python/pulumi_aws_native/xray/resource_policy.py
+++ b/sdk/python/pulumi_aws_native/xray/resource_policy.py
@@ -15,18 +15,19 @@ __all__ = ['ResourcePolicyArgs', 'ResourcePolicy']
 class ResourcePolicyArgs:
     def __init__(__self__, *,
                  policy_document: pulumi.Input[str],
-                 policy_name: pulumi.Input[str],
-                 bypass_policy_lockout_check: Optional[pulumi.Input[bool]] = None):
+                 bypass_policy_lockout_check: Optional[pulumi.Input[bool]] = None,
+                 policy_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a ResourcePolicy resource.
         :param pulumi.Input[str] policy_document: The resource policy document, which can be up to 5kb in size.
-        :param pulumi.Input[str] policy_name: The name of the resource policy. Must be unique within a specific AWS account.
         :param pulumi.Input[bool] bypass_policy_lockout_check: A flag to indicate whether to bypass the resource policy lockout safety check
+        :param pulumi.Input[str] policy_name: The name of the resource policy. Must be unique within a specific AWS account.
         """
         pulumi.set(__self__, "policy_document", policy_document)
-        pulumi.set(__self__, "policy_name", policy_name)
         if bypass_policy_lockout_check is not None:
             pulumi.set(__self__, "bypass_policy_lockout_check", bypass_policy_lockout_check)
+        if policy_name is not None:
+            pulumi.set(__self__, "policy_name", policy_name)
 
     @property
     @pulumi.getter(name="policyDocument")
@@ -41,18 +42,6 @@ class ResourcePolicyArgs:
         pulumi.set(self, "policy_document", value)
 
     @property
-    @pulumi.getter(name="policyName")
-    def policy_name(self) -> pulumi.Input[str]:
-        """
-        The name of the resource policy. Must be unique within a specific AWS account.
-        """
-        return pulumi.get(self, "policy_name")
-
-    @policy_name.setter
-    def policy_name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "policy_name", value)
-
-    @property
     @pulumi.getter(name="bypassPolicyLockoutCheck")
     def bypass_policy_lockout_check(self) -> Optional[pulumi.Input[bool]]:
         """
@@ -63,6 +52,18 @@ class ResourcePolicyArgs:
     @bypass_policy_lockout_check.setter
     def bypass_policy_lockout_check(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "bypass_policy_lockout_check", value)
+
+    @property
+    @pulumi.getter(name="policyName")
+    def policy_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The name of the resource policy. Must be unique within a specific AWS account.
+        """
+        return pulumi.get(self, "policy_name")
+
+    @policy_name.setter
+    def policy_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "policy_name", value)
 
 
 class ResourcePolicy(pulumi.CustomResource):
@@ -175,8 +176,6 @@ class ResourcePolicy(pulumi.CustomResource):
             if policy_document is None and not opts.urn:
                 raise TypeError("Missing required property 'policy_document'")
             __props__.__dict__["policy_document"] = policy_document
-            if policy_name is None and not opts.urn:
-                raise TypeError("Missing required property 'policy_name'")
             __props__.__dict__["policy_name"] = policy_name
         replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["policyName"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)


### PR DESCRIPTION
- Introduce report to highlight and help investigate resources we can't auto-name.
- Identify partial overlaps of resource and name fields e.g. ScalingPolicy has a field "PolicyName". This fixes 28 resources.
- Fix #1430 by removing hard coded resilience policy name.

There are still currently 387 resources remaining without auto-naming. Many of these genuinely can't be auto-named.