### PR TITLE
chore: revert .github/workflow changes from the previous PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -65,7 +65,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
@@ -159,7 +159,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -172,7 +172,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -264,7 +264,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -277,7 +277,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -370,7 +370,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -383,7 +383,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
@@ -421,7 +421,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
@@ -440,7 +440,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
     - name: Setup Node
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/cf2pulumi-release.yml
+++ b/.github/workflows/cf2pulumi-release.yml
@@ -43,7 +43,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install pulumictl

--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -44,7 +44,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
@@ -151,7 +151,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -164,7 +164,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -255,7 +255,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -268,7 +268,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -361,7 +361,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -374,7 +374,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
@@ -412,7 +412,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
@@ -431,7 +431,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -495,7 +495,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -508,7 +508,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
@@ -546,7 +546,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Download go SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -57,7 +57,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
@@ -151,7 +151,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -164,7 +164,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -255,7 +255,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -268,7 +268,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -361,7 +361,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -374,7 +374,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Configure AWS Credentials
@@ -412,7 +412,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Checkout Scripts Repo
@@ -431,7 +431,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -495,7 +495,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -508,7 +508,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
@@ -546,7 +546,7 @@ jobs:
         lfs: true
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Download go SDK

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -66,7 +66,7 @@ jobs:
         ref: ${{ env.PR_COMMIT_SHA }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -79,7 +79,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - if: github.event_name == 'pull_request'
@@ -176,7 +176,7 @@ jobs:
         ref: ${{ env.PR_COMMIT_SHA }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -189,7 +189,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node
@@ -284,7 +284,7 @@ jobs:
         ref: ${{ env.PR_COMMIT_SHA }}
     - id: version
       name: Set Provider Version
-      uses: pulumi/provider-version-action@7c54f136703646f7d6eaa3d3b3c877e5a805d6ab # v1
+      uses: pulumi/provider-version-action@v1
       with:
         set-env: PROVIDER_VERSION
     - name: Install Go
@@ -297,7 +297,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup Node

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
-      uses: pulumi/actions@c7fad9e2f0b79653172b36538b8b34b3c0291952 # v6
+      uses: pulumi/actions@v5
       with:
         pulumi-version-file: .pulumi.version
     - name: Setup DotNet


### PR DESCRIPTION
Per @blampe Renovate bot has been updated not to touch these workflows as they are managed by ci-mgmt for the moment.