### PR TITLE
Add pull request:write permissions to nightly build Workflow

### DIFF
--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
+      content: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -37,7 +37,7 @@ jobs:
     permissions:
       id-token: write
       pull-requests: write
-      content: write
+      contents: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/nightly-sdk-generation.yml
+++ b/.github/workflows/nightly-sdk-generation.yml
@@ -36,6 +36,7 @@ jobs:
     name: generate-sdk
     permissions:
       id-token: write
+      pull-requests: write
     steps:
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Proposed fix for https://github.com/pulumi/pulumi-aws-native/issues/2145.

update: it looks like the nightly build needs more than pull request permissions: https://github.com/pulumi/pulumi-aws-native/actions/runs/14070213304/job/39402424273#step:16:6

update: the nightly job pushes directly to a branch on origin so it needs `contents` permissions as well.
Successful run here: https://github.com/pulumi/pulumi-aws-native/actions/runs/14070892002/job/39404595733
Generated PR here: https://github.com/pulumi/pulumi-aws-native/pull/2149
