### PR TITLE
Disambiguate QBusiness::Index Status enum

### DIFF
--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1225,6 +1225,12 @@ func (ctx *cfSchemaContext) genEnumType(enumName string, propSchema *jsschema.Sc
 	case "networkfirewall:RuleGroupType":
 		typName = "RuleGroupTypeEnum" // Go SDK name conflict vs. RuleGroup resource
 	}
+
+	switch ctx.cfTypeName + "   " + enumName {
+	case "AWS::QBusiness::Index   Status":
+		typName = "QBusinessIndexStatus"
+	}
+
 	tok := fmt.Sprintf("%s:%s:%s", packageName, ctx.mod, typName)
 
 	enumSpec := &pschema.ComplexTypeSpec{


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-aws-native/issues/1506

IndexStatus enum name was creating a generate-phase panic as this token was already taken. 