### PR TITLE
Fix nil pointer panic when calculating patches

### DIFF
--- a/provider/pkg/resources/patching_test.go
+++ b/provider/pkg/resources/patching_test.go
@@ -63,6 +63,28 @@ func TestCalcPatch(t *testing.T) {
 					}})
 				assert.Empty(t, patch)
 			})
+			t.Run("no diff with must send props", func(t *testing.T) {
+				expected := []jsonpatch.JsonPatchOperation{
+					{Operation: "add", Path: "/Prop1", Value: "1"},
+				}
+				patch := run(t, args{
+					oldInputs: resource.PropertyMap{
+						"prop1": resource.NewStringProperty("1"),
+						"prop2": resource.NewStringProperty("2"),
+					},
+					newInputs: resource.PropertyMap{
+						"prop1": resource.NewStringProperty("1"),
+						"prop2": resource.NewStringProperty("2"),
+					},
+					spec: metadata.CloudAPIResource{
+						Inputs: map[string]schema.PropertySpec{
+							"prop1": {TypeSpec: schema.TypeSpec{Type: "string"}},
+							"prop2": {TypeSpec: schema.TypeSpec{Type: "string"}},
+						},
+						WriteOnly: []string{"prop1"},
+					}})
+				assert.Equal(t, expected, patch)
+			})
 			t.Run("always sends write-only properties", func(t *testing.T) {
 				expected := []jsonpatch.JsonPatchOperation{
 					{Operation: "add", Path: "/Prop1", Value: "1"},


### PR DESCRIPTION
Currently, when calculating the json patch for a resource with
write only properties but no diff we panic with a nil pointer
dereference.

This change fixes that by adding special handling for that
case.

This situation can happen when:
- The resource was created
- Cloud Control reported it as failed but it actually succeeded (intermittent failure)
- On the next run, Pulumi detects an update (to complete the operation) but the properties are still the same
- We calculate the diff between A and A and get an empty diff (nil)
- Panic in patch calculation

Fixes #1755