### PR TITLE
Ignore CLI extraction dirs left in the workspace by pulumi/esc-action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ aws-cloudformation-docs/
 
 # Local runtime artifacts (logs, temp files, etc.)
 .runtime/
+
+# CLI extraction dirs left in the workspace by pulumi/esc-action when it
+# installs the Pulumi/ESC CLI (e.g. pulumi-ktEWvw/, esc-VgHq48/). Without
+# this, create-pull-request's `git add -A` commits the >100MB pulumi binary
+# and the push is rejected by GitHub's file-size limit.
+/pulumi-*/
+/esc-*/


### PR DESCRIPTION
The `weekly-sdk-generation` workflow has been failing at the Create PR step because the push is rejected for containing a >100MB `pulumi` binary.

The "Export AWS Credentials" step's `pulumi/esc-action` (v3.0.0) installs the Pulumi CLI by extracting the release tarball into a workspace-relative directory (`pulumi-XXXXXX/`, `esc-XXXXXX/`) and does not clean it up. `peter-evans/create-pull-request` then runs `git add -A`, which stages that stray directory, including the pulumi binary, into the auto-generated SDK PR. GitHub's file-size limit rejects the push.

This ignores those extraction directories so `git add -A` never stages them. Verified locally: the patterns match the leftover dirs, match no tracked files, and a simulated `pulumi-XXXXXX/pulumi/pulumi` is skipped by `git add -A`.

A more thorough fix (scoping the create-pull-request step to the generated outputs via `add-paths:`, or a cleanup step) belongs in ci-mgmt since the workflow is generated; this `.gitignore` change is the durable in-repo mitigation.

Part of #3057
