### PR TITLE
Deterministically sort default tags to prevent permadiff

### DIFF
--- a/examples/default-tags-py/__main__.py
+++ b/examples/default-tags-py/__main__.py
@@ -1,7 +1,7 @@
 # Copyright 2021, Pulumi Corporation.  All rights reserved.
 
 import pulumi
-from pulumi_aws_native import logs, resiliencehub, TagArgs
+from pulumi_aws_native import logs, resiliencehub, TagArgs, s3
 
 log_group = logs.LogGroup(
     "log-test",
@@ -34,5 +34,8 @@ policy = resiliencehub.ResiliencyPolicy(
   tags={"localTag": "localTagValue"},
 )
 
+bucket = s3.Bucket("bucket", tags=[TagArgs(key="localTag", value="localTagValue")])
+
 pulumi.export("logGroupTags", log_group.tags)
 pulumi.export("policyTags", policy.tags)
+pulumi.export("bucketTags", bucket.tags)

--- a/examples/examples_py_test.go
+++ b/examples/examples_py_test.go
@@ -49,12 +49,17 @@ func TestDefaultTagsPython(t *testing.T) {
 			Config: map[string]string{
 				"aws-native:defaultTags": `{
 						"tags": {
-							"defaultTag": "defaultTagValue"
+							"defaultTag": "defaultTagValue",
+							"tag1": "tag1Value",
+							"tag2": "tag2Value",
+							"tag3": "tag3Value",
+							"tag4": "tag4Value"
 						}
 					}`,
 			},
+			RequireEmptyPreviewAfterRefresh: true,
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-				assert.Equal(t, []interface{}{
+				listTags := []interface{}{
 					map[string]interface{}{
 						"key":   "localTag",
 						"value": "localTagValue",
@@ -63,11 +68,35 @@ func TestDefaultTagsPython(t *testing.T) {
 						"key":   "defaultTag",
 						"value": "defaultTagValue",
 					},
-				}, stackInfo.Outputs["logGroupTags"])
+					map[string]interface{}{
+						"key":   "tag1",
+						"value": "tag1Value",
+					},
+					map[string]interface{}{
+						"key":   "tag2",
+						"value": "tag2Value",
+					},
+					map[string]interface{}{
+						"key":   "tag3",
+						"value": "tag3Value",
+					},
+					map[string]interface{}{
+						"key":   "tag4",
+						"value": "tag4Value",
+					},
+				}
+
+				// The CC tag output is randomly ordered. We can't assert on the order, but the preview test will catch any changes in the input order.
+				assert.ElementsMatch(t, listTags, stackInfo.Outputs["logGroupTags"])
+				assert.ElementsMatch(t, listTags, stackInfo.Outputs["bucketTags"])
 
 				assert.Equal(t, map[string]interface{}{
 					"defaultTag": "defaultTagValue",
 					"localTag":   "localTagValue",
+					"tag1": "tag1Value",
+					"tag2": "tag2Value",
+					"tag3": "tag3Value",
+					"tag4": "tag4Value",
 				}, stackInfo.Outputs["policyTags"])
 			},
 		})

--- a/provider/pkg/default_tags/merging.go
+++ b/provider/pkg/default_tags/merging.go
@@ -2,6 +2,7 @@ package default_tags
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -59,11 +60,19 @@ func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string
 				existingKeys[key.StringValue()] = true
 			}
 		}
-		for k, v := range defaultTags {
-			if _, ok := existingKeys[k]; !ok {
+
+		// Get the sorted list of keys from defaultTags
+		var keys []string
+		for k := range defaultTags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			if _, ok := existingKeys[key]; !ok {
 				asArray = append(asArray, resource.NewObjectProperty(map[resource.PropertyKey]resource.PropertyValue{
-					keyProp:   resource.NewStringProperty(k),
-					valueProp: resource.NewStringProperty(v),
+					keyProp:   resource.NewStringProperty(key),
+					valueProp: resource.NewStringProperty(defaultTags[key]),
 				}))
 			}
 		}

--- a/provider/pkg/default_tags/merging_test.go
+++ b/provider/pkg/default_tags/merging_test.go
@@ -155,6 +155,55 @@ func TestDefaultTags(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
+	t.Run("key value array tag ordering", func(t *testing.T) {
+		tags := resource.NewPropertyValue([]interface{}{
+			map[string]interface{}{
+				"key":   "localTag1",
+				"value": "localTagValue1",
+			},
+			map[string]interface{}{
+				"key":   "localTag2",
+				"value": "localTagValue2",
+			},
+		})
+		defaultTags := map[string]string{
+			"defaultTag1": "defaultTagValue1",
+			"defaultTag2": "defaultTagValue2",
+			"defaultTag3": "defaultTagValue3",
+			"defaultTag4": "defaultTagValue4",
+		}
+
+		expected := resource.NewPropertyValue([]interface{}{
+			map[string]interface{}{
+				"key":   "localTag1",
+				"value": "localTagValue1",
+			},
+			map[string]interface{}{
+				"key":   "localTag2",
+				"value": "localTagValue2",
+			},
+			map[string]interface{}{
+				"key":   "defaultTag1",
+				"value": "defaultTagValue1",
+			},
+			map[string]interface{}{
+				"key":   "defaultTag2",
+				"value": "defaultTagValue2",
+			},
+			map[string]interface{}{
+				"key":   "defaultTag3",
+				"value": "defaultTagValue3",
+			},
+			map[string]interface{}{
+				"key":   "defaultTag4",
+				"value": "defaultTagValue4",
+			},
+		})
+		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleKeyValueArray)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
 	t.Run("key value array uppercase", func(t *testing.T) {
 		tags := resource.NewPropertyValue([]interface{}{
 			map[string]interface{}{


### PR DESCRIPTION
Previously the default tags where randomly appended to the tag list because of Go's random iteration order for maps. This introduces sorting for the key's of the default tags in order to produce deterministic tag lists and prevent permadiffs.

Fixes #1486 