### PR TITLE
Exclude tools dir fom codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,5 @@ coverage:
     patch:
       default:
         informational: true
+  ignore:
+    - "provider/tools"


### PR DESCRIPTION
I'm assuming since this is just tooling to generate the ref metadata, we don't feel like it needs to be covered with extensive testing.