### PR TITLE
Isolate Azure CLI config dir when signing Windows binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,9 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 		else \
 			file=dist/build-provider-sign-windows_windows_${GORELEASER_ARCH}/pulumi-resource-aws-native.exe; \
 			mv $${file} $${file}.unsigned; \
+			AZURE_CONFIG_DIR=$$(mktemp -d); \
+			export AZURE_CONFIG_DIR; \
+			trap 'rm -rf "$${AZURE_CONFIG_DIR}"' EXIT; \
 			az login --service-principal \
 				--username "${AZURE_SIGNING_CLIENT_ID}" \
 				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
@@ -252,7 +255,6 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 				--alias "${AZURE_SIGNING_ACCOUNT_NAME}/${AZURE_SIGNING_CERT_PROFILE_NAME}" \
 				$${file}.unsigned; \
 			mv $${file}.unsigned $${file}; \
-			az logout; \
 		fi; \
 	fi
 


### PR DESCRIPTION
Gives each Windows-signing invocation its own `AZURE_CONFIG_DIR` (a fresh `mktemp -d`) so the concurrent amd64/arm64 signing runs don't share `~/.azure` and race on `accounts.json`, and drops the explicit `az logout` (cleanup on EXIT replaces it). Verified locally: the recipe expands via `make -n` and passes `bash -n`, and a shared-dir simulation reproduces the `ERROR: There are no active accounts.` failure that the isolated-dir version fixes.

Part of pulumi/home#4671
