### PR TITLE
Add pulumi-go-provider to renovate ignore list

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["github>pulumi/renovate-config//default.json5"],
+  // We only use pulumi-go-provider for resourcex which was removed in v1
+  ignoreDeps: ["github.com/pulumi/pulumi-go-provider"],
+}


### PR DESCRIPTION
We only use `pulumi-go-provider` for the `resourcex` package which was
[removed in v1](https://github.com/pulumi/pulumi-go-provider/pull/355).
The recommendation was to pin `pulumi-go-provider`.

closes #2221