### PR TITLE
Expose primary identifier information in the metadata

### DIFF
--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -29,6 +29,14 @@ type CloudAPIResource struct {
 
 	// Describes the behavior of the CF Ref intrinsic for this resource.
 	CfRef *CfRefBehavior `json:"cfRef,omitempty"`
+
+	// PrimaryIdentifier is a list of Pulumi property names that together uniquely identify a resource.
+	//
+	// If more than one property is given, the values may be joined with the "|" character to form a specific
+	// resource identifier value suitable for use with the Cloud Control API.
+	//
+	// See also https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-identifier.html
+	PrimaryIdentifier []string `json:"primaryIdentifier,omitempty"`
 }
 
 type AutoNamingSpec struct {

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -954,8 +954,18 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 		IrreversibleNames: irreversibleNames,
 		TagsProperty:      naming.ToSdkName(tagsProp),
 		TagsStyle:         tagsStyle,
+		PrimaryIdentifier: ctx.gatherResourcePrimaryIdentifier(),
 	}
 	return nil
+}
+
+func (ctx *cfSchemaContext) gatherResourcePrimaryIdentifier() []string {
+	primaryIdentifier := readPropNames(ctx.resourceSpec, "primaryIdentifier")
+	identifiers := make([]string, len(primaryIdentifier))
+	for i, v := range primaryIdentifier {
+		identifiers[i] = naming.ToSdkName(v)
+	}
+	return identifiers
 }
 
 func addUntypedPropDocs(propertySpec *pschema.PropertySpec, cfTypeName string) {


### PR DESCRIPTION
primaryIdentifier is a CloudControl concept that with this change will be exposed in the provider metadata. One of the use cases is correlating identifiers when importing state provisioned by `cdk` into `pulumi-cdk` managed stacks. 