### PR TITLE
Setup weekly SDK generation

### DIFF
--- a/.github/workflows/aws-native-weekly-sdk-generation.yml
+++ b/.github/workflows/aws-native-weekly-sdk-generation.yml
@@ -88,7 +88,7 @@ jobs:
         title: Automated SDK generation @ aws-cloudformation-user-guide ${{
           steps.vars.outputs.commit-hash }}
         author: pulumi-bot <bot@pulumi.com>
-        branch: create-pull-requeset/generate-sdk
+        branch: create-pull-request/generate-sdk
     - name: Enable auto-merge
       id: auto-merge
       # enable auto-merge so PR merges after required checks


### PR DESCRIPTION
This PR does a couple of things:

1. Switches the `nightly` workflow from nightly to weekly.
2. Renames the workflow with the `aws-native` prefix so that it is not managed by ci-mgmt
3. Switches the `repo-sync` action to `create-pull-request` (repo-sync is archived)
4. Adds the `needs-release/minor` label and enables auto-merge so that merging this automatically releases

Tested this by triggering the workflow manually:

- Test Run: https://github.com/pulumi/pulumi-aws-native/actions/runs/20378140559/job/58561771397?pr=2719
- Created and merged https://github.com/pulumi/pulumi-aws-native/pull/2721

**Follow ups**: need to remove the old nightly job from ci-mgmt

closes #2235