### PR TITLE
Implement autonaming configuration protocol

### DIFF
--- a/provider/pkg/autonaming/application_test.go
+++ b/provider/pkg/autonaming/application_test.go
@@ -146,13 +146,13 @@ func Test_getDefaultName(t *testing.T) {
 					},
 				},
 			}
-			got, has, err := getDefaultName(urn, tt.engineAutonaming, autoNamingSpec, tt.olds, tt.news, nil)
+			got, err := getDefaultName(urn, tt.engineAutonaming, autoNamingSpec, tt.olds, tt.news, nil)
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, tt.noName, !has)
+				require.Equal(t, tt.noName, got == nil)
 			}
 			if !tt.comparison(t, got) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", *got, autoNamingSpec)
@@ -264,13 +264,13 @@ func Test_getDefaultName_withAutoNameConfig(t *testing.T) {
 
 			autoNameConfig := tt.autoNameConfig
 			engineAutonaming := EngineAutonamingConfiguration{}
-			got, has, err := getDefaultName(urn, engineAutonaming, autoNamingSpec, tt.olds, tt.news, &autoNameConfig)
+			got, err := getDefaultName(urn, engineAutonaming, autoNamingSpec, tt.olds, tt.news, &autoNameConfig)
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
 			} else {
 				require.NoError(t, err)
-				require.True(t, has)
+				require.True(t, got != nil)
 			}
 			if !tt.comparison(t, got) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", *got, autoNamingSpec)

--- a/provider/pkg/autonaming/semantics.go
+++ b/provider/pkg/autonaming/semantics.go
@@ -27,6 +27,9 @@ func CheckNamingTrivia(sdkName string, props resource.PropertyMap, spec *metadat
 	if err != nil {
 		return false, nil, err
 	}
+	if !namingTriviaApplies {
+		return false, nil, nil
+	}
 	namingTrivia := *spec.Trivia
 
 	return namingTriviaApplies, &namingTrivia, nil

--- a/provider/pkg/provider/provider_2e2_test.go
+++ b/provider/pkg/provider/provider_2e2_test.go
@@ -32,7 +32,7 @@ func TestE2eSnapshots(t *testing.T) {
 }
 
 func TestAutonaming(t *testing.T) {
-	t.Parallel()
+	skipIfShort(t)
 	pt := newAwsTest(t, filepath.Join("testdata", "autonaming"), opttest.Env("PULUMI_EXPERIMENTAL", "1"))
 	pt.Preview(t)
 	up := pt.Up(t)
@@ -75,4 +75,10 @@ func testProviderServer() (pulumirpc.ResourceProviderServer, error) {
 		return nil, err
 	}
 	return provider.NewAwsNativeProvider(nil, "aws-native", "0.1.0", schemaBytes, metadataBytes)
+}
+
+func skipIfShort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
 }

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -66,7 +66,7 @@ func TestConfigure(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.NotNil(t, provider.autoNamingConfig)
-		assert.Equal(t, autonaming.AutoNamingConfig{
+		assert.Equal(t, autonaming.ProviderAutoNamingConfig{
 			AutoTrim:              true,
 			RandomSuffixMinLength: 5,
 		}, *provider.autoNamingConfig)
@@ -85,7 +85,7 @@ func TestConfigure(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.NotNil(t, provider.autoNamingConfig)
-		assert.Equal(t, autonaming.AutoNamingConfig{}, *provider.autoNamingConfig)
+		assert.Equal(t, autonaming.ProviderAutoNamingConfig{}, *provider.autoNamingConfig)
 	})
 
 	t.Run("AutoNaming config invalid", func(t *testing.T) {

--- a/provider/pkg/provider/testdata/autonaming/Pulumi.yaml
+++ b/provider/pkg/provider/testdata/autonaming/Pulumi.yaml
@@ -1,0 +1,24 @@
+name: autonaming
+description: Autonaming configuration example
+runtime: yaml
+config:
+  pulumi:autonaming:
+    value:
+      providers:
+        aws-native:
+          pattern: ${project}-${name}-${alphanum(6)}
+          resources:
+            aws-native:sqs:Queue:
+              pattern: ${name}
+resources:
+  log:
+    type: aws-native:logs:LogGroup
+    properties:
+      retentionInDays: 90
+  queue:
+    type: aws-native:sqs:Queue
+    properties:
+      fifoQueue: true
+outputs:
+  logGroupName: ${log.arn}
+  fifoQueueName: ${queue.queueName}

--- a/provider/pkg/resources/cfn_custom_resource.go
+++ b/provider/pkg/resources/cfn_custom_resource.go
@@ -233,7 +233,7 @@ type customResourceInvokeData struct {
 
 // Check validates the inputs of the resource and applies default values if necessary.
 // It returns the inputs, validation failures, and an error if the inputs cannot be unmarshalled.
-func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming.EngineAutonamingConfiguration, inputs resource.PropertyMap, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming.EngineAutoNamingConfig, inputs resource.PropertyMap, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {

--- a/provider/pkg/resources/cfn_custom_resource.go
+++ b/provider/pkg/resources/cfn_custom_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/cfn"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	"github.com/pulumi/pulumi-go-provider/resourcex"
@@ -232,7 +233,7 @@ type customResourceInvokeData struct {
 
 // Check validates the inputs of the resource and applies default values if necessary.
 // It returns the inputs, validation failures, and an error if the inputs cannot be unmarshalled.
-func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, randomSeed []byte, inputs resource.PropertyMap, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming.EngineAutonamingConfiguration, inputs resource.PropertyMap, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {

--- a/provider/pkg/resources/cfn_custom_resource_test.go
+++ b/provider/pkg/resources/cfn_custom_resource_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/cfn"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -89,12 +90,12 @@ func TestCfnCustomResource_Check(t *testing.T) {
 		{
 			name: "Unknown inputs",
 			inputs: resource.PropertyMap{
-				"serviceToken":             resource.MakeComputed(resource.NewStringProperty("")),
-				"stackId":                  resource.MakeComputed(resource.NewStringProperty("")),
+				"serviceToken": resource.MakeComputed(resource.NewStringProperty("")),
+				"stackId":      resource.MakeComputed(resource.NewStringProperty("")),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken":             resource.MakeComputed(resource.NewStringProperty("")),
-				"stackId":                  resource.MakeComputed(resource.NewStringProperty("")),
+				"serviceToken": resource.MakeComputed(resource.NewStringProperty("")),
+				"stackId":      resource.MakeComputed(resource.NewStringProperty("")),
 			},
 		},
 		{
@@ -117,11 +118,13 @@ func TestCfnCustomResource_Check(t *testing.T) {
 			c := &cfnCustomResource{}
 			ctx := context.Background()
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
-			randomSeed := []byte{}
+			engineAutonaming := autonaming.EngineAutonamingConfiguration{
+				RandomSeed: []byte{},
+			}
 			state := resource.PropertyMap{}
 			defaultTags := map[string]string{}
 
-			newInputs, failures, err := c.Check(ctx, urn, randomSeed, tt.inputs, state, defaultTags)
+			newInputs, failures, err := c.Check(ctx, urn, engineAutonaming, tt.inputs, state, defaultTags)
 
 			if tt.expectedError != nil {
 				assert.Error(t, err)
@@ -233,7 +236,7 @@ func TestCfnCustomResource_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "CustomResource without response data",
+			name:               "CustomResource without response data",
 			customResourceData: nil,
 			customResourceInputs: map[string]interface{}{
 				"key1": "value1",
@@ -624,7 +627,7 @@ func TestCfnCustomResource_Update(t *testing.T) {
 			newCustomResourceData: map[string]interface{}{"new": "value"},
 		},
 		{
-			name: "CustomResource without response data",
+			name:                  "CustomResource without response data",
 			newCustomResourceData: nil,
 		},
 	}

--- a/provider/pkg/resources/cfn_custom_resource_test.go
+++ b/provider/pkg/resources/cfn_custom_resource_test.go
@@ -118,7 +118,7 @@ func TestCfnCustomResource_Check(t *testing.T) {
 			c := &cfnCustomResource{}
 			ctx := context.Background()
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
-			engineAutonaming := autonaming.EngineAutonamingConfiguration{
+			engineAutonaming := autonaming.EngineAutoNamingConfig{
 				RandomSeed: []byte{},
 			}
 			state := resource.PropertyMap{}

--- a/provider/pkg/resources/custom.go
+++ b/provider/pkg/resources/custom.go
@@ -6,13 +6,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 //go:generate mockgen -package resources -source custom.go -destination mock_custom_resource.go CustomResource
 type CustomResource interface {
 	// Check validates and transforms the inputs of the resource.
-	Check(ctx context.Context, urn resource.URN, randomSeed []byte, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error)
+	Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutonamingConfiguration,
+		inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error)
 	// Create creates a new resource in the cloud provider and returns its unique identifier and outputs.
 	Create(ctx context.Context, urn resource.URN, inputs resource.PropertyMap, timeout time.Duration) (identifier *string, outputs resource.PropertyMap, err error)
 	// Read returns the outputs and the updated inputs of the resource.

--- a/provider/pkg/resources/custom.go
+++ b/provider/pkg/resources/custom.go
@@ -13,7 +13,7 @@ import (
 //go:generate mockgen -package resources -source custom.go -destination mock_custom_resource.go CustomResource
 type CustomResource interface {
 	// Check validates and transforms the inputs of the resource.
-	Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutonamingConfiguration,
+	Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutoNamingConfig,
 		inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error)
 	// Create creates a new resource in the cloud provider and returns its unique identifier and outputs.
 	Create(ctx context.Context, urn resource.URN, inputs resource.PropertyMap, timeout time.Duration) (identifier *string, outputs resource.PropertyMap, err error)

--- a/provider/pkg/resources/extension_resource.go
+++ b/provider/pkg/resources/extension_resource.go
@@ -46,7 +46,7 @@ func NewExtensionResource(client client.CloudControlClient) *extensionResource {
 }
 
 func (r *extensionResource) Check(ctx context.Context, urn resource.URN,
-	engineAutonaming autonaming.EngineAutonamingConfiguration, inputs, state resource.PropertyMap,
+	engineAutonaming autonaming.EngineAutoNamingConfig, inputs, state resource.PropertyMap,
 	defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs ExtensionResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
@@ -66,7 +66,7 @@ func (r *extensionResource) Check(ctx context.Context, urn resource.URN,
 			SdkName:   typedInputs.AutoNaming.PropertyName,
 			MinLength: typedInputs.AutoNaming.MinLength,
 			MaxLength: typedInputs.AutoNaming.MaxLength,
-		}, urn, engineAutonaming, state, inputs, nil); err != nil {
+		}, urn, engineAutonaming, nil, state, inputs); err != nil {
 			return nil, nil, fmt.Errorf("failed to apply auto-naming: %w", err)
 		}
 	}

--- a/provider/pkg/resources/extension_resource.go
+++ b/provider/pkg/resources/extension_resource.go
@@ -45,7 +45,9 @@ func NewExtensionResource(client client.CloudControlClient) *extensionResource {
 	}
 }
 
-func (r *extensionResource) Check(ctx context.Context, urn resource.URN, randomSeed []byte, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (r *extensionResource) Check(ctx context.Context, urn resource.URN,
+	engineAutonaming autonaming.EngineAutonamingConfiguration, inputs, state resource.PropertyMap,
+	defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs ExtensionResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -64,7 +66,7 @@ func (r *extensionResource) Check(ctx context.Context, urn resource.URN, randomS
 			SdkName:   typedInputs.AutoNaming.PropertyName,
 			MinLength: typedInputs.AutoNaming.MinLength,
 			MaxLength: typedInputs.AutoNaming.MaxLength,
-		}, urn, randomSeed, state, inputs, nil); err != nil {
+		}, urn, engineAutonaming, state, inputs, nil); err != nil {
 			return nil, nil, fmt.Errorf("failed to apply auto-naming: %w", err)
 		}
 	}

--- a/provider/pkg/resources/mock_custom_resource.go
+++ b/provider/pkg/resources/mock_custom_resource.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	autonaming "github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	resource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -43,9 +44,9 @@ func (m *MockCustomResource) EXPECT() *MockCustomResourceMockRecorder {
 }
 
 // Check mocks base method.
-func (m *MockCustomResource) Check(ctx context.Context, urn resource.URN, randomSeed []byte, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (m *MockCustomResource) Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutonamingConfiguration, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Check", ctx, urn, randomSeed, inputs, state, defaultTags)
+	ret := m.ctrl.Call(m, "Check", ctx, urn, engineAutonaming, inputs, state, defaultTags)
 	ret0, _ := ret[0].(resource.PropertyMap)
 	ret1, _ := ret[1].([]ValidationFailure)
 	ret2, _ := ret[2].(error)
@@ -53,9 +54,9 @@ func (m *MockCustomResource) Check(ctx context.Context, urn resource.URN, random
 }
 
 // Check indicates an expected call of Check.
-func (mr *MockCustomResourceMockRecorder) Check(ctx, urn, randomSeed, inputs, state, defaultTags any) *gomock.Call {
+func (mr *MockCustomResourceMockRecorder) Check(ctx, urn, engineAutonaming, inputs, state, defaultTags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockCustomResource)(nil).Check), ctx, urn, randomSeed, inputs, state, defaultTags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockCustomResource)(nil).Check), ctx, urn, engineAutonaming, inputs, state, defaultTags)
 }
 
 // Create mocks base method.

--- a/provider/pkg/resources/mock_custom_resource.go
+++ b/provider/pkg/resources/mock_custom_resource.go
@@ -44,7 +44,7 @@ func (m *MockCustomResource) EXPECT() *MockCustomResourceMockRecorder {
 }
 
 // Check mocks base method.
-func (m *MockCustomResource) Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutonamingConfiguration, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (m *MockCustomResource) Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutoNamingConfig, inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Check", ctx, urn, engineAutonaming, inputs, state, defaultTags)
 	ret0, _ := ret[0].(resource.PropertyMap)


### PR DESCRIPTION
This PR implement the AWS Native part of https://github.com/pulumi/pulumi/issues/1518. See https://github.com/pulumi/pulumi/discussions/17592 for the full design.

In short, https://github.com/pulumi/pulumi/pull/17810 introduced the protobuf changes required for the provider-side implementation. With those, a provider can:

- Declare that it supports autonaming configurations with a response flag in Configure
- Accept two extra properties in CheckRequest: a proposed name and a mode to apply it

This PR applies those parameters to auto-name calculation if they are specified:

- In Disabled mode, we don't calculate auto-names and let the resource validation fail if an explicit name is not specified. For that, I had to thread an extra `bool` flag through autonaming machinery.
- In Enforce mode, we use whatever ProposedName is supplied by the engine
- In Propose mode, we take the ProposedName but can also apply trivia (e.g. add a suffix, as in the e2e test), or check the max/min length

I added unit tests to cover most autonaming cases. Also, added an end-to-end test in YAML. Apparently, end-2-end tests had no AWS credentials configured, so I added those. Let me know if that's against the intention.

Resolves https://github.com/pulumi/pulumi-aws-native/issues/1901