### PR TITLE
chore: add readOnlyProperties to metadata

### DIFF
--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -22,6 +22,7 @@ type CloudAPIResource struct {
 	AutoNamingSpec    *AutoNamingSpec                 `json:"autoNamingSpec,omitempty"`
 	Required          []string                        `json:"required,omitempty"`
 	CreateOnly        []string                        `json:"createOnly,omitempty"`
+	ReadOnly          []string                        `json:"readOnly,omitempty"`
 	WriteOnly         []string                        `json:"writeOnly,omitempty"`
 	IrreversibleNames map[string]string               `json:"irreversibleNames,omitempty"`
 	TagsProperty      string                          `json:"tagsProperty,omitempty"`

--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -16,17 +16,30 @@ type CloudAPIMetadata struct {
 
 // CloudAPIResource contains metadata for a single AWS Resource.
 type CloudAPIResource struct {
-	CfType            string                          `json:"cf"`
-	Inputs            map[string]pschema.PropertySpec `json:"inputs"`
-	Outputs           map[string]pschema.PropertySpec `json:"outputs"`
-	AutoNamingSpec    *AutoNamingSpec                 `json:"autoNamingSpec,omitempty"`
-	Required          []string                        `json:"required,omitempty"`
-	CreateOnly        []string                        `json:"createOnly,omitempty"`
-	ReadOnly          []string                        `json:"readOnly,omitempty"`
-	WriteOnly         []string                        `json:"writeOnly,omitempty"`
-	IrreversibleNames map[string]string               `json:"irreversibleNames,omitempty"`
-	TagsProperty      string                          `json:"tagsProperty,omitempty"`
-	TagsStyle         default_tags.TagsStyle          `json:"tagsStyle,omitempty"`
+	CfType         string                          `json:"cf"`
+	Inputs         map[string]pschema.PropertySpec `json:"inputs"`
+	Outputs        map[string]pschema.PropertySpec `json:"outputs"`
+	AutoNamingSpec *AutoNamingSpec                 `json:"autoNamingSpec,omitempty"`
+	Required       []string                        `json:"required,omitempty"`
+	CreateOnly     []string                        `json:"createOnly,omitempty"`
+	// ReadOnly properties are properties that only exist as output values
+	// The properties can be top level properties or can be nested within object or array
+	// properties.
+	// '/' is used to denote a nested object property
+	// '/*/' is used to denote a nested array property
+	// e.g.
+	// - ReadOnly: [
+	//     'arn', // top level
+	//     'someObjectProp/arn', // the arn value of someObjectProp is an output (but not the other properties of someObjectProp)
+	//     'someArrayProp/*/someObjectProp/arn'
+	//   ]
+	//
+	// NOTE: The values in this property will have been converted from CFN casing to pulumi sdk casing
+	ReadOnly          []string               `json:"readOnly,omitempty"`
+	WriteOnly         []string               `json:"writeOnly,omitempty"`
+	IrreversibleNames map[string]string      `json:"irreversibleNames,omitempty"`
+	TagsProperty      string                 `json:"tagsProperty,omitempty"`
+	TagsStyle         default_tags.TagsStyle `json:"tagsStyle,omitempty"`
 
 	// Describes the behavior of the CF Ref intrinsic for this resource.
 	CfRef *CfRefBehavior `json:"cfRef,omitempty"`

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -848,8 +848,8 @@ func readPropSdkNames(resourceSpec *jsschema.Schema, listName string) codegen.St
 	if p, ok := resourceSpec.Extras[listName]; ok {
 		pSlice := p.([]interface{})
 		for _, v := range pSlice {
-			n := strings.TrimPrefix(v.(string), "/properties/")
-			output.Add(naming.ToSdkName(n))
+			n := ResourceProperty(strings.TrimPrefix(v.(string), "/properties/"))
+			output.Add(n.ToSdkName())
 		}
 	}
 	return output
@@ -951,6 +951,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 		Required:          requiredInputs.SortedValues(),
 		AutoNamingSpec:    autoNamingSpec,
 		WriteOnly:         writeOnlyProperties.SortedValues(),
+		ReadOnly:          readPropSdkNames(ctx.resourceSpec, "readOnlyProperties").SortedValues(),
 		IrreversibleNames: irreversibleNames,
 		TagsProperty:      naming.ToSdkName(tagsProp),
 		TagsStyle:         tagsStyle,

--- a/provider/pkg/schema/resource_props.go
+++ b/provider/pkg/schema/resource_props.go
@@ -1,0 +1,31 @@
+package schema
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+)
+
+// Represents a property listed in `readOnlyProperties`, `writeOnlyProperties`,
+// or `createOnlyProperties` in the Cloud Control schema.
+type ResourceProperty string
+
+// ToSdkName converts the property name to an SDK-compatible name.
+// This will also handle converting all nested properties.
+//   - Nested object properties are delimited with `/`
+//   - Nested array properties are delimited with `/*/`
+//
+// e.g.
+//   - `Foo/Bar/Baz` => `foo/bar/baz`
+//   - `Foo/*/BarBaz` => `foo/*/barBaz`
+func (r *ResourceProperty) ToSdkName() string {
+	arrayProps := strings.Split(string(*r), "/*/")
+	for i, p := range arrayProps {
+		nested := strings.Split(p, "/")
+		for idx, n := range nested {
+			nested[idx] = naming.ToSdkName(n)
+		}
+		arrayProps[i] = strings.Join(nested, "/")
+	}
+	return strings.Join(arrayProps, "/*/")
+}

--- a/provider/pkg/schema/resource_props.go
+++ b/provider/pkg/schema/resource_props.go
@@ -18,8 +18,8 @@ type ResourceProperty string
 // e.g.
 //   - `Foo/Bar/Baz` => `foo/bar/baz`
 //   - `Foo/*/BarBaz` => `foo/*/barBaz`
-func (r *ResourceProperty) ToSdkName() string {
-	arrayProps := strings.Split(string(*r), "/*/")
+func (r ResourceProperty) ToSdkName() string {
+	arrayProps := strings.Split(string(r), "/*/")
 	for i, p := range arrayProps {
 		nested := strings.Split(p, "/")
 		for idx, n := range nested {

--- a/provider/pkg/schema/resource_props_test.go
+++ b/provider/pkg/schema/resource_props_test.go
@@ -1,0 +1,36 @@
+package schema
+
+import "testing"
+
+func TestToSdkName(t *testing.T) {
+	cases := map[string]struct {
+		input    ResourceProperty
+		expected string
+	}{
+		"simple": {
+			input:    "Foo",
+			expected: "foo",
+		},
+		"nestedObject": {
+			input:    "Foo/BarBaz",
+			expected: "foo/barBaz",
+		},
+		"nestedArray": {
+			input:    "Foo/*/BarBaz",
+			expected: "foo/*/barBaz",
+		},
+		"nestedArrayObject": {
+			input:    "Foo/*/Bar/Baz",
+			expected: "foo/*/bar/baz",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := tc.input.ToSdkName()
+			if actual != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/provider/pkg/schema/resource_props_test.go
+++ b/provider/pkg/schema/resource_props_test.go
@@ -23,6 +23,10 @@ func TestToSdkName(t *testing.T) {
 			input:    "Foo/*/Bar/Baz",
 			expected: "foo/*/bar/baz",
 		},
+		"multiNestedArrayObject": {
+			input:    "Foo/*/Bar/*/Baz/Hello",
+			expected: "foo/*/bar/*/baz/hello",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
This PR adds `readOnlyProperties` to the pulumi metadata. It also fixes
an issue with all properties (`readOnly/createOnly/writeOnly`) where
nested properties where not converted to the correct sdk name value.