### PR TITLE
chore: clarify DiffConfig code

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -266,15 +266,14 @@ func (p *cfnProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequest
 		return &pulumirpc.DiffResponse{Changes: pulumirpc.DiffResponse_DIFF_NONE}, nil
 	}
 
-	var diffs, replaces []string
+	var diffs []string
 	for _, k := range diff.Keys() {
 		diffs = append(diffs, string(k))
 	}
 
 	return &pulumirpc.DiffResponse{
-		Changes:  pulumirpc.DiffResponse_DIFF_SOME,
-		Diffs:    diffs,
-		Replaces: replaces,
+		Changes: pulumirpc.DiffResponse_DIFF_SOME,
+		Diffs:   diffs,
 	}, nil
 }
 


### PR DESCRIPTION
This change does not affect the code behavior but makes it clear that AWS Native never cascade-replaces resources in DiffConfig.