### PR TITLE
Add provider to path for running integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ install_java_sdk::
 install_nodejs_sdk::
 	yarn link --cwd $(WORKING_DIR)/sdk/nodejs/bin
 
+test:: PATH := $(WORKING_DIR)/bin:$(PATH)
 test::
 	cd examples && go test -v -tags=all -timeout 2h
 


### PR DESCRIPTION
Previously you had to manually add the provider to the PATH for the tests to work. This automates that