### PR TITLE
Additional backof delay for retrying Resource.Get Not Found

### DIFF
--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -202,7 +202,7 @@ func (c *clientImpl) getResourceRetryNotFound(
 }
 
 func (*clientImpl) getResourceRetryNotFoundRetrySettings() (int, *retry.ExponentialJitterBackoff) {
-	retryBackoff := retry.NewExponentialJitterBackoff(3 * time.Second)
-	maxAttempts := 3
+	retryBackoff := retry.NewExponentialJitterBackoff(5 * time.Second)
+	maxAttempts := 5
 	return maxAttempts, retryBackoff
 }

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -375,7 +375,17 @@ func TestGetResourceRetryNotFoundRetrySettings(t *testing.T) {
 	for attempt := 0; attempt < attempts; attempt++ {
 		delay, err := backoff.BackoffDelay(attempt, nil)
 		require.NoError(t, err)
+		t.Logf("attempt %d delay is %v", attempt, delay)
 		totalDelay += delay
 	}
-	require.LessOrEqual(t, totalDelay, 10*time.Second)
+	// Typical test output (though it is random):
+	//
+	// client_test.go:378: attempt 0 delay is 745.506998ms
+	// client_test.go:378: attempt 1 delay is 1.229581817s
+	// client_test.go:378: attempt 2 delay is 931.993865ms
+	// client_test.go:378: attempt 3 delay is 5s
+	// client_test.go:378: attempt 4 delay is 5s
+	//
+	// The worst case wait is 25 seconds.
+	require.LessOrEqual(t, totalDelay, 25*time.Second)
 }


### PR DESCRIPTION
It appears that the CDK test suite is still failing, so this change adjusts the backoff/retry on Resource.Get to be more generous and allow more time. 

https://github.com/pulumi/pulumi-cdk/actions/runs/11818972903/job/32927805461?pr=212
