### PR TITLE
Skip aws:cdk:path metadata which fails conversion

### DIFF
--- a/provider/pkg/cf2pulumi/renderer.go
+++ b/provider/pkg/cf2pulumi/renderer.go
@@ -898,12 +898,17 @@ func (ctx *renderContext) renderResource(attr *ast.MappingValueNode) (model.Body
 				return nil, diagnostics, fmt.Errorf("'%v' must be a mapping", keyString(f))
 			}
 			for _, sf := range subValues {
+				keyValue := keyString(sf)
+				// Properties should never contain a colon. This is only used within metadata which we discard.
+				if strings.ContainsRune(keyValue, ':') {
+					continue
+				}
 				sv, err := ctx.renderValue(sf.Value)
 				if err != nil {
 					return nil, diagnostics, err
 				}
 				items = append(items, &model.Attribute{
-					Name:  camel(keyString(sf)),
+					Name:  camel(keyValue),
 					Value: sv,
 				})
 			}


### PR DESCRIPTION
Fixes #1304

Exclude all keys containing `:` as these will never render correctly into code right now and is almost certainly just metadata such as `aws:cdk:path` as in the associated issue.

There are no tests at all around cf2pulumi so I've tested this manually using the example from the linked issue.