### PR TITLE
Fix TestAutonaming flakiness

### DIFF
--- a/provider/pkg/provider/provider_2e2_test.go
+++ b/provider/pkg/provider/provider_2e2_test.go
@@ -41,7 +41,9 @@ func TestAutonaming(t *testing.T) {
 	assert.Contains(t, logGroupName, "autonaming-log-") // project + name + random suffix
 	fifoQueueName, ok := up.Outputs["fifoQueueName"].Value.(string)
 	assert.True(t, ok)
-	assert.Contains(t, fifoQueueName, "queue.fifo") // verbatim name + resource's autonaming trivia suffix
+
+	// Check that the queue name matches pattern: ${name}-${alphanum(6)}.fifo (.fifo is the resource's autonaming trivia suffix)
+	assert.Regexp(t, `^queue-[a-zA-Z0-9]{6}\.fifo$`, fifoQueueName)
 }
 
 func testUpgradeFrom(t *testing.T, test *pulumitest.PulumiTest, version string) {

--- a/provider/pkg/provider/testdata/autonaming/Pulumi.yaml
+++ b/provider/pkg/provider/testdata/autonaming/Pulumi.yaml
@@ -9,7 +9,7 @@ config:
           pattern: ${project}-${name}-${alphanum(6)}
           resources:
             aws-native:sqs:Queue:
-              pattern: ${name}
+              pattern: ${name}-${alphanum(6)}
 resources:
   log:
     type: aws-native:logs:LogGroup


### PR DESCRIPTION
`TestAutonaming` occasionally fails if test runs are running within 1 minute of each other because SQS does not allow recreating a deleted queue within 60s:
```
          aws-native:sqs:Queue (queue):
            error: creating resource: creating resource (await): operation CREATE failed with "Throttling": You must wait 60 seconds after deleting a queue before you can create another with the same name. (Service: Sqs, Status Code: 400, Request ID: 7503e9ea-2fa2-5fba-b1cc-b6117f9af4d4)
```

To fix this I added some random parts to the resource name

Fixes https://github.com/pulumi/pulumi-aws-native/issues/1983