### PR TITLE
Preserve Any property keys in CFN outputs

### DIFF
--- a/provider/pkg/naming/convert.go
+++ b/provider/pkg/naming/convert.go
@@ -11,11 +11,13 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/mattbaird/jsonpatch"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+
 	"github.com/pulumi/pulumi-go-provider/resourcex"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 // SdkToCfn converts Pulumi-SDK-shaped state to CloudFormation-shaped payload. In particular, SDK properties
@@ -43,6 +45,8 @@ var schemaStringReplacer = strings.NewReplacer(
 	// Paragraph separator
 	"\u2029", "\n")
 
+const schemaTypeObject = "object"
+
 // SanitizeCfnString ensures that a string from CFN docs meets the requirements for Pulumi schema strings.
 func SanitizeCfnString(str string) string {
 	return schemaStringReplacer.Replace(str)
@@ -51,6 +55,16 @@ func SanitizeCfnString(str string) string {
 type sdkToCfnConverter struct {
 	spec  *metadata.CloudAPIResource
 	types map[string]metadata.CloudAPIType
+}
+
+type cfnToSdkConverter struct {
+	spec  *metadata.CloudAPIResource
+	types map[string]metadata.CloudAPIType
+}
+
+type sdkProperty struct {
+	name string
+	spec pschema.PropertySpec
 }
 
 func (c *sdkToCfnConverter) sdkToCfn(properties map[string]interface{}) (map[string]interface{}, error) {
@@ -76,6 +90,211 @@ func (c *sdkToCfnConverter) sdkToCfn(properties map[string]interface{}) (map[str
 	return result, nil
 }
 
+func (c *cfnToSdkConverter) cfnToSdk(properties map[string]interface{}) (map[string]interface{}, error) {
+	props := mapCfnNamesToSdkProperties(c.spec.Inputs, c.spec.Outputs, c.spec.IrreversibleNames)
+	return c.cfnObjectPropertiesToSdk(props, properties)
+}
+
+// cfnObjectValueToSdk converts a typed CloudFormation object value to its SDK shape.
+//
+// It uses the CloudAPIType property schema to decide which nested keys are provider property names and which
+// values need recursive typed conversion. For example, a nested property with IrreversibleNames{"awsId": "Id"}
+// maps the CFN key "Id" to the SDK key "awsId", while a sibling property typed as pulumi.json#/Any keeps its
+// own document keys unchanged.
+func (c *cfnToSdkConverter) cfnObjectValueToSdk(
+	spec metadata.CloudAPIType,
+	value interface{},
+) (interface{}, error) {
+	properties, ok := value.(map[string]interface{})
+	if !ok {
+		return cfnValueToSdk(value), nil
+	}
+
+	props := mapCfnNamesToSdkProperties(spec.Properties, nil, spec.IrreversibleNames)
+	return c.cfnObjectPropertiesToSdk(props, properties)
+}
+
+// cfnObjectPropertiesToSdk converts one CFN object using a precomputed CFN-name to SDK-property map.
+//
+// Known properties are converted according to their schema. Unknown properties use legacy CfnToSdk behavior so
+// that unexpected CloudControl response fields still surface in state instead of making reads, creates, or
+// updates fail.
+func (c *cfnToSdkConverter) cfnObjectPropertiesToSdk(
+	props map[string]sdkProperty, properties map[string]interface{},
+) (map[string]interface{}, error) {
+	result := map[string]interface{}{}
+	for cfnName, v := range properties {
+		prop, ok := props[cfnName]
+		if !ok {
+			result[ToSdkName(cfnName)] = cfnValueToSdk(v)
+			continue
+		}
+		converted, err := c.cfnTypedValueToSdk(&prop.spec.TypeSpec, v)
+		if err != nil {
+			return nil, err
+		}
+		result[prop.name] = converted
+	}
+	return result, nil
+}
+
+// mapCfnNamesToSdkProperties returns the lookup table used by schema-aware CFN-to-SDK conversion.
+//
+// Each property is addressable by both its SDK name and expected CFN name. The SDK-name alias allows tests and
+// callers that already have SDK-shaped mock data to flow through the same typed conversion path, while normal
+// CloudControl responses match through ToCfnName and irreversible name metadata. For example, an output named
+// "awsId" with IrreversibleNames{"awsId": "Id"} can be matched by either "Id" or "awsId" and always produces
+// the SDK key "awsId".
+func mapCfnNamesToSdkProperties(
+	inputs map[string]pschema.PropertySpec,
+	outputs map[string]pschema.PropertySpec,
+	irreversibleNames map[string]string,
+) map[string]sdkProperty {
+	result := map[string]sdkProperty{}
+	add := func(properties map[string]pschema.PropertySpec) {
+		for sdkName, prop := range properties {
+			mapped := sdkProperty{name: sdkName, spec: prop}
+			if _, exists := result[sdkName]; !exists {
+				result[sdkName] = mapped
+			}
+			cfnName := ToCfnName(sdkName, irreversibleNames)
+			if _, exists := result[cfnName]; !exists {
+				result[cfnName] = mapped
+			}
+		}
+	}
+	add(inputs)
+	add(outputs)
+	return result
+}
+
+// cfnTypedValueToSdk converts a CFN value according to a Pulumi schema TypeSpec.
+//
+// Refs to pulumi.json#/Any intentionally return the value unchanged because the payload is user-defined JSON,
+// not a provider-shaped object. Typed object refs recurse into CloudAPIType metadata, arrays and maps recurse
+// into their item specs, and OneOf cases reuse the same "largest successful conversion" heuristic as SdkToCfn.
+// Missing type refs or unexpected primitive/object shapes fall back to legacy conversion to preserve provider
+// tolerance for CloudControl response drift.
+func (c *cfnToSdkConverter) cfnTypedValueToSdk(spec *pschema.TypeSpec, v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	if spec == nil {
+		return cfnValueToSdk(v), nil
+	}
+
+	if spec.Ref != "" {
+		if spec.Ref == "pulumi.json#/Any" {
+			return v, nil
+		}
+
+		typName := strings.TrimPrefix(spec.Ref, "#/types/")
+		typSpec, ok := c.types[typName]
+		if !ok {
+			return cfnValueToSdk(v), nil
+		}
+		switch typSpec.Type {
+		case schemaTypeObject:
+			return c.cfnObjectValueToSdk(typSpec, v)
+		default:
+			return v, nil
+		}
+	}
+
+	if spec.OneOf != nil {
+		contract.Assertf(len(spec.OneOf) >= 1, "at least one union case is required")
+
+		results := []any{}
+		errs := []error{}
+		for _, item := range spec.OneOf {
+			converted, err := c.cfnTypedValueToSdk(&item, v)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				results = append(results, converted)
+			}
+		}
+
+		switch {
+		case len(results) == 0:
+			glog.V(9).Infof("conversion error: all union variants failed: %v", errors.Join(errs...))
+			return nil, &ConversionError{fmt.Sprintf("%v", *spec), v}
+		case len(results) == 1:
+			return results[0], nil
+		default:
+			return largestConversionResult(results), nil
+		}
+	}
+
+	switch spec.Type {
+	case "array":
+		s := reflect.ValueOf(v)
+		if s.Kind() != reflect.Slice && s.Kind() != reflect.Array {
+			return v, nil
+		}
+		result := make([]interface{}, s.Len())
+		for i := 0; i < s.Len(); i++ {
+			converted, err := c.cfnTypedValueToSdk(spec.Items, s.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			result[i] = converted
+		}
+		return result, nil
+	case schemaTypeObject:
+		sourceMap, ok := v.(map[string]interface{})
+		if !ok {
+			return v, nil
+		}
+		if spec.AdditionalProperties == nil {
+			return cfnValueToSdk(sourceMap), nil
+		}
+		result := map[string]interface{}{}
+		for key, item := range sourceMap {
+			converted, err := c.cfnTypedValueToSdk(spec.AdditionalProperties, item)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = converted
+		}
+		return result, nil
+	default:
+		return v, nil
+	}
+}
+
+// largestConversionResult picks the most specific conversion result from ambiguous OneOf variants.
+//
+// The AWS schema often omits discriminators. When several variants can convert successfully, preferring the
+// result with the most top-level entries keeps the variant that recognized more of the payload. For example,
+// if one union branch recognizes "RedshiftRunConfiguration" and another only returns an empty object, this
+// selects the redshift-shaped result.
+func largestConversionResult(results []any) any {
+	sizeOf := func(x any) int {
+		switch x := x.(type) {
+		case map[string]any:
+			return len(x)
+		case []any:
+			return len(x)
+		case nil:
+			return 0
+		default:
+			return 1
+		}
+	}
+
+	var bestResult any
+	bestResultSize := -1
+	for _, r := range results {
+		s := sizeOf(r)
+		if s > bestResultSize {
+			bestResult = r
+			bestResultSize = s
+		}
+	}
+	return bestResult
+}
+
 func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interface{}) (interface{}, error) {
 	if spec.Ref != "" {
 		if spec.Ref == "pulumi.json#/Any" {
@@ -85,7 +304,7 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 		typName := strings.TrimPrefix(spec.Ref, "#/types/")
 		typSpec := c.types[typName]
 		switch typSpec.Type {
-		case "object":
+		case schemaTypeObject:
 			return c.sdkObjectValueToCfn(typName, typSpec, v)
 		case "string":
 			if _, ok := v.(string); ok {
@@ -121,30 +340,7 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 			// Properties such as aws-native:datazone:DataSource configuration do not specify a
 			// discriminator yet. Without a discriminator in case of multiple successful results we could
 			// instead pick the largest by length.
-
-			sizeOf := func(x any) int {
-				switch x := x.(type) {
-				case map[string]any:
-					return len(x)
-				case []any:
-					return len(x)
-				case nil:
-					return 0
-				default:
-					return 1
-				}
-			}
-
-			var bestResult any
-			bestResultSize := -1
-			for _, r := range results {
-				s := sizeOf(r)
-				if s > bestResultSize {
-					bestResult = r
-					bestResultSize = s
-				}
-			}
-			return bestResult, nil
+			return largestConversionResult(results), nil
 		}
 
 	}
@@ -162,7 +358,7 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 			}
 			return vs, nil
 		}
-	case "object":
+	case schemaTypeObject:
 		if sourceMap, ok := v.(map[string]interface{}); ok {
 			vs := map[string]interface{}{}
 			for n, item := range sourceMap {
@@ -308,6 +504,18 @@ func CfnToSdk(properties map[string]interface{}) map[string]interface{} {
 		result[ToSdkName(n)] = cfnValueToSdk(v)
 	}
 	return result
+}
+
+// CfnToSdkV2 converts CloudFormation-shaped payload to Pulumi-SDK-shaped state using resource schema metadata.
+// Known resource and type properties are matched by their CFN names first, including irreversible names. Unknown
+// fields keep the legacy best-effort CfnToSdk conversion.
+func CfnToSdkV2(
+	res *metadata.CloudAPIResource,
+	types map[string]metadata.CloudAPIType,
+	properties map[string]interface{},
+) (map[string]interface{}, error) {
+	converter := cfnToSdkConverter{res, types}
+	return converter.cfnToSdk(properties)
 }
 
 func cfnValueToSdk(value interface{}) interface{} {

--- a/provider/pkg/naming/convert_test.go
+++ b/provider/pkg/naming/convert_test.go
@@ -7,17 +7,251 @@ import (
 	"testing"
 
 	"github.com/mattbaird/jsonpatch"
-
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func TestCfnToSdk(t *testing.T) {
 	actual := CfnToSdk(cfnPayload)
 	assert.Equal(t, sdkState, actual)
+}
+
+func TestCfnToSdkV2(t *testing.T) {
+	t.Run("typed resource properties", func(t *testing.T) {
+		res := sampleSchema.Resources["aws-native:ecs:Service"]
+		actual, err := CfnToSdkV2(&res, sampleSchema.Types, cfnPayload)
+		require.NoError(t, err)
+		assert.Equal(t, sdkState, actual)
+	})
+
+	t.Run("schema names and Any values", func(t *testing.T) {
+		res := metadata.CloudAPIResource{
+			Inputs: map[string]pschema.PropertySpec{
+				"assumeRolePolicyDocument": {
+					TypeSpec: pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+				},
+				"policyDocuments": {
+					TypeSpec: pschema.TypeSpec{
+						Type:  "array",
+						Items: &pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+					},
+				},
+				"namedPolicies": {
+					TypeSpec: pschema.TypeSpec{
+						Type:                 "object",
+						AdditionalProperties: &pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+					},
+				},
+			},
+			Outputs: map[string]pschema.PropertySpec{
+				"awsId": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			},
+			IrreversibleNames: map[string]string{
+				"awsId": "Id",
+			},
+		}
+		state := map[string]interface{}{
+			"Id": "resource-id",
+			"AssumeRolePolicyDocument": map[string]interface{}{
+				"Version": "2012-10-17",
+				"Statement": []interface{}{
+					map[string]interface{}{"Action": "sts:AssumeRole"},
+				},
+			},
+			"PolicyDocuments": []interface{}{
+				map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "s3:GetObject"}}},
+			},
+			"NamedPolicies": map[string]interface{}{
+				"AdminPolicy": map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "*"}}},
+			},
+			"UnknownObject": map[string]interface{}{"NestedKey": "value"},
+		}
+
+		actual, err := CfnToSdkV2(&res, nil, state)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"awsId": "resource-id",
+			"assumeRolePolicyDocument": map[string]interface{}{
+				"Version": "2012-10-17",
+				"Statement": []interface{}{
+					map[string]interface{}{"Action": "sts:AssumeRole"},
+				},
+			},
+			"policyDocuments": []interface{}{
+				map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "s3:GetObject"}}},
+			},
+			"namedPolicies": map[string]interface{}{
+				"AdminPolicy": map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "*"}}},
+			},
+			"unknownObject": map[string]interface{}{"nestedKey": "value"},
+		}, actual)
+	})
+
+	t.Run("typed objects use nested schema names and preserve nested Any", func(t *testing.T) {
+		res := metadata.CloudAPIResource{
+			Inputs: map[string]pschema.PropertySpec{
+				"configuration": {
+					TypeSpec: pschema.TypeSpec{Ref: "#/types/custom:Configuration"},
+				},
+				"configurations": {
+					TypeSpec: pschema.TypeSpec{
+						Type:  "array",
+						Items: &pschema.TypeSpec{Ref: "#/types/custom:Configuration"},
+					},
+				},
+				"namedConfigurations": {
+					TypeSpec: pschema.TypeSpec{
+						Type:                 "object",
+						AdditionalProperties: &pschema.TypeSpec{Ref: "#/types/custom:Configuration"},
+					},
+				},
+			},
+		}
+		types := map[string]metadata.CloudAPIType{
+			"custom:Configuration": {
+				Type: "object",
+				Properties: map[string]pschema.PropertySpec{
+					"awsId":          {TypeSpec: pschema.TypeSpec{Type: "string"}},
+					"policyDocument": {TypeSpec: pschema.TypeSpec{Ref: "pulumi.json#/Any"}},
+				},
+				IrreversibleNames: map[string]string{
+					"awsId": "Id",
+				},
+			},
+		}
+		policy := map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []interface{}{
+				map[string]interface{}{"Action": "sts:AssumeRole"},
+			},
+		}
+
+		actual, err := CfnToSdkV2(&res, types, map[string]interface{}{
+			"Configuration": map[string]interface{}{
+				"Id":             "primary",
+				"PolicyDocument": policy,
+			},
+			"Configurations": []interface{}{
+				map[string]interface{}{
+					"Id":             "array-item",
+					"PolicyDocument": policy,
+				},
+			},
+			"NamedConfigurations": map[string]interface{}{
+				"main": map[string]interface{}{
+					"Id":             "map-item",
+					"PolicyDocument": policy,
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"configuration": map[string]interface{}{
+				"awsId":          "primary",
+				"policyDocument": policy,
+			},
+			"configurations": []interface{}{
+				map[string]interface{}{
+					"awsId":          "array-item",
+					"policyDocument": policy,
+				},
+			},
+			"namedConfigurations": map[string]interface{}{
+				"main": map[string]interface{}{
+					"awsId":          "map-item",
+					"policyDocument": policy,
+				},
+			},
+		}, actual)
+	})
+
+	t.Run("missing ref and unexpected typed object shapes fall back to legacy conversion", func(t *testing.T) {
+		res := metadata.CloudAPIResource{
+			Inputs: map[string]pschema.PropertySpec{
+				"missing": {
+					TypeSpec: pschema.TypeSpec{Ref: "#/types/custom:Missing"},
+				},
+				"typed": {
+					TypeSpec: pschema.TypeSpec{Ref: "#/types/custom:Typed"},
+				},
+			},
+		}
+		types := map[string]metadata.CloudAPIType{
+			"custom:Typed": {
+				Type: "object",
+				Properties: map[string]pschema.PropertySpec{
+					"nestedValue": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				},
+			},
+		}
+
+		actual, err := CfnToSdkV2(&res, types, map[string]interface{}{
+			"Missing": map[string]interface{}{"NestedValue": "fallback"},
+			"Typed":   "not-an-object",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"missing": map[string]interface{}{"nestedValue": "fallback"},
+			"typed":   "not-an-object",
+		}, actual)
+	})
+
+	t.Run("oneOf values use schema-aware conversion", func(t *testing.T) {
+		res := metadata.CloudAPIResource{
+			Inputs: map[string]pschema.PropertySpec{
+				"configuration": {
+					TypeSpec: pschema.TypeSpec{
+						OneOf: []pschema.TypeSpec{
+							{Ref: "#/types/custom:PrimaryConfiguration"},
+							{Ref: "#/types/custom:SecondaryConfiguration"},
+						},
+					},
+				},
+			},
+		}
+		types := map[string]metadata.CloudAPIType{
+			"custom:PrimaryConfiguration": {
+				Type: "object",
+				Properties: map[string]pschema.PropertySpec{
+					"awsId":          {TypeSpec: pschema.TypeSpec{Type: "string"}},
+					"policyDocument": {TypeSpec: pschema.TypeSpec{Ref: "pulumi.json#/Any"}},
+				},
+				IrreversibleNames: map[string]string{
+					"awsId": "Id",
+				},
+			},
+			"custom:SecondaryConfiguration": {
+				Type: "object",
+				Properties: map[string]pschema.PropertySpec{
+					"secondaryValue": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				},
+			},
+		}
+		policy := map[string]interface{}{
+			"Statement": []interface{}{
+				map[string]interface{}{"Action": "sts:AssumeRole"},
+			},
+		}
+
+		actual, err := CfnToSdkV2(&res, types, map[string]interface{}{
+			"Configuration": map[string]interface{}{
+				"Id":             "primary",
+				"PolicyDocument": policy,
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"configuration": map[string]interface{}{
+				"awsId":          "primary",
+				"policyDocument": policy,
+			},
+		}, actual)
+	})
 }
 
 func TestSdkToCfn(t *testing.T) {
@@ -97,34 +331,34 @@ func TestSdkToCfnOneOfAmbiguous(t *testing.T) {
 		},
 	}
 	types := map[string]metadata.CloudAPIType{
-		"aws-native:datazone:DataSourceConfigurationInput0Properties": metadata.CloudAPIType{
+		"aws-native:datazone:DataSourceConfigurationInput0Properties": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
-				"glueRunConfiguration": pschema.PropertySpec{
+				"glueRunConfiguration": {
 					TypeSpec: pschema.TypeSpec{
 						Ref: "#/types/aws-native:datazone:DataSourceGlueRunConfigurationInput",
 					},
 				},
 			},
 		},
-		"aws-native:datazone:DataSourceGlueRunConfigurationInput": metadata.CloudAPIType{
+		"aws-native:datazone:DataSourceGlueRunConfigurationInput": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
-				"dataAccessRole": pschema.PropertySpec{TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"dataAccessRole": {TypeSpec: pschema.TypeSpec{Type: "string"}},
 			},
 		},
-		"aws-native:datazone:DataSourceConfigurationInput1Properties": metadata.CloudAPIType{
+		"aws-native:datazone:DataSourceConfigurationInput1Properties": {
 			Type: "object",
-			Properties: map[string]pschema.PropertySpec{"redshiftRunConfiguration": pschema.PropertySpec{
+			Properties: map[string]pschema.PropertySpec{"redshiftRunConfiguration": {
 				TypeSpec: pschema.TypeSpec{
 					Ref: "#/types/aws-native:datazone:DataSourceRedshiftRunConfigurationInput",
 				},
 			}},
 		},
-		"aws-native:datazone:DataSourceRedshiftRunConfigurationInput": metadata.CloudAPIType{
+		"aws-native:datazone:DataSourceRedshiftRunConfigurationInput": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
-				"dataAccessRole": pschema.PropertySpec{TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"dataAccessRole": {TypeSpec: pschema.TypeSpec{Type: "string"}},
 			},
 		},
 	}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -48,6 +48,19 @@ import (
 	"github.com/golang/glog"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-go-provider/resourcex"
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
@@ -56,17 +69,6 @@ import (
 	pOutputs "github.com/pulumi/pulumi-aws-native/provider/pkg/outputs"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/resources"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
-	"github.com/pulumi/pulumi-go-provider/resourcex"
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // The APN 1.1 AWS Marketplace identifier to should be used in the User-Agent header.
@@ -925,7 +927,7 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 		// Convert SDK inputs to CFN payload.
 		payload, err := naming.SdkToCfn(&spec, p.resourceMap.Types, resourcex.Decode(inputs))
 		if err != nil {
-			return nil, fmt.Errorf("Failed to convert value for %s: %w", resourceToken, err)
+			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
 		}
 
 		// Create the resource with Cloud API.
@@ -936,7 +938,10 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 			return nil, errors.Wrapf(createErr, "creating resource")
 		}
 
-		rawOutputs := naming.CfnToSdk(resourceState)
+		rawOutputs, err := naming.CfnToSdkV2(&spec, p.resourceMap.Types, resourceState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
+		}
 		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent from the inputs.
 		if hasSpec && len(spec.WriteOnly) > 0 {
 			inputsMap := inputs.Mappable()
@@ -1033,7 +1038,10 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 			// Not Exists means that the resource was deleted.
 			return &pulumirpc.ReadResponse{Id: ""}, nil
 		}
-		rawState := naming.CfnToSdk(resourceState)
+		rawState, err := naming.CfnToSdkV2(&spec, p.resourceMap.Types, resourceState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
+		}
 
 		if inputs == nil {
 			// There may be no old state (i.e., importing a new resource).
@@ -1189,7 +1197,10 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 		if err != nil {
 			return nil, err
 		}
-		rawOutputs := naming.CfnToSdk(resourceState)
+		rawOutputs, err := naming.CfnToSdkV2(&spec, p.resourceMap.Types, resourceState)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
+		}
 
 		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent from the inputs.
 		if len(spec.WriteOnly) > 0 {

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -5,19 +5,21 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	gomock "go.uber.org/mock/gomock"
-	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/resources"
 )
 
 func TestConfigure(t *testing.T) {
@@ -220,7 +222,7 @@ func TestCreatePreview(t *testing.T) {
 	provider := &cfnProvider{
 		name: "test-provider",
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws-native:s3:Bucket": metadata.CloudAPIResource{
+			"aws-native:s3:Bucket": {
 				CfType: "AWS::S3::Bucket",
 				Outputs: map[string]schema.PropertySpec{
 					"arn":        {TypeSpec: schema.TypeSpec{Type: "string"}},
@@ -293,7 +295,7 @@ func TestUpdatePreview(t *testing.T) {
 	provider := &cfnProvider{
 		name: "test-provider",
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws-native:s3:Bucket": metadata.CloudAPIResource{
+			"aws-native:s3:Bucket": {
 				CfType: "AWS::S3::Bucket",
 				Outputs: map[string]schema.PropertySpec{
 					"arn":        {TypeSpec: schema.TypeSpec{Type: "string"}},
@@ -432,6 +434,56 @@ func TestCreate(t *testing.T) {
 		assert.Equal(t, "input value", inputs["my"].StringValue())
 	})
 
+	t.Run("StandardResource/PreservesAnyPropertyKeys", func(t *testing.T) {
+		provider.resourceMap.Resources["aws:iam/role:Role"] = metadata.CloudAPIResource{
+			CfType: "AWS::IAM::Role",
+			Inputs: map[string]schema.PropertySpec{
+				"assumeRolePolicyDocument": {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+			},
+			Outputs: map[string]schema.PropertySpec{
+				"awsId": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			IrreversibleNames: map[string]string{
+				"awsId": "Id",
+			},
+		}
+		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:iam/role:Role", "name"))
+		policyDocument := resource.NewObjectProperty(resource.PropertyMap{
+			"Version": resource.NewStringProperty("2012-10-17"),
+			"Statement": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"Action": resource.NewStringProperty("sts:AssumeRole"),
+				}),
+			}),
+		})
+		req.Properties = mustMarshalProperties(t, resource.PropertyMap{
+			"assumeRolePolicyDocument": policyDocument,
+		})
+
+		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::IAM::Role", gomock.Any()).Return(
+			stringPtr("role-id"),
+			map[string]interface{}{
+				"Id": "role-output-id",
+				"AssumeRolePolicyDocument": map[string]interface{}{
+					"Version": "2012-10-17",
+					"Statement": []interface{}{
+						map[string]interface{}{"Action": "sts:AssumeRole"},
+					},
+				},
+			}, nil,
+		)
+
+		resp, err := provider.Create(ctx, req)
+		assert.NoError(t, err)
+		require.NotNil(t, resp.Properties)
+		props := mustUnmarshalProperties(t, resp.Properties)
+		assert.Equal(t, "role-output-id", props["awsId"].StringValue())
+		doc := props["assumeRolePolicyDocument"].ObjectValue()
+		assert.Equal(t, "2012-10-17", doc["Version"].StringValue())
+		statement := doc["Statement"].ArrayValue()[0].ObjectValue()
+		assert.Equal(t, "sts:AssumeRole", statement["Action"].StringValue())
+	})
+
 	t.Run("StandardResource/NotFound", func(t *testing.T) {
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "unknown:resource", "name"))
 
@@ -460,6 +512,7 @@ func TestCreate(t *testing.T) {
 			CfType: "AWS::S3::Bucket",
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Properties = mustMarshalProperties(t, resource.PropertyMap{"my": resource.NewStringProperty("input value")})
 
 		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			stringPtr("bucket-id"), map[string]interface{}{"foo": "bar"}, assert.AnError,
@@ -591,6 +644,45 @@ func TestRead(t *testing.T) {
 		assert.Equal(t, "my-bucket", inputs["bucketName"].StringValue())
 		assert.True(t, inputs.HasValue("objectLockEnabled"), "Expected 'objectLockEnabled' property in inputs")
 		assert.True(t, inputs["objectLockEnabled"].BoolValue())
+	})
+
+	t.Run("StandardResource/ImportPreservesAnyPropertyKeys", func(t *testing.T) {
+		provider.resourceMap.Resources["aws:iam/role:Role"] = metadata.CloudAPIResource{
+			CfType: "AWS::IAM::Role",
+			Inputs: map[string]schema.PropertySpec{
+				"assumeRolePolicyDocument": {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+			},
+		}
+		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:iam/role:Role", "name"))
+		req.Properties = mustMarshalProperties(t, resource.PropertyMap{"foo": resource.NewStringProperty("bar")})
+
+		mockCCC.EXPECT().Read(ctx, "AWS::IAM::Role", "resource-id").Return(
+			map[string]interface{}{
+				"AssumeRolePolicyDocument": map[string]interface{}{
+					"Version": "2012-10-17",
+					"Statement": []interface{}{
+						map[string]interface{}{"Action": "sts:AssumeRole"},
+					},
+				},
+			}, true, nil,
+		)
+
+		resp, err := provider.Read(ctx, req)
+		assert.NoError(t, err)
+		require.NotNil(t, resp.Properties)
+		props := mustUnmarshalProperties(t, resp.Properties)
+		doc := props["assumeRolePolicyDocument"].ObjectValue()
+		assert.True(t, doc.HasValue("Version"), "Expected Any property key to be preserved")
+		assert.Equal(t, "2012-10-17", doc["Version"].StringValue())
+		statement := doc["Statement"].ArrayValue()[0].ObjectValue()
+		assert.True(t, statement.HasValue("Action"), "Expected nested Any property key to be preserved")
+		assert.Equal(t, "sts:AssumeRole", statement["Action"].StringValue())
+
+		require.NotNil(t, resp.Inputs)
+		inputs := mustUnmarshalProperties(t, resp.Inputs)
+		inputDoc := inputs["assumeRolePolicyDocument"].ObjectValue()
+		assert.True(t, inputDoc.HasValue("Version"), "Expected imported inputs to preserve Any property key")
+		assert.Equal(t, "2012-10-17", inputDoc["Version"].StringValue())
 	})
 
 	t.Run("StandardResource/NotFound", func(t *testing.T) {
@@ -807,6 +899,64 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, "new-bucket", checkpoint["bucketName"].StringValue())
 		require.True(t, checkpoint.HasValue("objectLockEnabled"), "Expected 'objectLockEnabled' property in '__inputs'")
 		assert.False(t, checkpoint["objectLockEnabled"].BoolValue())
+	})
+
+	t.Run("StandardResource/PreservesAnyPropertyKeys", func(t *testing.T) {
+		provider.resourceMap.Resources["aws:iam/role:Role"] = metadata.CloudAPIResource{
+			CfType: "AWS::IAM::Role",
+			Inputs: map[string]schema.PropertySpec{
+				"assumeRolePolicyDocument": {TypeSpec: schema.TypeSpec{Ref: "pulumi.json#/Any"}},
+			},
+			Outputs: map[string]schema.PropertySpec{
+				"awsId": {TypeSpec: schema.TypeSpec{Type: "string"}},
+			},
+			IrreversibleNames: map[string]string{
+				"awsId": "Id",
+			},
+		}
+		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:iam/role:Role", "name"))
+		oldPolicyDocument := resource.NewObjectProperty(resource.PropertyMap{
+			"Version": resource.NewStringProperty("2012-10-17"),
+		})
+		newPolicyDocument := resource.NewObjectProperty(resource.PropertyMap{
+			"Version": resource.NewStringProperty("2012-10-17"),
+			"Statement": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"Action": resource.NewStringProperty("sts:AssumeRole"),
+				}),
+			}),
+		})
+		req.News = mustMarshalProperties(t, resource.PropertyMap{
+			"assumeRolePolicyDocument": newPolicyDocument,
+		})
+		req.Olds = mustMarshalProperties(t, resource.PropertyMap{
+			"assumeRolePolicyDocument": oldPolicyDocument,
+			"__inputs": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+				"assumeRolePolicyDocument": oldPolicyDocument,
+			})),
+		})
+
+		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::IAM::Role", "resource-id", gomock.Any()).Return(
+			map[string]interface{}{
+				"Id": "role-output-id",
+				"AssumeRolePolicyDocument": map[string]interface{}{
+					"Version": "2012-10-17",
+					"Statement": []interface{}{
+						map[string]interface{}{"Action": "sts:AssumeRole"},
+					},
+				},
+			}, nil,
+		)
+
+		resp, err := provider.Update(ctx, req)
+		assert.NoError(t, err)
+		require.NotNil(t, resp.Properties)
+		props := mustUnmarshalProperties(t, resp.Properties)
+		assert.Equal(t, "role-output-id", props["awsId"].StringValue())
+		doc := props["assumeRolePolicyDocument"].ObjectValue()
+		assert.Equal(t, "2012-10-17", doc["Version"].StringValue())
+		statement := doc["Statement"].ArrayValue()[0].ObjectValue()
+		assert.Equal(t, "sts:AssumeRole", statement["Action"].StringValue())
 	})
 
 	t.Run("StandardResource/Error", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add schema-aware CfnToSdkV2 conversion while preserving the existing CfnToSdk API
- use CfnToSdkV2 for standard Create, Read, and Update outputs
- preserve pulumi.json#/Any payload keys while still mapping known CFN resource/type properties to SDK names

## Why
The write path already uses schema metadata when converting SDK-shaped inputs to CloudFormation-shaped payloads. That lets it distinguish provider-typed objects from `pulumi.json#/Any` values, so user-defined JSON documents such as IAM policies keep keys like `Version`, `Statement`, and `Action` intact when sent to CloudControl.

The read/output path did not have the same schema-aware boundary. It used legacy `CfnToSdk`, which lower-camel-cased every nested object key. That is correct for typed provider objects, but wrong for arbitrary JSON payloads returned in `pulumi.json#/Any` properties, and can cause returned state to differ from the JSON users supplied.

This change makes output conversion symmetric with the existing write conversion while keeping the existing public `CfnToSdk` API unchanged. `CfnToSdkV2` lets provider runtime paths use schema metadata to map known CFN resource/type properties to SDK names while preserving arbitrary JSON payloads as-is.

## Testing
- mise exec -- go test -count=1 ./pkg/naming
- mise exec -- go test -count=1 ./pkg/provider -run 'TestRead|TestCreate|TestUpdate'
- mise exec -- make test_provider_fast

fixes https://github.com/pulumi/pulumi-aws-native/issues/2961