### PR TITLE
chore: rename CHANGELOG.md to CHANGELOG_OLD.md

### DIFF
--- a/CHANGELOG_OLD.md
+++ b/CHANGELOG_OLD.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Notice (2024-04-12)
+
+*As of this notice, using CHANGELOG.md is DEPRECATED. We will be using [GitHub Releases](https://github.com/pulumi/pulumi-aws-native/releases) for this repository*
+
 ## 0.101.0 (2024-04-11)
 
 ### Breaking changes


### PR DESCRIPTION
Currently we have to manually update the changelog on almost every auto generated PR (e.g. [this one](https://github.com/pulumi/pulumi-aws-native/pull/1479)) which means we can't automate this process.

I am switching to automatic release note generation (re [ci-mgmt](https://github.com/pulumi/ci-mgmt/pull/882)) which will mean that the GitHub release will contain these release notes.