### PR TITLE
Expose resource-scoped logging to the CloudControl client

### DIFF
--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/mattbaird/jsonpatch"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var testURN = resource.URN("urn:pulumi:stack::project::type::name")
 
 func TestClientRead(t *testing.T) {
 	ctx := context.TODO()
@@ -132,7 +135,7 @@ func TestClientCreate(t *testing.T) {
 			return resourceState, nil
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.NoError(t, err)
 		assert.Equal(t, &resourceID, id)
@@ -144,7 +147,7 @@ func TestClientCreate(t *testing.T) {
 			return nil, errors.New("creation failed")
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "creating resource: creation failed", err.Error())
 		assert.Nil(t, id)
@@ -163,7 +166,7 @@ func TestClientCreate(t *testing.T) {
 			return nil, errors.New("creation failed")
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "creating resource (await): creation failed", err.Error())
 		assert.Nil(t, id)
@@ -182,7 +185,7 @@ func TestClientCreate(t *testing.T) {
 			return &types.ProgressEvent{Identifier: nil}, nil
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "received nil identifier while awaiting completion", err.Error())
 		assert.Nil(t, id)
@@ -207,7 +210,7 @@ func TestClientCreate(t *testing.T) {
 			return nil, errors.New("read error")
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "creating resource (await): await failed", err.Error())
 		assert.Nil(t, id)
@@ -232,7 +235,7 @@ func TestClientCreate(t *testing.T) {
 			return nil, errors.New("read error")
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "reading resource state: read error", err.Error())
 		assert.Nil(t, id)
@@ -258,7 +261,7 @@ func TestClientCreate(t *testing.T) {
 			return resourceState, nil
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "await failed", err.Error())
 		assert.Equal(t, &resourceID, id)
@@ -277,7 +280,7 @@ func TestClientCreate(t *testing.T) {
 			return &types.ProgressEvent{Identifier: &resourceID, ErrorCode: "AlreadyExists"}, errors.New("resource with same id alteady exists")
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.Equal(t, "resource with same id alteady exists", err.Error())
 		assert.Nil(t, id)
@@ -320,7 +323,7 @@ func TestClientCreate(t *testing.T) {
 			}
 		}
 
-		id, outputs, err := client.Create(ctx, typeName, desiredState)
+		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
 
 		assert.NoError(t, err)
 		t.Logf("ID=%v", id)

--- a/provider/pkg/client/mock_client.go
+++ b/provider/pkg/client/mock_client.go
@@ -14,8 +14,48 @@ import (
 	reflect "reflect"
 
 	jsonpatch "github.com/mattbaird/jsonpatch"
+	diag "github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	resource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	gomock "go.uber.org/mock/gomock"
 )
+
+// MockLogger is a mock of Logger interface.
+type MockLogger struct {
+	ctrl     *gomock.Controller
+	recorder *MockLoggerMockRecorder
+	isgomock struct{}
+}
+
+// MockLoggerMockRecorder is the mock recorder for MockLogger.
+type MockLoggerMockRecorder struct {
+	mock *MockLogger
+}
+
+// NewMockLogger creates a new mock instance.
+func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
+	mock := &MockLogger{ctrl: ctrl}
+	mock.recorder = &MockLoggerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
+	return m.recorder
+}
+
+// LogStatus mocks base method.
+func (m *MockLogger) LogStatus(ctx context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LogStatus", ctx, sev, urn, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LogStatus indicates an expected call of LogStatus.
+func (mr *MockLoggerMockRecorder) LogStatus(ctx, sev, urn, msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogStatus", reflect.TypeOf((*MockLogger)(nil).LogStatus), ctx, sev, urn, msg)
+}
 
 // MockCloudControlClient is a mock of CloudControlClient interface.
 type MockCloudControlClient struct {
@@ -42,9 +82,9 @@ func (m *MockCloudControlClient) EXPECT() *MockCloudControlClientMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockCloudControlClient) Create(ctx context.Context, typeName string, desiredState map[string]any) (*string, map[string]any, error) {
+func (m *MockCloudControlClient) Create(ctx context.Context, urn resource.URN, typeName string, desiredState map[string]any) (*string, map[string]any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, typeName, desiredState)
+	ret := m.ctrl.Call(m, "Create", ctx, urn, typeName, desiredState)
 	ret0, _ := ret[0].(*string)
 	ret1, _ := ret[1].(map[string]any)
 	ret2, _ := ret[2].(error)
@@ -52,23 +92,23 @@ func (m *MockCloudControlClient) Create(ctx context.Context, typeName string, de
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockCloudControlClientMockRecorder) Create(ctx, typeName, desiredState any) *gomock.Call {
+func (mr *MockCloudControlClientMockRecorder) Create(ctx, urn, typeName, desiredState any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCloudControlClient)(nil).Create), ctx, typeName, desiredState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCloudControlClient)(nil).Create), ctx, urn, typeName, desiredState)
 }
 
 // Delete mocks base method.
-func (m *MockCloudControlClient) Delete(ctx context.Context, typeName, identifier string) error {
+func (m *MockCloudControlClient) Delete(ctx context.Context, urn resource.URN, typeName, identifier string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, typeName, identifier)
+	ret := m.ctrl.Call(m, "Delete", ctx, urn, typeName, identifier)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockCloudControlClientMockRecorder) Delete(ctx, typeName, identifier any) *gomock.Call {
+func (mr *MockCloudControlClientMockRecorder) Delete(ctx, urn, typeName, identifier any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCloudControlClient)(nil).Delete), ctx, typeName, identifier)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCloudControlClient)(nil).Delete), ctx, urn, typeName, identifier)
 }
 
 // Read mocks base method.
@@ -88,16 +128,16 @@ func (mr *MockCloudControlClientMockRecorder) Read(ctx, typeName, identifier any
 }
 
 // Update mocks base method.
-func (m *MockCloudControlClient) Update(ctx context.Context, typeName, identifier string, patches []jsonpatch.JsonPatchOperation) (map[string]any, error) {
+func (m *MockCloudControlClient) Update(ctx context.Context, urn resource.URN, typeName, identifier string, patches []jsonpatch.JsonPatchOperation) (map[string]any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, typeName, identifier, patches)
+	ret := m.ctrl.Call(m, "Update", ctx, urn, typeName, identifier, patches)
 	ret0, _ := ret[0].(map[string]any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockCloudControlClientMockRecorder) Update(ctx, typeName, identifier, patches any) *gomock.Call {
+func (mr *MockCloudControlClientMockRecorder) Update(ctx, urn, typeName, identifier, patches any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCloudControlClient)(nil).Update), ctx, typeName, identifier, patches)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCloudControlClient)(nil).Update), ctx, urn, typeName, identifier, patches)
 }

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -491,7 +491,7 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 	}
 
 	p.cfn = cloudformation.NewFromConfig(cfg)
-	p.ccc = client.NewCloudControlClient(cloudcontrol.NewFromConfig(cfg), p.roleArn)
+	p.ccc = client.NewCloudControlClient(cloudcontrol.NewFromConfig(cfg), p.roleArn, p.host)
 	p.ec2 = ec2.NewFromConfig(cfg)
 	p.ssm = ssm.NewFromConfig(cfg)
 	p.sts = sts.NewFromConfig(cfg)
@@ -902,7 +902,7 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 		// Create the resource with Cloud API.
 		glog.V(9).Infof("%s.CreateResource %q", label, cfType)
 		var resourceState map[string]interface{}
-		id, resourceState, createErr = p.ccc.Create(ctx, cfType, payload)
+		id, resourceState, createErr = p.ccc.Create(ctx, urn, cfType, payload)
 		if createErr != nil && (id == nil || resourceState == nil) {
 			return nil, errors.Wrapf(createErr, "creating resource")
 		}
@@ -1152,7 +1152,7 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 		}
 
 		glog.V(9).Infof("%s.UpdateResource %q id %q state %+v", label, spec.CfType, id, ops)
-		resourceState, err := p.ccc.Update(p.canceler.context, spec.CfType, id, ops)
+		resourceState, err := p.ccc.Update(p.canceler.context, urn, spec.CfType, id, ops)
 		if err != nil {
 			return nil, err
 		}
@@ -1220,7 +1220,7 @@ func (p *cfnProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) 
 		}
 
 		glog.V(9).Infof("%s.DeleteResource %q id %q", label, spec.CfType, id)
-		err := p.ccc.Delete(p.canceler.context, spec.CfType, id)
+		err := p.ccc.Delete(p.canceler.context, urn, spec.CfType, id)
 		if err != nil {
 			return nil, err
 		}

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -365,7 +365,7 @@ func TestCreate(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Create(ctx, "AWS::S3::Bucket", gomock.Any()).Return(
+		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			stringPtr("bucket-id"), map[string]interface{}{"foo": "bar"}, nil,
 		)
 
@@ -397,7 +397,7 @@ func TestCreate(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Create(ctx, "AWS::S3::Bucket", gomock.Any()).Return(
+		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			nil, nil, assert.AnError,
 		)
 
@@ -412,7 +412,7 @@ func TestCreate(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Create(ctx, "AWS::S3::Bucket", gomock.Any()).Return(
+		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			stringPtr("bucket-id"), map[string]interface{}{"foo": "bar"}, assert.AnError,
 		)
 
@@ -734,7 +734,7 @@ func TestUpdate(t *testing.T) {
 			"__inputs":          resource.MakeSecret(resource.NewObjectProperty(inputs)),
 		})
 
-		mockCCC.EXPECT().Update(ctx, "AWS::S3::Bucket", "resource-id", gomock.Any()).Return(
+		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", gomock.Any()).Return(
 			map[string]interface{}{
 				// Change the bucket name and object lock status according to the inputs
 				"bucketName":        resource.NewStringProperty("new-bucket"),
@@ -766,7 +766,7 @@ func TestUpdate(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Update(ctx, "AWS::S3::Bucket", "resource-id", gomock.Any()).Return(
+		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", gomock.Any()).Return(
 			nil, assert.AnError,
 		)
 
@@ -821,7 +821,7 @@ func TestDelete(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Delete(ctx, "AWS::S3::Bucket", "resource-id").Return(nil)
+		mockCCC.EXPECT().Delete(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id").Return(nil)
 
 		_, err := provider.Delete(ctx, req)
 		assert.NoError(t, err)
@@ -833,7 +833,7 @@ func TestDelete(t *testing.T) {
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
 
-		mockCCC.EXPECT().Delete(ctx, "AWS::S3::Bucket", "resource-id").Return(assert.AnError)
+		mockCCC.EXPECT().Delete(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id").Return(assert.AnError)
 
 		_, err := provider.Delete(ctx, req)
 		assert.Error(t, err)

--- a/provider/pkg/resources/extension_resource.go
+++ b/provider/pkg/resources/extension_resource.go
@@ -122,7 +122,7 @@ func (r *extensionResource) Create(ctx context.Context, urn resource.URN, inputs
 		return nil, nil, fmt.Errorf("failed to unmarshal inputs: %w", err)
 	}
 
-	id, resourceState, err := r.client.Create(ctx, typedInputs.Type, typedInputs.Properties)
+	id, resourceState, err := r.client.Create(ctx, urn, typedInputs.Type, typedInputs.Properties)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create resource: %w", err)
 	}
@@ -191,7 +191,7 @@ func (r *extensionResource) Update(ctx context.Context, urn resource.URN, id str
 		return nil, fmt.Errorf("failed to calculate patch: %w", err)
 	}
 
-	resourceState, err := r.client.Update(ctx, typedInputs.Type, id, jsonPatch)
+	resourceState, err := r.client.Update(ctx, urn, typedInputs.Type, id, jsonPatch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update resource: %w", err)
 	}
@@ -207,7 +207,7 @@ func (r *extensionResource) Delete(ctx context.Context, urn resource.URN, id str
 		return fmt.Errorf("failed to unmarshal inputs: %w", err)
 	}
 
-	err = r.client.Delete(ctx, typedInputs.Type, id)
+	err = r.client.Delete(ctx, urn, typedInputs.Type, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete resource: %w", err)
 	}


### PR DESCRIPTION
This plumbs the URN down to our CC client so we can log status messages
for resources. This will allow us to log when we are retrying operations
due to Throttling errors.
