### PR TITLE
chore: do not clean untracked files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,6 @@ generate_python: .pulumi/bin/pulumi
 	.pulumi/bin/pulumi package gen-sdk provider/cmd/pulumi-resource-aws-native/schema.json --language python --version "$(VERSION_GENERIC)"
 
 build_python::
-	# Delete files not tracked in Git
-	cd sdk/python/ && git clean -fxd
 	cd sdk/python/ && \
         cp ../../README.md . && \
         rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \


### PR DESCRIPTION
I don't know why we were running `git clean` here, but we don't do that
in any other providers. This is preventing our check worktree clean job
to correctly catch when new sdk files are not checked in.

fixes #1827