### PR TITLE
Regenerate SDK

### DIFF
--- a/sdk/nodejs/invoicing/getInvoiceUnit.ts
+++ b/sdk/nodejs/invoicing/getInvoiceUnit.ts
@@ -32,7 +32,7 @@ export interface GetInvoiceUnitResult {
 /**
  * An invoice unit is a set of mutually exclusive accounts that correspond to your business entity. Invoice units allow you to separate AWS account costs and configures your invoice for each business entity.
  */
-export function getInvoiceUnitOutput(args: GetInvoiceUnitOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetInvoiceUnitResult> {
+export function getInvoiceUnitOutput(args: GetInvoiceUnitOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetInvoiceUnitResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("aws-native:invoicing:getInvoiceUnit", {
         "invoiceUnitArn": args.invoiceUnitArn,

--- a/sdk/nodejs/logs/getIntegration.ts
+++ b/sdk/nodejs/logs/getIntegration.ts
@@ -33,7 +33,7 @@ export interface GetIntegrationResult {
 /**
  * Resource Schema for Logs Integration Resource
  */
-export function getIntegrationOutput(args: GetIntegrationOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetIntegrationResult> {
+export function getIntegrationOutput(args: GetIntegrationOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetIntegrationResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("aws-native:logs:getIntegration", {
         "integrationName": args.integrationName,

--- a/sdk/nodejs/memorydb/getMultiRegionCluster.ts
+++ b/sdk/nodejs/memorydb/getMultiRegionCluster.ts
@@ -61,7 +61,7 @@ export interface GetMultiRegionClusterResult {
 /**
  * The AWS::MemoryDB::Multi Region Cluster resource creates an Amazon MemoryDB Multi Region Cluster.
  */
-export function getMultiRegionClusterOutput(args: GetMultiRegionClusterOutputArgs, opts?: pulumi.InvokeOptions): pulumi.Output<GetMultiRegionClusterResult> {
+export function getMultiRegionClusterOutput(args: GetMultiRegionClusterOutputArgs, opts?: pulumi.InvokeOutputOptions): pulumi.Output<GetMultiRegionClusterResult> {
     opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts || {});
     return pulumi.runtime.invokeOutput("aws-native:memorydb:getMultiRegionCluster", {
         "multiRegionClusterName": args.multiRegionClusterName,

--- a/sdk/python/pulumi_aws_native/invoicing/get_invoice_unit.py
+++ b/sdk/python/pulumi_aws_native/invoicing/get_invoice_unit.py
@@ -108,13 +108,13 @@ def get_invoice_unit(invoice_unit_arn: Optional[str] = None,
         rule=pulumi.get(__ret__, 'rule'),
         tax_inheritance_disabled=pulumi.get(__ret__, 'tax_inheritance_disabled'))
 def get_invoice_unit_output(invoice_unit_arn: Optional[pulumi.Input[str]] = None,
-                            opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetInvoiceUnitResult]:
+                            opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetInvoiceUnitResult]:
     """
     An invoice unit is a set of mutually exclusive accounts that correspond to your business entity. Invoice units allow you to separate AWS account costs and configures your invoice for each business entity.
     """
     __args__ = dict()
     __args__['invoiceUnitArn'] = invoice_unit_arn
-    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
+    opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke_output('aws-native:invoicing:getInvoiceUnit', __args__, opts=opts, typ=GetInvoiceUnitResult)
     return __ret__.apply(lambda __response__: GetInvoiceUnitResult(
         description=pulumi.get(__response__, 'description'),

--- a/sdk/python/pulumi_aws_native/logs/get_integration.py
+++ b/sdk/python/pulumi_aws_native/logs/get_integration.py
@@ -63,7 +63,7 @@ def get_integration(integration_name: Optional[str] = None,
     return AwaitableGetIntegrationResult(
         integration_status=pulumi.get(__ret__, 'integration_status'))
 def get_integration_output(integration_name: Optional[pulumi.Input[str]] = None,
-                           opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetIntegrationResult]:
+                           opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetIntegrationResult]:
     """
     Resource Schema for Logs Integration Resource
 
@@ -72,7 +72,7 @@ def get_integration_output(integration_name: Optional[pulumi.Input[str]] = None,
     """
     __args__ = dict()
     __args__['integrationName'] = integration_name
-    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
+    opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke_output('aws-native:logs:getIntegration', __args__, opts=opts, typ=GetIntegrationResult)
     return __ret__.apply(lambda __response__: GetIntegrationResult(
         integration_status=pulumi.get(__response__, 'integration_status')))

--- a/sdk/python/pulumi_aws_native/memorydb/get_multi_region_cluster.py
+++ b/sdk/python/pulumi_aws_native/memorydb/get_multi_region_cluster.py
@@ -154,7 +154,7 @@ def get_multi_region_cluster(multi_region_cluster_name: Optional[str] = None,
         status=pulumi.get(__ret__, 'status'),
         tags=pulumi.get(__ret__, 'tags'))
 def get_multi_region_cluster_output(multi_region_cluster_name: Optional[pulumi.Input[str]] = None,
-                                    opts: Optional[pulumi.InvokeOptions] = None) -> pulumi.Output[GetMultiRegionClusterResult]:
+                                    opts: Optional[Union[pulumi.InvokeOptions, pulumi.InvokeOutputOptions]] = None) -> pulumi.Output[GetMultiRegionClusterResult]:
     """
     The AWS::MemoryDB::Multi Region Cluster resource creates an Amazon MemoryDB Multi Region Cluster.
 
@@ -163,7 +163,7 @@ def get_multi_region_cluster_output(multi_region_cluster_name: Optional[pulumi.I
     """
     __args__ = dict()
     __args__['multiRegionClusterName'] = multi_region_cluster_name
-    opts = pulumi.InvokeOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
+    opts = pulumi.InvokeOutputOptions.merge(_utilities.get_invoke_opts_defaults(), opts)
     __ret__ = pulumi.runtime.invoke_output('aws-native:memorydb:getMultiRegionCluster', __args__, opts=opts, typ=GetMultiRegionClusterResult)
     return __ret__.apply(lambda __response__: GetMultiRegionClusterResult(
         arn=pulumi.get(__response__, 'arn'),


### PR DESCRIPTION
Merging both #1870 and #1875 on top of each other caused the SDK to go out of sync. This PR just regenerates the SDK to get a passing build again.

Fixes https://github.com/pulumi/pulumi-aws-native/issues/1877