### PR TITLE
Fix cidr function

### DIFF
--- a/examples/cidr-ts/Pulumi.yaml
+++ b/examples/cidr-ts/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-cidr-ts
+runtime: nodejs
+description: A TypeScript Pulumi program with AWS Cloud Control provider

--- a/examples/cidr-ts/index.ts
+++ b/examples/cidr-ts/index.ts
@@ -1,0 +1,48 @@
+// Copyright 2016-2021, Pulumi Corporation.
+
+import * as pulumi from '@pulumi/pulumi';
+import * as aws from "@pulumi/aws-native";
+
+const cidrBlock = '192.168.0.0/24';
+const vpc = new aws.ec2.Vpc('vpc', {
+    cidrBlock,
+});
+
+const ipv6Cidr = new aws.ec2.VpcCidrBlock('ipv6Cidr', {
+    vpcId: vpc.vpcId,
+    amazonProvidedIpv6CidrBlock: true,
+});
+
+
+const cidrs = aws.cidrOutput({
+    count: 4,
+    ipBlock: cidrBlock,
+    cidrBits: 5
+});
+const ipvcCidrs = aws.cidrOutput({
+    ipBlock: ipv6Cidr.ipv6CidrBlock.apply(cidr => cidr!),
+    cidrBits: 64,
+    count: 4,
+});
+
+ipvcCidrs.apply(cidr => {
+    if (cidr.subnets.length !== 4) {
+        throw new Error('Expected 4 ipv6 CIDRs');
+    }
+})
+
+cidrs.apply(cidr => {
+    if (cidr.subnets.length !== 4) {
+        throw new Error('Expected 4 ipv4 CIDRs');
+    }
+})
+
+pulumi.all([cidrs.subnets, ipvcCidrs.subnets]).apply(([ipv4, ipv6]) => {
+    for (let i = 0; i < 4; i++) {
+        new aws.ec2.Subnet(`subnet-${i}`, {
+            vpcId: vpc.id,
+            cidrBlock: ipv4[i],
+            ipv6CidrBlock: ipv6[i]
+        });
+    }
+});

--- a/examples/cidr-ts/package.json
+++ b/examples/cidr-ts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "aws-cidr-ts",
+  "devDependencies": {
+    "@types/node": "^8.0.0"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.136.0"
+  },
+  "peerDependencies": {
+    "@pulumi/aws-native": "dev"
+  }
+}

--- a/examples/cidr-ts/tsconfig.json
+++ b/examples/cidr-ts/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -29,6 +29,15 @@ func TestGetTs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestVpcCidrs(t *testing.T) {
+	test := getJSBaseOptions(t).
+		With(integration.ProgramTestOptions{
+			Dir: filepath.Join(getCwd(t), "cidr-ts"),
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestUpdate(t *testing.T) {
 	test := getJSBaseOptions(t).
 		With(integration.ProgramTestOptions{


### PR DESCRIPTION
In #1791 we \"fixed\" the cidr function so that it would generate subnets
correctly. We did not fix it correctly though. This cidr function needs
to match the logic that the CloudFormation Fn::Cidr function has.

Critically the `cidrBits` logic was incorrect. It should be the inverse
of the subnet mask that you want to have for the subnets.

For example a `cidrBits` of 5 means that I want subnets with a mask of
`/27` (32-5=27).

```ts
cidr({
  ipBlock: '192.168.0.0/24',
  count: 6,
  cidrBits: 5,
});
```