### PR TITLE
Fix WAFv2 byte match alias updates

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -787,6 +787,8 @@ func (p *cfnProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*
 			newInputs[tagsKey] = val
 		}
 
+		resources.NormalizeWafv2ByteMatchInputs(resourceToken, newInputs)
+
 		failures, err = resources.ValidateResource(&spec, p.resourceMap.Types, newInputs)
 		if err != nil {
 			return nil, err
@@ -855,6 +857,7 @@ func (p *cfnProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pu
 	if spec, hasSpec := p.resourceMap.Resources[resourceToken]; hasSpec {
 		classifier := resources.NewPathClassifier(&spec, p.resourceMap.Types)
 		baseline := classifier.ActualInputBaselineFromOutputs(oldInputs, oldState, newInputs)
+		resources.NormalizeWafv2ByteMatchBaseline(resourceToken, baseline, newInputs)
 		diff := baseline.Diff(newInputs)
 
 		// Apply propertyTransform-based diff suppression for semantically equivalent values.
@@ -1065,6 +1068,7 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 			classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
 			resources.PreserveSecretWrappers(newStateProps, inputs)
 			baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
+			resources.NormalizeWafv2ByteMatchBaseline(resourceToken, baseline, inputs)
 			newInputs = resources.SuppressBaselineDiffs(resourceToken, &spec, inputs, baseline, p.transformCache)
 			newState = resources.CheckpointPropertyMap(newInputs, newStateProps)
 		}

--- a/provider/pkg/resources/patching.go
+++ b/provider/pkg/resources/patching.go
@@ -34,6 +34,7 @@ func CalcPatchWithActualOutputs(
 		classifier = NewPathClassifier(&spec, types)
 	}
 	baseline := classifier.ActualInputBaselineFromOutputs(oldInputs, actualOutputs, newInputs)
+	NormalizeWafv2ByteMatchBaseline(resourceToken, baseline, newInputs)
 	return calcPatchFromBaseline(oldInputs, baseline, newInputs, spec, types, resourceToken, transformCache)
 }
 
@@ -49,6 +50,23 @@ func calcPatchFromBaseline(
 	diff := baseline.Diff(newInputs)
 	if resourceToken != "" {
 		diff = SuppressAWSManagedDiffsWithContext(resourceToken, &spec, diff, oldInputs, baseline, newInputs, transformCache)
+	}
+
+	// CloudControl validates the complete WAFv2 model on every update. Its read
+	// response can contain both SearchString and SearchStringBase64, so resend
+	// the canonical rules whenever another WebAcl property changes.
+	if diff != nil && resourceToken == awsNativeWafv2WebAclToken {
+		if rules, ok := newInputs[wafv2RulesProperty]; ok {
+			if diff.Updates == nil {
+				diff.Updates = map[resource.PropertyKey]resource.ValueDiff{}
+			}
+			delete(diff.Adds, wafv2RulesProperty)
+			delete(diff.Deletes, wafv2RulesProperty)
+			diff.Updates[wafv2RulesProperty] = resource.ValueDiff{
+				Old: baseline[wafv2RulesProperty],
+				New: rules,
+			}
+		}
 	}
 
 	// Write-only properties can't even be read internally within the CloudControl service so they must be included in

--- a/provider/pkg/resources/patching_test.go
+++ b/provider/pkg/resources/patching_test.go
@@ -351,6 +351,72 @@ func TestCalcPatchWithActualOutputs(t *testing.T) {
 		assert.Empty(t, patch)
 	})
 
+	t.Run("WAF WebAcl updates resend canonical rules", func(t *testing.T) {
+		const tokenDomainsProperty = "tokenDomains"
+
+		spec := metadata.CloudAPIResource{
+			Inputs: map[string]schema.PropertySpec{
+				wafv2RulesProperty: {
+					TypeSpec: schema.TypeSpec{
+						Type:  "array",
+						Items: &schema.TypeSpec{Type: "string"},
+					},
+				},
+				tokenDomainsProperty: {
+					TypeSpec: schema.TypeSpec{
+						Type:  "array",
+						Items: &schema.TypeSpec{Type: "string"},
+					},
+				},
+			},
+			Outputs: map[string]schema.PropertySpec{
+				wafv2RulesProperty: {
+					TypeSpec: schema.TypeSpec{
+						Type:  "array",
+						Items: &schema.TypeSpec{Type: "string"},
+					},
+				},
+				tokenDomainsProperty: {
+					TypeSpec: schema.TypeSpec{
+						Type:  "array",
+						Items: &schema.TypeSpec{Type: "string"},
+					},
+				},
+			},
+		}
+		rules := resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("canonical-rule"),
+		})
+		oldInputs := resource.PropertyMap{
+			wafv2RulesProperty: rules,
+			tokenDomainsProperty: resource.NewArrayProperty(
+				[]resource.PropertyValue{resource.NewStringProperty("old.example")},
+			),
+		}
+		newInputs := resource.PropertyMap{
+			wafv2RulesProperty: rules,
+			tokenDomainsProperty: resource.NewArrayProperty(
+				[]resource.PropertyValue{resource.NewStringProperty("new.example")},
+			),
+		}
+
+		patch, err := CalcPatchWithActualOutputs(
+			oldInputs,
+			oldInputs,
+			newInputs,
+			spec,
+			nil,
+			nil,
+			awsNativeWafv2WebAclToken,
+			NewTransformCache(),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []jsonpatch.JsonPatchOperation{
+			{Operation: "replace", Path: "/Rules", Value: []interface{}{"canonical-rule"}},
+			{Operation: "replace", Path: "/TokenDomains", Value: []interface{}{"new.example"}},
+		}, patch)
+	})
+
 	t.Run("key value array tag reorder is suppressed", func(t *testing.T) {
 		spec := metadata.CloudAPIResource{
 			TagsProperty: "tags",

--- a/provider/pkg/resources/wafv2_normalize.go
+++ b/provider/pkg/resources/wafv2_normalize.go
@@ -1,0 +1,158 @@
+// Copyright 2026, Pulumi Corporation.
+
+package resources
+
+import (
+	"encoding/base64"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+const (
+	awsNativeWafv2WebAclToken    = "aws-native:wafv2:WebAcl"    //nolint:gosec // Resource type token, not a credential.
+	awsNativeWafv2RuleGroupToken = "aws-native:wafv2:RuleGroup" //nolint:gosec // Resource type token, not a credential.
+	wafv2RulesProperty           = "rules"
+	wafv2StatementProperty       = "statement"
+	wafv2ByteMatchProperty       = "byteMatchStatement"
+	wafv2SearchStringProperty    = "searchString"
+	wafv2SearchStringBase64Prop  = "searchStringBase64"
+)
+
+// NormalizeWafv2ByteMatchInputs converts the user-friendly searchString form
+// into searchStringBase64 for WAFv2 resources.
+//
+// CloudControl reads ByteMatchStatement values back with both properties set,
+// even though its update model requires exactly one. Sending the canonical
+// base64 form avoids CloudFormation adding the alias again while validating an
+// update. If a user explicitly specifies both properties, this function leaves
+// them unchanged so normal validation can report the invalid input.
+func NormalizeWafv2ByteMatchInputs(resourceToken string, inputs resource.PropertyMap) {
+	if !isWafv2RuleContainer(resourceToken) {
+		return
+	}
+	normalizeWafv2ByteMatchInputValue(resource.NewObjectProperty(inputs))
+}
+
+// NormalizeWafv2ByteMatchBaseline removes the redundant alias that
+// CloudControl returns from an actual-state baseline. The desired input decides
+// which representation to retain, so refresh preserves the user's existing
+// representation while checked program inputs can migrate to the canonical
+// base64 form without perpetual diffs.
+func NormalizeWafv2ByteMatchBaseline(
+	resourceToken string,
+	actual resource.PropertyMap,
+	desired resource.PropertyMap,
+) {
+	if !isWafv2RuleContainer(resourceToken) {
+		return
+	}
+	normalizeWafv2ByteMatchBaselineValue(
+		resource.NewObjectProperty(actual),
+		resource.NewObjectProperty(desired),
+	)
+}
+
+func isWafv2RuleContainer(resourceToken string) bool {
+	return resourceToken == awsNativeWafv2WebAclToken || resourceToken == awsNativeWafv2RuleGroupToken
+}
+
+func normalizeWafv2ByteMatchInputValue(value resource.PropertyValue) {
+	switch {
+	case value.IsSecret():
+		normalizeWafv2ByteMatchInputValue(value.SecretValue().Element)
+	case value.IsArray():
+		for _, item := range value.ArrayValue() {
+			normalizeWafv2ByteMatchInputValue(item)
+		}
+	case value.IsObject():
+		obj := value.ObjectValue()
+		searchString, hasSearchString := obj[wafv2SearchStringProperty]
+		_, hasSearchStringBase64 := obj[wafv2SearchStringBase64Prop]
+		if hasSearchString && !hasSearchStringBase64 {
+			if encoded, ok := base64PropertyValue(searchString); ok {
+				obj[wafv2SearchStringBase64Prop] = encoded
+				delete(obj, wafv2SearchStringProperty)
+			}
+		}
+		for _, child := range obj {
+			normalizeWafv2ByteMatchInputValue(child)
+		}
+	}
+}
+
+func normalizeWafv2ByteMatchBaselineValue(actual, desired resource.PropertyValue) {
+	if actual.IsSecret() {
+		actual = actual.SecretValue().Element
+	}
+	if desired.IsSecret() {
+		desired = desired.SecretValue().Element
+	}
+
+	switch {
+	case actual.IsArray():
+		actualItems := actual.ArrayValue()
+		var desiredItems []resource.PropertyValue
+		if desired.IsArray() {
+			desiredItems = desired.ArrayValue()
+		}
+		for i, item := range actualItems {
+			desiredItem := resource.PropertyValue{}
+			if i < len(desiredItems) {
+				desiredItem = desiredItems[i]
+			}
+			normalizeWafv2ByteMatchBaselineValue(item, desiredItem)
+		}
+	case actual.IsObject():
+		actualObj := actual.ObjectValue()
+		desiredObj := resource.PropertyMap{}
+		if desired.IsObject() {
+			desiredObj = desired.ObjectValue()
+		}
+
+		searchString, hasSearchString := actualObj[wafv2SearchStringProperty]
+		searchStringBase64, hasSearchStringBase64 := actualObj[wafv2SearchStringBase64Prop]
+		if hasSearchString && hasSearchStringBase64 && base64ValuesEquivalent(searchString, searchStringBase64) {
+			_, desiredHasSearchString := desiredObj[wafv2SearchStringProperty]
+			_, desiredHasSearchStringBase64 := desiredObj[wafv2SearchStringBase64Prop]
+			switch {
+			case desiredHasSearchStringBase64 && !desiredHasSearchString:
+				delete(actualObj, wafv2SearchStringProperty)
+			case desiredHasSearchString && !desiredHasSearchStringBase64:
+				delete(actualObj, wafv2SearchStringBase64Prop)
+			default:
+				delete(actualObj, wafv2SearchStringProperty)
+			}
+		}
+
+		for key, child := range actualObj {
+			normalizeWafv2ByteMatchBaselineValue(child, desiredObj[key])
+		}
+	}
+}
+
+func base64PropertyValue(value resource.PropertyValue) (resource.PropertyValue, bool) {
+	if value.IsSecret() {
+		encoded, ok := base64PropertyValue(value.SecretValue().Element)
+		if !ok {
+			return resource.PropertyValue{}, false
+		}
+		return resource.MakeSecret(encoded), true
+	}
+	if !value.IsString() {
+		return resource.PropertyValue{}, false
+	}
+	return resource.NewStringProperty(base64.StdEncoding.EncodeToString([]byte(value.StringValue()))), true
+}
+
+func base64ValuesEquivalent(searchString, searchStringBase64 resource.PropertyValue) bool {
+	if searchString.IsSecret() {
+		searchString = searchString.SecretValue().Element
+	}
+	if searchStringBase64.IsSecret() {
+		searchStringBase64 = searchStringBase64.SecretValue().Element
+	}
+	if !searchString.IsString() || !searchStringBase64.IsString() {
+		return false
+	}
+	return base64.StdEncoding.EncodeToString([]byte(searchString.StringValue())) == searchStringBase64.StringValue()
+}

--- a/provider/pkg/resources/wafv2_normalize_test.go
+++ b/provider/pkg/resources/wafv2_normalize_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026, Pulumi Corporation.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func TestNormalizeWafv2ByteMatchInputs(t *testing.T) {
+	inputs := resource.PropertyMap{
+		wafv2RulesProperty: resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{
+				wafv2StatementProperty: resource.NewObjectProperty(resource.PropertyMap{
+					wafv2ByteMatchProperty: resource.NewObjectProperty(resource.PropertyMap{
+						wafv2SearchStringProperty: resource.NewStringProperty("/login"),
+					}),
+				}),
+			}),
+		}),
+	}
+
+	NormalizeWafv2ByteMatchInputs(awsNativeWafv2WebAclToken, inputs)
+
+	byteMatch := inputs[wafv2RulesProperty].ArrayValue()[0].ObjectValue()[wafv2StatementProperty].
+		ObjectValue()[wafv2ByteMatchProperty].ObjectValue()
+	assert.NotContains(t, byteMatch, resource.PropertyKey(wafv2SearchStringProperty))
+	assert.Equal(t, "L2xvZ2lu", byteMatch[wafv2SearchStringBase64Prop].StringValue())
+}
+
+func TestNormalizeWafv2ByteMatchInputsPreservesExplicitBoth(t *testing.T) {
+	byteMatch := resource.PropertyMap{
+		wafv2SearchStringProperty:   resource.NewStringProperty("/login"),
+		wafv2SearchStringBase64Prop: resource.NewStringProperty("L2xvZ2lu"),
+	}
+	inputs := resource.PropertyMap{
+		wafv2RulesProperty: resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(byteMatch),
+		}),
+	}
+
+	NormalizeWafv2ByteMatchInputs(awsNativeWafv2WebAclToken, inputs)
+
+	assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringProperty))
+	assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringBase64Prop))
+}
+
+func TestNormalizeWafv2ByteMatchBaseline(t *testing.T) {
+	newByteMatch := func() resource.PropertyValue {
+		return resource.NewObjectProperty(resource.PropertyMap{
+			wafv2SearchStringProperty:   resource.NewStringProperty("/login"),
+			wafv2SearchStringBase64Prop: resource.NewStringProperty("L2xvZ2lu"),
+		})
+	}
+
+	t.Run("keeps base64 when desired uses base64", func(t *testing.T) {
+		actual := resource.PropertyMap{wafv2StatementProperty: newByteMatch()}
+		desired := resource.PropertyMap{
+			wafv2StatementProperty: resource.NewObjectProperty(resource.PropertyMap{
+				wafv2SearchStringBase64Prop: resource.NewStringProperty("L2xvZ2lu"),
+			}),
+		}
+
+		NormalizeWafv2ByteMatchBaseline(awsNativeWafv2WebAclToken, actual, desired)
+
+		byteMatch := actual[wafv2StatementProperty].ObjectValue()
+		assert.NotContains(t, byteMatch, resource.PropertyKey(wafv2SearchStringProperty))
+		assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringBase64Prop))
+	})
+
+	t.Run("keeps plain string when desired uses plain string", func(t *testing.T) {
+		actual := resource.PropertyMap{wafv2StatementProperty: newByteMatch()}
+		desired := resource.PropertyMap{
+			wafv2StatementProperty: resource.NewObjectProperty(resource.PropertyMap{
+				wafv2SearchStringProperty: resource.NewStringProperty("/login"),
+			}),
+		}
+
+		NormalizeWafv2ByteMatchBaseline(awsNativeWafv2WebAclToken, actual, desired)
+
+		byteMatch := actual[wafv2StatementProperty].ObjectValue()
+		assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringProperty))
+		assert.NotContains(t, byteMatch, resource.PropertyKey(wafv2SearchStringBase64Prop))
+	})
+
+	t.Run("does not alter a non-equivalent pair", func(t *testing.T) {
+		actual := resource.PropertyMap{
+			wafv2StatementProperty: resource.NewObjectProperty(resource.PropertyMap{
+				wafv2SearchStringProperty:   resource.NewStringProperty("/login"),
+				wafv2SearchStringBase64Prop: resource.NewStringProperty("ZGlmZmVyZW50"),
+			}),
+		}
+
+		NormalizeWafv2ByteMatchBaseline(awsNativeWafv2WebAclToken, actual, resource.PropertyMap{})
+
+		byteMatch := actual[wafv2StatementProperty].ObjectValue()
+		assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringProperty))
+		assert.Contains(t, byteMatch, resource.PropertyKey(wafv2SearchStringBase64Prop))
+	})
+}


### PR DESCRIPTION
## Summary

- Normalize WAFv2 `ByteMatchStatement` search-string aliases returned by AWS Cloud Control.
- Canonicalize provider inputs to `searchStringBase64`, normalize refreshed state against the desired representation, and resend WebACL rules when another property triggers an update.
- Prevent updates from sending both `SearchString` and `SearchStringBase64`, which AWS rejects.

Fixes #3078.

## Scope

- Hand-written provider runtime behavior for `aws-native:wafv2:WebAcl` and `aws-native:wafv2:RuleGroup`.
- Focused unit and patch regression coverage for equivalent aliases, conflicting explicit aliases, nested statements, refresh baselines, and unrelated WebACL updates.
- No schema, SDK, or generated-code changes.

## Validation

- [ ] `make lint` — attempted with the pinned toolchain; the repository-wide target reports 204 repository-wide baseline findings. Changed-code lint reports 0 issues: `golangci-lint run -c ../.golangci.yml --new-from-rev=$(git merge-base HEAD origin/master)`.
- [x] `make test_provider_fast`
- [ ] `make test_provider` — not run because it includes live provider tests.
- [ ] `make test` — not run; integration contracts are unchanged and upstream acceptance tests require a maintainer trigger.

Additional validation:

- [x] `go test -count=1 ./pkg/resources -run 'TestNormalizeWafv2ByteMatch|TestCalcPatch'`
- [x] `go test -count=1 ./pkg/provider -run 'TestStandardResourceDiffUsesActualOutputBaseline|TestStandardResourceReadReturnsOwnershipFilteredInputs'`
- [x] Reproduced the AWS error with an existing WebACL, then verified the patched provider completes the update, refreshes unchanged, and produces a clean preview.

## Generation / Drift Checks

- [x] No hand-edits to generated schema, metadata, SDK, or documentation files.
- [x] Generation is not required for this provider-runtime-only change.

## Risk

The behavior is scoped to WAFv2 WebACL and RuleGroup byte-match statements. Plain search strings are stored in their byte-equivalent Base64 representation, and WebACL updates resend the canonicalized rules so Cloud Control validates a consistent full resource model. The main risk is a larger update patch for WebACLs when unrelated mutable properties change.

## Rollback

Revert this commit to restore the previous pass-through behavior for WAFv2 byte-match aliases.

