### PR TITLE
Rename project to AWS Cloud Control Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-# Pulumi AWS Native Provider (preview)
+# Pulumi AWS Cloud Control Provider (preview)
 
-The Pulumi AWS Native Provider enables you to build, deploy, and manage [any AWS resource that's supported by the AWS Cloud Control API](https://github.com/pulumi/pulumi-aws-native/blob/master/provider/cmd/pulumi-gen-aws-native/supported-types.txt).
-With AWS Native, you get same-day access to all new AWS resources and all new properties on existing resources supported by the Cloud Control API.
-You can use AWS Native from a Pulumi program written in any Pulumi language: C#, Go, JavaScript/TypeScript, and Python.
+The Pulumi AWS Cloud Control Provider enables you to build, deploy, and manage [any AWS resource that's supported by the AWS Cloud Control API](https://github.com/pulumi/pulumi-aws-native/blob/master/provider/cmd/pulumi-gen-aws-native/supported-types.txt).
+With Pulumi's native provider for AWS Cloud Control, you get same-day access to all new AWS resources and all new properties on existing resources supported by the Cloud Control API.
+You can use the AWS Cloud Control provider from a Pulumi program written in any Pulumi language: C#, Go, JavaScript/TypeScript, and Python.
 You'll need to [install and configure the Pulumi CLI](https://pulumi.com/docs/get-started/install) if you haven't already.
 
 ---
 > [!NOTE]
-> AWS Native is in public preview.
+> AWS Cloud Control is in public preview.
 > This provider covers all resources as supported by the [AWS Cloud Control API](https://aws.amazon.com/cloudcontrolapi/). This does not yet include all AWS resources. See the [list of supported resources](https://github.com/pulumi/pulumi-aws-native/blob/master/provider/cmd/pulumi-gen-aws-native/supported-types.txt) for full details.
 
-For new projects, we recommend using AWS Native and [AWS Classic](https://github.com/pulumi/pulumi-aws) side-by-side so you can get the speed and correctness benefits of AWS Native where possible.
-For existing projects, AWS Classic remains fully supported; at this time, we recommend waiting to migrate existing projects to AWS Native.
+For new projects, we recommend starting with our primary [AWS Provider](https://github.com/pulumi/pulumi-aws) and adding AWS Cloud Control resources on an as needed basis.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pulumi AWS Cloud Control Provider (preview)
+# Pulumi AWS Cloud Control Provider
 
 The Pulumi AWS Cloud Control Provider enables you to build, deploy, and manage [any AWS resource that's supported by the AWS Cloud Control API](https://github.com/pulumi/pulumi-aws-native/blob/master/provider/cmd/pulumi-gen-aws-native/supported-types.txt).
 With Pulumi's native provider for AWS Cloud Control, you get same-day access to all new AWS resources and all new properties on existing resources supported by the Cloud Control API.
@@ -7,7 +7,6 @@ You'll need to [install and configure the Pulumi CLI](https://pulumi.com/docs/ge
 
 ---
 > [!NOTE]
-> AWS Cloud Control is in public preview.
 > This provider covers all resources as supported by the [AWS Cloud Control API](https://aws.amazon.com/cloudcontrolapi/). This does not yet include all AWS resources. See the [list of supported resources](https://github.com/pulumi/pulumi-aws-native/blob/master/provider/cmd/pulumi-gen-aws-native/supported-types.txt) for full details.
 
 For new projects, we recommend starting with our primary [AWS Provider](https://github.com/pulumi/pulumi-aws) and adding AWS Cloud Control resources on an as needed basis.

--- a/examples/aws-native-ts-stepfunctions/Pulumi.yaml
+++ b/examples/aws-native-ts-stepfunctions/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: stepfunctions
-description: Basic example of AWS Step Functions with AWS Native
+description: Basic example of AWS Step Functions with AWS Cloud Control
 runtime: nodejs

--- a/examples/aws-native-ts-stepfunctions/README.md
+++ b/examples/aws-native-ts-stepfunctions/README.md
@@ -2,7 +2,7 @@
 
 # AWS Step Functions
 
-A basic example that demonstrates using AWS Step Functions with a Lambda function using the AWS Native provider.
+A basic example that demonstrates using AWS Step Functions with a Lambda function using the AWS Cloud Control provider.
 
 ```
 # Create and configure a new stack

--- a/examples/aws-ts-assume-role/README.md
+++ b/examples/aws-ts-assume-role/README.md
@@ -1,6 +1,6 @@
 # AWS Resources Using AssumeRole
 
-This example demonstrates how to use the AssumeRole functionality of the AWS Native provider in order to create
+This example demonstrates how to use the AssumeRole functionality of the AWS Cloud Control provider in order to create
 resources in the security context of an IAM Role assumed by the IAM User running the Pulumi program.
 
 ### Part 1: Privileged Components

--- a/examples/ecs/Pulumi.yaml
+++ b/examples/ecs/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-native-ecs
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider that provisions an ECS Cluster
+description: A TypeScript Pulumi program with AWS Cloud Control provider that provisions an ECS Cluster

--- a/examples/get-ts/Pulumi.yaml
+++ b/examples/get-ts/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-get-ts
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider
+description: A TypeScript Pulumi program with AWS Cloud Control provider

--- a/examples/lambda-update/step1/Pulumi.yaml
+++ b/examples/lambda-update/step1/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-simple-ts
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider
+description: A TypeScript Pulumi program with AWS Cloud Control provider

--- a/examples/simple-go/Pulumi.yaml
+++ b/examples/simple-go/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-simple-go
 runtime: go
-description: A Go Pulumi program with AWS Native provider
+description: A Go Pulumi program with AWS Cloud Control provider

--- a/examples/simple-ts/Pulumi.yaml
+++ b/examples/simple-ts/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-simple-ts
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider
+description: A TypeScript Pulumi program with AWS Cloud Control provider

--- a/examples/update/step1/Pulumi.yaml
+++ b/examples/update/step1/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-update
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider testing an update
+description: A TypeScript Pulumi program with AWS Cloud Control provider testing an update

--- a/examples/update/step2/Pulumi.yaml
+++ b/examples/update/step2/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-update
 runtime: nodejs
-description: A TypeScript Pulumi program with AWS Native provider testing an update
+description: A TypeScript Pulumi program with AWS Cloud Control provider testing an update

--- a/examples/write-only-go/Pulumi.yaml
+++ b/examples/write-only-go/Pulumi.yaml
@@ -1,3 +1,3 @@
 name: aws-simple-go
 runtime: go
-description: A Go Pulumi program with AWS Native provider
+description: A Go Pulumi program with AWS Cloud Control provider

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -38,7 +38,7 @@ var forceDocumentationAugmentation = map[string]bool{
 }
 
 type RegionInfo struct {
-	Name string `json:"name"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 }
 
@@ -66,11 +66,13 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []*jsschema.Sche
 	p := pschema.PackageSpec{
 		Name:        packageName,
 		Description: "A native Pulumi package for creating and managing Amazon Web Services (AWS) resources.",
-		DisplayName: "AWS Native",
+		DisplayName: "AWS Cloud Control",
 		Keywords: []string{
 			"pulumi",
 			"aws",
 			"aws-native",
+			"cloud control",
+			"ccapi",
 			"category/cloud",
 			"kind/native",
 		},
@@ -181,7 +183,7 @@ func GatherPackage(supportedResourceTypes []string, jsonSchemas []*jsschema.Sche
 		},
 		Provider: pschema.ResourceSpec{
 			ObjectTypeSpec: pschema.ObjectTypeSpec{
-				Description: "The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.",
+				Description: "The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.",
 				Properties: map[string]pschema.PropertySpec{
 					"allowedAccountIds": {
 						Description: "List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one. Conflicts with `forbiddenAccountIds`.",
@@ -891,7 +893,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 	ctx.updateDesc(ctx.cfTypeName, "", ctx.resourceSpec)
 	var deprecationMessage string
 	if !ctx.isSupported {
-		deprecationMessage = fmt.Sprintf("%s is not yet supported by AWS Native, so its creation will currently fail. Please use the classic AWS provider, if possible.", resourceTypeName)
+		deprecationMessage = fmt.Sprintf("%s is not yet supported by AWS Cloud Control, so its creation will currently fail. Please use the classic AWS provider, if possible.", resourceTypeName)
 	}
 	resourceSpec := pschema.ResourceSpec{
 		ObjectTypeSpec: pschema.ObjectTypeSpec{

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.AwsNative
 {
     /// <summary>
-    /// The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+    /// The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
     /// </summary>
     [AwsNativeResourceType("pulumi:providers:aws-native")]
     public partial class Provider : global::Pulumi.ProviderResource

--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+// The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
 type Provider struct {
 	pulumi.ProviderResourceState
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -5,6 +5,8 @@
         "pulumi",
         "aws",
         "aws-native",
+        "cloud control",
+        "ccapi",
         "category/cloud",
         "kind/native"
     ],

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -10,7 +10,7 @@ import * as utilities from "./utilities";
 import {Region} from "./index";
 
 /**
- * The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+ * The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
  */
 export class Provider extends pulumi.ProviderResource {
     /** @internal */

--- a/sdk/python/pulumi_aws_native/provider.py
+++ b/sdk/python/pulumi_aws_native/provider.py
@@ -402,7 +402,7 @@ class Provider(pulumi.ProviderResource):
                  token: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
-        The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+        The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -435,7 +435,7 @@ class Provider(pulumi.ProviderResource):
                  args: ProviderArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        The provider type for the AWS native package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
+        The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
 
         :param str resource_name: The name of the resource.
         :param ProviderArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -2,7 +2,7 @@
   name = "pulumi_aws_native"
   description = "A native Pulumi package for creating and managing Amazon Web Services (AWS) resources."
   dependencies = ["parver>=0.2.1", "pulumi>=3.0.0,<4.0.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
-  keywords = ["pulumi", "aws", "aws-native", "category/cloud", "kind/native"]
+  keywords = ["pulumi", "aws", "aws-native", "cloud control", "ccapi", "category/cloud", "kind/native"]
   readme = "README.md"
   requires-python = ">=3.8"
   version = "1.0.0a0+dev"


### PR DESCRIPTION
Updates references from `AWS Native` to `AWS Cloud Control`

re #1296