### PR TITLE
Java 1.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CODEGEN         := pulumi-gen-${PACK}
 WORKING_DIR		:= $(shell pwd)
 
 JAVA_GEN		 := pulumi-java-gen
-JAVA_GEN_VERSION := v0.9.7
+JAVA_GEN_VERSION := v1.16.0
 
 # Override during CI using `make [TARGET] PROVIDER_VERSION=""` or by setting a PROVIDER_VERSION environment variable
 # Local & branch builds will just used this fixed default version unless specified

--- a/sdk/java/build.gradle
+++ b/sdk/java/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id("signing")
     id("java-library")
     id("maven-publish")
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 group = "com.pulumi"
@@ -17,7 +17,8 @@ def resolvedVersion = System.getenv("PACKAGE_VERSION") ?:
 
 def signingKey = System.getenv("SIGNING_KEY")
 def signingPassword = System.getenv("SIGNING_PASSWORD")
-def publishRepoURL = System.getenv("PUBLISH_REPO_URL") ?: "https://s01.oss.sonatype.org"
+def publishRepoURL = System.getenv("PUBLISH_REPO_URL") ?: "https://central.sonatype.com/repository/maven-snapshots/"
+def publishStagingURL = System.getenv("PUBLISH_STAGING_URL") ?: "https://ossrh-staging-api.central.sonatype.com/service/local/"
 def publishRepoUsername = System.getenv("PUBLISH_REPO_USERNAME")
 def publishRepoPassword = System.getenv("PUBLISH_REPO_PASSWORD")
 
@@ -30,6 +31,7 @@ java {
 compileJava {
     options.fork = true
     options.forkOptions.jvmArgs.addAll(["-Xmx16g"])
+    options.encoding = "UTF-8"
 }
 
 repositories {
@@ -43,7 +45,7 @@ repositories {
 dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("com.google.code.gson:gson:2.8.9")
-    implementation("com.pulumi:pulumi:0.9.7")
+    implementation("com.pulumi:pulumi:1.16.0")
 }
 
 task sourcesJar(type: Jar) {
@@ -64,11 +66,13 @@ def genPulumiResources = tasks.register('genPulumiResources') {
         def outDir = file("$resourcesDir/$subDir")
         outDir.mkdirs()
         new File(outDir, "version.txt").text = resolvedVersion
-        def info = new Object()
-        info.metaClass.resource = true
-        info.metaClass.name = "aws-native"
-        info.metaClass.version = resolvedVersion
-        def infoJson = new groovy.json.JsonBuilder(info).toPrettyString()
+        def builder = new groovy.json.JsonBuilder()
+        builder {
+            resource true
+            name "aws-native"
+            version resolvedVersion
+        }
+        def infoJson = builder.toPrettyString()
         new File(outDir, "plugin.json").text = infoJson
     }
 }
@@ -135,8 +139,8 @@ if (publishRepoUsername) {
     nexusPublishing {
         repositories {
             sonatype {
-                nexusUrl.set(uri(publishRepoURL + "/service/local/"))
-                snapshotRepositoryUrl.set(uri(publishRepoURL + "/content/repositories/snapshots/"))
+                nexusUrl.set(uri(publishStagingURL))
+                snapshotRepositoryUrl.set(uri(publishRepoURL))
                 username = publishRepoUsername
                 password = publishRepoPassword
             }


### PR DESCRIPTION
Updates Java generation and SDK to 1.16.0

This should re-enable the ability to publish to Maven Central after OSSRH is sunset.

Part of the larger roll-out https://github.com/pulumi/ci-mgmt/issues/1611