### PR TITLE
Adopting new APN/1.1 user agent string (pulumi/home#4348)

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -70,7 +70,7 @@ import (
 )
 
 // The APN 1.1 AWS Marketplace identifier to should be used in the User-Agent header.
-var pulumiAWSMarketplaceCode string = "c7qiae2l6usvzoynupds6v7hf"
+var PulumiAWSMarketplaceCode string = "c7qiae2l6usvzoynupds6v7hf"
 
 type cancellationContext struct {
 	context context.Context
@@ -1271,7 +1271,7 @@ var pulumiUserAgentMiddleware = middleware.BuildMiddlewareFunc("PulumiUserAgent"
 	const userAgentKey = "User-Agent"
 
 	// Replace the whole user-agent string to include only the marketplace identifier
-	newValue := fmt.Sprintf("APN/1.1 (%s)", pulumiAWSMarketplaceCode)
+	newValue := fmt.Sprintf("APN/1.1 (%s)", PulumiAWSMarketplaceCode)
 
 	request.Header.Set(userAgentKey, newValue)
 

--- a/provider/pkg/provider/provider_endpoints_test.go
+++ b/provider/pkg/provider/provider_endpoints_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +65,7 @@ func TestProviderEndpoints(t *testing.T) {
 		t.Parallel()
 		requestCount := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "APN/1.1 ("+metadata.PulumiAWSMarketplaceCode+")", r.Header.Get("User-Agent"))
+			assert.Equal(t, "APN/1.1 ("+provider.PulumiAWSMarketplaceCode+")", r.Header.Get("User-Agent"))
 			requestCount++
 			w.Write([]byte(stsGetCallerIdentityResponse))
 		}))


### PR DESCRIPTION
Part of pulumi/home#4348

Changes:
* Add the AWS marketplace to the `User-Agent` request header. The User-Agent will now follow the following format: `APN/1.1 (marketplaceIdentifier))
* Added `Configure` test to verify that the header is added.

## Follow ups
* [x] Decision: Inject the APN value through `ci-mgmt->.goreleaser.yml`

### CI Failure

* [x] Fix NodeJS test examples:

```
--- FAIL: TestPreviewStableProperties (88.55s)
...
            error: Error: failed to register new resource object [aws:s3/bucketObjectv2:BucketObjectv2]: 13 INTERNAL: Request message serialization failure: message.getHidediffsList is not a function
```

Unrelated?

### Questions

* [x]  ~~How to add a `CHANGELOG` entry to the releases?~~ This automatically done from the commits.