### PR TITLE
Enable provider linting in CI

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -6,7 +6,7 @@ providerDefaultBranch: master
 checkoutSubmodules: true
 pulumiVersionFile: .pulumi.version
 parallel: 3
-lint: false
+lint: true
 enableChangelog: true
 envOverride:
     AWS_REGION: us-west-2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,3 +555,7 @@ jobs:
         status: ${{ job.status }}
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
+  lint:
+    name: lint
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -526,3 +526,10 @@ jobs:
     needs:
     - test
     - prerequisites
+    - lint
+  lint:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    name: lint
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,14 @@
 # Contributing to pulumi-aws-native
 
 ## Prerequisites
-Use the same toolchain contract as CI:
+Use the same toolchain contract as CI and prepare local generated artifacts:
 
 ```bash
-mise install
+mise exec -- make prepare_local_workspace
 ```
 
-Tool versions are pinned in `.config/mise.toml`.
+This installs the tools pinned in `.config/mise.toml`, downloads Go modules, initializes submodules, and creates the
+ignored schema/metadata artifacts required by local builds and tests.
 
 ## Quick Flow
 1. Review `AGENTS.md` (agent instructions) and `ARCHITECTURE.md` (module map and system boundaries).

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,19 @@ PROVIDER_VERSION ?= 1.0.0-alpha.0+dev
 VERSION_GENERIC = $(shell pulumictl convert-version --language generic --version "$(PROVIDER_VERSION)")
 VERSION_FLAGS   := -ldflags "-X github.com/pulumi/pulumi-${PACK}/provider/pkg/version.Version=${VERSION_GENERIC}"
 
-CFN_SCHEMA_DIR  := aws-cloudformation-schema
-METADATA_DIR    := meta
+CFN_SCHEMA_DIR      := aws-cloudformation-schema
+METADATA_DIR        := meta
+PROVIDER_RESOURCE_DIR := provider/cmd/pulumi-resource-aws-native
+CF2PULUMI_DIR       := provider/cmd/cf2pulumi
+
+PROVIDER_EMBED_ARTIFACTS := \
+	$(PROVIDER_RESOURCE_DIR)/schema.json.gz \
+	$(PROVIDER_RESOURCE_DIR)/metadata.json.gz
+CF2PULUMI_EMBED_ARTIFACTS := \
+	$(CF2PULUMI_DIR)/schema.json.gz \
+	$(CF2PULUMI_DIR)/metadata.json.gz
+TEST_RUNTIME_ARTIFACTS := bin/schema.json.gz bin/metadata.json.gz
+LOCAL_ARTIFACTS := $(PROVIDER_EMBED_ARTIFACTS) $(CF2PULUMI_EMBED_ARTIFACTS) $(TEST_RUNTIME_ARTIFACTS)
 
 # Only use explicitly installed plugins - this is to avoid using any ambient plugins from the PATH
 export PULUMI_IGNORE_AMBIENT_PLUGINS = true
@@ -60,7 +71,20 @@ ensure:: init_submodules
 	cd sdk/go && GO111MODULE=on go mod tidy
 	cd examples && GO111MODULE=on go mod tidy
 
-prepare_local_workspace:: init_submodules
+$(PROVIDER_RESOURCE_DIR)/%.json.gz: $(PROVIDER_RESOURCE_DIR)/%.json
+	@tmp="$@.tmp"; trap 'rm -f "$$tmp"' EXIT; gzip -n -c "$<" > "$$tmp"; mv "$$tmp" "$@"
+
+$(CF2PULUMI_DIR)/%.json.gz: $(PROVIDER_RESOURCE_DIR)/%.json
+	@tmp="$@.tmp"; trap 'rm -f "$$tmp"' EXIT; gzip -n -c "$<" > "$$tmp"; mv "$$tmp" "$@"
+
+bin/%.json.gz: $(PROVIDER_RESOURCE_DIR)/%.json
+	@mkdir -p "$(@D)"
+	@tmp="$@.tmp"; trap 'rm -f "$$tmp"' EXIT; gzip -n -c "$<" > "$$tmp"; mv "$$tmp" "$@"
+
+prepare_local_artifacts:: $(LOCAL_ARTIFACTS)
+.PHONY: prepare_local_artifacts
+
+prepare_local_workspace:: init_submodules prepare_local_artifacts
 	@command -v mise >/dev/null 2>&1 || (echo "mise is required to install pinned toolchain versions. Install from https://mise.jdx.dev/" && exit 1)
 	mise install
 	cd provider && GO111MODULE=on go mod download
@@ -76,22 +100,30 @@ generate_schema:: docs
 codegen::
 	(cd provider && go build -o $(WORKING_DIR)/bin/$(CODEGEN) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(CODEGEN))
 
-provider::
+provider:: $(PROVIDER_EMBED_ARTIFACTS)
 	(cd provider && go build -o $(WORKING_DIR)/bin/$(PROVIDER) $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
 
-install_provider::
+install_provider:: $(PROVIDER_EMBED_ARTIFACTS)
 	(cd provider && go install $(VERSION_FLAGS) $(PROJECT)/provider/cmd/$(PROVIDER))
 
-cf2pulumi::
+cf2pulumi:: $(CF2PULUMI_EMBED_ARTIFACTS)
 	(cd provider && go build -o $(WORKING_DIR)/bin/cf2pulumi $(VERSION_FLAGS) $(PROJECT)/provider/cmd/cf2pulumi)
 
-test_provider::
+test_provider:: $(LOCAL_ARTIFACTS)
 	(cd provider && go test -v -coverpkg=./... -coverprofile=coverage.txt ./...)
 
-test_provider_fast:: # Runs short-mode provider unit tests
+test_provider_fast:: $(TEST_RUNTIME_ARTIFACTS) # Runs short-mode provider unit tests
 	(cd provider && go test -short ./pkg/...)
 
-lint:: provider # lint the provider code
+lint:: # lint the provider code
+	@set -e; \
+	embed_files="$$(git grep -l 'go:embed' -- provider)"; \
+	restore_embeds() { \
+		cd "$(WORKING_DIR)"; \
+		for file in $$embed_files; do perl -i -pe 's/ goembed/go:embed/g' "$$file"; done; \
+	}; \
+	trap restore_embeds EXIT INT TERM; \
+	for file in $$embed_files; do perl -i -pe 's/go:embed/ goembed/g' "$$file"; done; \
 	cd provider && GOGC=20 golangci-lint run -c ../.golangci.yml
 
 .pulumi/bin/pulumi: PULUMI_VERSION := $(shell cat .pulumi.version)
@@ -264,5 +296,5 @@ sign-goreleaser-exe-%: bin/jsign-7.4.jar
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@b6bfde4bf3d1f9e539671e20aad7801e4ba5d300 generate
+	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
 .PHONY: ci-mgmt

--- a/Makefile
+++ b/Makefile
@@ -115,15 +115,7 @@ test_provider:: $(LOCAL_ARTIFACTS)
 test_provider_fast:: $(TEST_RUNTIME_ARTIFACTS) # Runs short-mode provider unit tests
 	(cd provider && go test -short ./pkg/...)
 
-lint:: # lint the provider code
-	@set -e; \
-	embed_files="$$(git grep -l 'go:embed' -- provider)"; \
-	restore_embeds() { \
-		cd "$(WORKING_DIR)"; \
-		for file in $$embed_files; do perl -i -pe 's/ goembed/go:embed/g' "$$file"; done; \
-	}; \
-	trap restore_embeds EXIT INT TERM; \
-	for file in $$embed_files; do perl -i -pe 's/go:embed/ goembed/g' "$$file"; done; \
+lint:: $(PROVIDER_EMBED_ARTIFACTS) $(CF2PULUMI_EMBED_ARTIFACTS) # lint the provider code
 	cd provider && GOGC=20 golangci-lint run -c ../.golangci.yml
 
 .pulumi/bin/pulumi: PULUMI_VERSION := $(shell cat .pulumi.version)

--- a/provider/cmd/cf2pulumi/main.go
+++ b/provider/cmd/cf2pulumi/main.go
@@ -5,17 +5,14 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
-	pschema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/version"
+	_ "embed"
+
 	"github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/codegen"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -23,6 +20,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
+	pschema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/version"
 )
 
 //go:embed schema.json.gz
@@ -55,7 +57,9 @@ func main() {
 		log.Fatalf("failed to render template: %v", err)
 	}
 	if len(diags) > 0 {
-		syntax.NewDiagnosticWriter(os.Stderr, nil, 0, true).WriteDiagnostics(diags)
+		if err := syntax.NewDiagnosticWriter(os.Stderr, nil, 0, true).WriteDiagnostics(diags); err != nil {
+			log.Printf("failed to write render diagnostics: %v", err)
+		}
 	}
 
 	cf2pulumi.FormatBody(template)
@@ -67,7 +71,9 @@ func main() {
 	}
 	if parser.Diagnostics.HasErrors() {
 		fmt.Print(programText)
-		parser.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(parser.Diagnostics)
+		if err := parser.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(parser.Diagnostics); err != nil {
+			log.Printf("failed to write parser diagnostics: %v", err)
+		}
 		os.Exit(-1)
 	}
 
@@ -89,7 +95,9 @@ func main() {
 	}
 	if diags.HasErrors() {
 		fmt.Print(programText)
-		program.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(diags)
+		if err := program.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(diags); err != nil {
+			log.Printf("failed to write program diagnostics: %v", err)
+		}
 		os.Exit(-1)
 	}
 
@@ -110,7 +118,9 @@ func main() {
 		log.Fatalf("failed to generate program: %v", err)
 	}
 	if diags.HasErrors() {
-		program.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(diags)
+		if err := program.NewDiagnosticWriter(os.Stderr, 0, true).WriteDiagnostics(diags); err != nil {
+			log.Printf("failed to write generation diagnostics: %v", err)
+		}
 		os.Exit(-1)
 	}
 

--- a/provider/cmd/cf2pulumi/main.go
+++ b/provider/cmd/cf2pulumi/main.go
@@ -81,7 +81,12 @@ func main() {
 	// The aws-native schema is self-contained, so binding it does not need to resolve any external
 	// packages. As of pulumi/pkg v3.253.0 ImportSpec requires a non-nil loader argument (it
 	// previously constructed a plugin loader when passed nil), so pass a null loader here.
-	pkg, err := schema.ImportSpec(*pkgSpec, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+	pkg, err := schema.ImportSpec(
+		*pkgSpec,
+		nil,
+		schema.NewNullLoader(),
+		schema.ValidationOptions{AllowDanglingReferences: true},
+	)
 	if err != nil {
 		log.Fatalf("failed to parse import the spec: %v", err)
 	}

--- a/provider/cmd/pulumi-gen-aws-native/examples.go
+++ b/provider/cmd/pulumi-gen-aws-native/examples.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package main
 
 import (
@@ -14,10 +15,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
-	pschema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
+
 	"github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/codegen"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
@@ -25,6 +23,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/pcl"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/cf2pulumi"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+	pschema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 )
 
 func generateExamples(pkgSpec *schema.PackageSpec, metadata *metadata.CloudAPIMetadata, languages []string) error {
@@ -70,7 +73,7 @@ func generateExamples(pkgSpec *schema.PackageSpec, metadata *metadata.CloudAPIMe
 			ExampleDescription:       "Example",
 			LanguageToExampleProgram: example.LanguageToExampleProgram,
 		})
-		total += 1
+		total++
 	}
 	fmt.Printf("Number of examples: %v\n", total)
 
@@ -84,7 +87,13 @@ func generateExamples(pkgSpec *schema.PackageSpec, metadata *metadata.CloudAPIMe
 	return nil
 }
 
-func generateExample(yaml string, metadata *metadata.CloudAPIMetadata, languages []string, loader schema.Loader, bindOpts ...pcl.BindOption) (*resourceExample, error) {
+func generateExample(
+	yaml string,
+	metadata *metadata.CloudAPIMetadata,
+	languages []string,
+	loader schema.Loader,
+	bindOpts ...pcl.BindOption,
+) (*resourceExample, error) {
 	body, diagnostics, err := cf2pulumi.RenderText(yaml, metadata)
 	if err != nil {
 		return nil, errors.Wrapf(err, "rendering YAML")
@@ -233,7 +242,10 @@ func findExamples(fileName string) ([]string, error) {
 
 type programGenFn func(*pcl.Program) (map[string][]byte, hcl.Diagnostics, error)
 
-func recoverableProgramGen(program *pcl.Program, fn programGenFn) (files map[string][]byte, d hcl.Diagnostics, err error) {
+func recoverableProgramGen(
+	program *pcl.Program,
+	fn programGenFn,
+) (files map[string][]byte, d hcl.Diagnostics, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic recovered during generation: %v", r)

--- a/provider/cmd/pulumi-gen-aws-native/examples.go
+++ b/provider/cmd/pulumi-gen-aws-native/examples.go
@@ -44,7 +44,12 @@ func generateExamples(pkgSpec *schema.PackageSpec, metadata *metadata.CloudAPIMe
 	// does not need to resolve any external packages. Previously ImportSpec accepted a nil loader
 	// and internally constructed a plugin loader on demand; as of pulumi/pkg v3.253.0 the loader is
 	// a required, must-be-non-nil argument, so pass a null loader that resolves nothing.
-	pkg, err := schema.ImportSpec(*pkgSpec, nil, schema.NewNullLoader(), schema.ValidationOptions{AllowDanglingReferences: true})
+	pkg, err := schema.ImportSpec(
+		*pkgSpec,
+		nil,
+		schema.NewNullLoader(),
+		schema.ValidationOptions{AllowDanglingReferences: true},
+	)
 	if err != nil {
 		return err
 	}

--- a/provider/cmd/pulumi-gen-aws-native/main.go
+++ b/provider/cmd/pulumi-gen-aws-native/main.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package main
 
 import (
@@ -11,28 +12,27 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
-
-	"slices"
-
-	"github.com/pulumi/pulumi/pkg/v3/codegen"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/pkg/errors"
+
 	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/refdb"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 // ensureDir ensures that a target directory exists (like `mkdir -p`), returning a non-nil error if any problem occurs.
@@ -86,18 +86,31 @@ func main() {
 		flag.PrintDefaults()
 	}
 
-	var version, operation, schemaFolder, docsUrl, metadataFolder string
+	var version, operation, schemaFolder, docsURL, metadataFolder string
 	var jsonSchemaUrls schemaUrls
 	flag.StringVar(&version, "version", "", "the provider version to record in the generated code")
 	flag.StringVar(&schemaFolder, "schema-folder", "", "The folder containing the CloudFormation schema files")
-	flag.StringVar(&docsUrl, "docs-url", "", "The URL to download the CloudFormation docs")
-	flag.StringVar(&metadataFolder, "metadata-folder", "", "The folder containing metadata files needed for schema generation")
+	flag.StringVar(&docsURL, "docs-url", "", "The URL to download the CloudFormation docs")
+	flag.StringVar(
+		&metadataFolder,
+		"metadata-folder",
+		"",
+		"The folder containing metadata files needed for schema generation",
+	)
 	flag.Var(&jsonSchemaUrls, "schema-urls", "A comma delimited list of CloudFormation schema urls")
 
 	flag.Parse()
 	operation = flag.Arg(0)
-	fmt.Printf("%s: version: %s, schema-folder: %s, docs-url: %s, schema-urls: %s, metadata-folder: %s\n", operation, version, schemaFolder, docsUrl, jsonSchemaUrls, metadataFolder)
-	if version == "" && operation == "" && (jsonSchemaUrls == nil && docsUrl == "") {
+	fmt.Printf(
+		"%s: version: %s, schema-folder: %s, docs-url: %s, schema-urls: %s, metadata-folder: %s\n",
+		operation,
+		version,
+		schemaFolder,
+		docsURL,
+		jsonSchemaUrls,
+		metadataFolder,
+	)
+	if version == "" && operation == "" && (jsonSchemaUrls == nil && docsURL == "") {
 		flag.Usage()
 		return
 	}
@@ -114,13 +127,13 @@ func main() {
 
 	switch operation {
 	case "docs":
-		if docsUrl == "" {
+		if docsURL == "" {
 			fmt.Println("Error: docs operation requires additional --docs-url argument")
 			flag.Usage()
 			return
 		}
 
-		if err := downloadCloudFormationDocs(docsUrl, filepath.Join(".", "aws-cloudformation-docs")); err != nil {
+		if err := downloadCloudFormationDocs(docsURL, filepath.Join(".", "aws-cloudformation-docs")); err != nil {
 			fatalf("error download CloudFormation docs: %v", err)
 		}
 
@@ -140,8 +153,10 @@ func main() {
 
 	case "schema":
 		supportedTypes := readSupportedResourceTypes(genDir)
-		jsonSchemas := readJsonSchemas(schemaFolder, autoNameOverlay)
-		docsTypes, err := schema.ReadCloudFormationDocsFile(filepath.Join(".", "aws-cloudformation-docs", "CloudFormationDocumentation.json"))
+		jsonSchemas := readJSONSchemas(schemaFolder, autoNameOverlay)
+		docsTypes, err := schema.ReadCloudFormationDocsFile(
+			filepath.Join(".", "aws-cloudformation-docs", "CloudFormationDocumentation.json"),
+		)
 		if err != nil {
 			fatalf("error reading CloudFormation docs file: %v", err)
 		}
@@ -160,7 +175,15 @@ func main() {
 			fatalf("error reading %q", refDBFile)
 		}
 
-		packageSpec, meta, reports, err := schema.GatherPackage(supportedTypes, jsonSchemas, false, &semanticsDocument, docsTypes, regions, refDB)
+		packageSpec, meta, reports, err := schema.GatherPackage(
+			supportedTypes,
+			jsonSchemas,
+			false,
+			&semanticsDocument,
+			docsTypes,
+			regions,
+			refDB,
+		)
 		if err != nil {
 			fatalf("error generating schema: %v", err)
 		}
@@ -211,10 +234,13 @@ func fatalf(format string, a ...any) {
 	log.Fatalf("schema generation failed\n%s\n%s\n%s\n", barrier, fmt.Sprintf(format, a...), barrier)
 }
 
-func readJsonSchemas(schemaDir string, overlay map[string]AutoNamingOverlay) (res []*jsschema.Schema) {
+func readJSONSchemas(schemaDir string, overlay map[string]AutoNamingOverlay) (res []*jsschema.Schema) {
 	var fileNames []string
 	root := filepath.Join(".", schemaDir)
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
 		if info != nil && !info.IsDir() {
 			fileNames = append(fileNames, path)
 		}
@@ -226,12 +252,12 @@ func readJsonSchemas(schemaDir string, overlay map[string]AutoNamingOverlay) (re
 
 	sort.Strings(fileNames)
 	for _, fileName := range fileNames {
-		res = append(res, readJsonSchema(fileName, overlay))
+		res = append(res, readJSONSchema(fileName, overlay))
 	}
 	return
 }
 
-func readJsonSchema(schemaPath string, overlay map[string]AutoNamingOverlay) *jsschema.Schema {
+func readJSONSchema(schemaPath string, overlay map[string]AutoNamingOverlay) *jsschema.Schema {
 	raw, err := os.ReadFile(schemaPath)
 	if err != nil {
 		fatalf("error reading json schema: %v", errors.Wrap(err, schemaPath))
@@ -381,7 +407,11 @@ func writeSupportedResourceTypes(outDir string) error {
 	cfn := cloudformation.NewFromConfig(cfg)
 
 	supported := codegen.NewStringSet()
-	for _, provisioningType := range []types.ProvisioningType{types.ProvisioningTypeFullyMutable, types.ProvisioningTypeImmutable} {
+	provisioningTypes := []types.ProvisioningType{
+		types.ProvisioningTypeFullyMutable,
+		types.ProvisioningTypeImmutable,
+	}
+	for _, provisioningType := range provisioningTypes {
 		var nextToken *string
 		for {
 			out, err := cfn.ListTypes(ctx.Background(), &cloudformation.ListTypesInput{
@@ -453,7 +483,7 @@ func downloadCloudFormationDocs(url, outDir string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.Get(url)
+	resp, err := http.Get(url) //nolint:gosec // The documentation URL is a trusted generation input.
 	if err != nil {
 		return err
 	}
@@ -464,7 +494,7 @@ func downloadCloudFormationDocs(url, outDir string) error {
 		return err
 	}
 	outPath := filepath.Join(outDir, "CloudFormationDocumentation.json")
-	if err := os.WriteFile(outPath, body, 0644); err != nil {
+	if err := os.WriteFile(outPath, body, 0o644); err != nil { //nolint:gosec // Generated docs are public data.
 		return err
 	}
 	return nil
@@ -478,13 +508,13 @@ func downloadCloudFormationSchemas(urls []string, outDir string, genDir string) 
 	}
 
 	for _, url := range urls {
-		resp, err := http.Get(url)
+		resp, err := http.Get(url) //nolint:gosec // Schema URLs are trusted generation inputs.
 		if err != nil {
 			return err
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -496,7 +526,10 @@ func downloadCloudFormationSchemas(urls []string, outDir string, genDir string) 
 
 		// Read all the files from zip archive
 		for _, f := range zipReader.File {
-			outPath := filepath.Join(outDir, f.Name)
+			if !filepath.IsLocal(f.Name) {
+				return fmt.Errorf("invalid schema archive path %q", f.Name)
+			}
+			outPath := filepath.Join(outDir, f.Name) //nolint:gosec // filepath.IsLocal above prevents traversal.
 
 			outFile, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
 			if err != nil {
@@ -508,7 +541,7 @@ func downloadCloudFormationSchemas(urls []string, outDir string, genDir string) 
 				return err
 			}
 
-			_, err = io.Copy(outFile, rc)
+			_, err = io.Copy(outFile, rc) //nolint:gosec // CloudFormation schema archives are trusted inputs.
 			if err != nil {
 				return err
 			}
@@ -526,7 +559,7 @@ func writePulumiSchema(pkgSpec pschema.PackageSpec, outdir string, includeUncomp
 	if err != nil {
 		return errors.Wrap(err, "failed to compress schema")
 	}
-	err = emitFile(outdir, "schema.json.gz", []byte(compressedSchema))
+	err = emitFile(outdir, "schema.json.gz", compressedSchema)
 	if err != nil {
 		panic(errors.Wrap(err, "saving metadata"))
 	}
@@ -560,7 +593,7 @@ func writeMetadata(metadata *metadata.CloudAPIMetadata, outDir string, includeUn
 		return errors.Wrap(err, "marshaling metadata")
 	}
 
-	err = emitFile(outDir, "metadata.json.gz", []byte(compressedMeta.Bytes()))
+	err = emitFile(outDir, "metadata.json.gz", compressedMeta.Bytes())
 	if err != nil {
 		return err
 	}

--- a/provider/cmd/pulumi-gen-aws-native/main_test.go
+++ b/provider/cmd/pulumi-gen-aws-native/main_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package main
 
 import (
@@ -19,9 +20,10 @@ import (
 	"os"
 	"testing"
 
-	jsschema "github.com/pulumi/jsschema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	jsschema "github.com/pulumi/jsschema"
 )
 
 func TestCleanDir(t *testing.T) {
@@ -133,7 +135,7 @@ func Test_mergeAutoNaming(t *testing.T) {
 	})
 }
 
-func Test_readJsonSchema_convertsExclusiveBounds(t *testing.T) {
+func Test_readJSONSchema_convertsExclusiveBounds(t *testing.T) {
 	tempDir := t.TempDir()
 	schemaPath := tempDir + "/schema.json"
 	err := os.WriteFile(schemaPath, []byte(`
@@ -148,7 +150,7 @@ func Test_readJsonSchema_convertsExclusiveBounds(t *testing.T) {
 }`), 0o600)
 	require.NoError(t, err)
 
-	schema := readJsonSchema(schemaPath, nil)
+	schema := readJSONSchema(schemaPath, nil)
 	size := schema.Properties["Size"]
 	require.NotNil(t, size)
 	assert.Equal(t, float64(10), size.Maximum.Val)

--- a/provider/pkg/autonaming/application.go
+++ b/provider/pkg/autonaming/application.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 // ProviderAutoNamingConfig contains autonaming parameters configured for the provider.
@@ -88,7 +89,9 @@ func getDefaultName(
 	if engineConfig.AutonamingMode != nil {
 		// Engine autonaming conflicts with provider autonaming. If both are specified, return an error.
 		if providerConfig != nil {
-			return nil, fmt.Errorf("pulumi:autonaming conflicts with provider autonaming configuration, please specify only one")
+			return nil, fmt.Errorf(
+				"pulumi:autonaming conflicts with provider autonaming configuration, please specify only one",
+			)
 		}
 
 		switch *engineConfig.AutonamingMode {
@@ -107,10 +110,18 @@ func getDefaultName(
 
 			// Validate the proposed name against the length constraints.
 			if propertySpec.MaxLength > 0 && len(proposedName) > propertySpec.MaxLength {
-				return nil, fmt.Errorf("proposed name %q exceeds max length of %d", proposedName, propertySpec.MaxLength)
+				return nil, fmt.Errorf(
+					"proposed name %q exceeds max length of %d",
+					proposedName,
+					propertySpec.MaxLength,
+				)
 			}
 			if propertySpec.MinLength > 0 && len(proposedName) < propertySpec.MinLength {
-				return nil, fmt.Errorf("proposed name %q is shorter than min length of %d", proposedName, propertySpec.MinLength)
+				return nil, fmt.Errorf(
+					"proposed name %q is shorter than min length of %d",
+					proposedName,
+					propertySpec.MinLength,
+				)
 			}
 
 			v := resource.NewStringProperty(proposedName)
@@ -162,11 +173,10 @@ func getDefaultName(
 					" Prefix: %[2]q is too large to fix max length constraint of %[3]d"+
 					" with required suffix %[4]q. Please provide a value for %[1]q",
 					sdkName, prefix, propertySpec.MaxLength, namingTrivia.Suffix)
-			} else {
-				return nil, fmt.Errorf("failed to auto-generate value for %[1]q."+
-					" Prefix: %[2]q is too large to fix max length constraint of %[3]d. Please provide a value for %[1]q",
-					sdkName, prefix, propertySpec.MaxLength)
 			}
+			return nil, fmt.Errorf("failed to auto-generate value for %[1]q."+
+				" Prefix: %[2]q is too large to fix max length constraint of %[3]d. Please provide a value for %[1]q",
+				sdkName, prefix, propertySpec.MaxLength)
 		}
 		if left < randLength {
 			randLength = left

--- a/provider/pkg/autonaming/application_test.go
+++ b/provider/pkg/autonaming/application_test.go
@@ -1,15 +1,18 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package autonaming
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func Test_getDefaultName(t *testing.T) {
@@ -61,7 +64,11 @@ func Test_getDefaultName(t *testing.T) {
 			name:       "Autoname with max length too small",
 			maxLength:  6,
 			comparison: within(15, 15),
-			err:        fmt.Errorf("failed to auto-generate value for %[1]q. Prefix: \"myName-\" is too large to fix max length constraint of 6. Please provide a value for %[1]q", sdkName),
+			err: fmt.Errorf(
+				//nolint:lll // Preserve the exact fixture or documentation text.
+				"failed to auto-generate value for %[1]q. Prefix: \"myName-\" is too large to fix max length constraint of 6. Please provide a value for %[1]q",
+				sdkName,
+			),
 		},
 		{
 			name:       "Autoname with constraints on min and max length",
@@ -90,7 +97,7 @@ func Test_getDefaultName(t *testing.T) {
 			engineConfig: EngineAutoNamingConfig{
 				AutonamingMode: p(EngineAutonamingModeDisable),
 			},
-			comparison: func(t *testing.T, actual *resource.PropertyValue) bool {
+			comparison: func(_ *testing.T, actual *resource.PropertyValue) bool {
 				return actual == nil
 			},
 			noName: true,
@@ -134,7 +141,9 @@ func Test_getDefaultName(t *testing.T) {
 				AutoTrim:              true,
 				RandomSuffixMinLength: 5,
 			},
-			err: fmt.Errorf("pulumi:autonaming conflicts with provider autonaming configuration, please specify only one"),
+			err: fmt.Errorf(
+				"pulumi:autonaming conflicts with provider autonaming configuration, please specify only one",
+			),
 		},
 	}
 
@@ -163,10 +172,9 @@ func Test_getDefaultName(t *testing.T) {
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.noName, got == nil)
 			}
+			require.NoError(t, err)
+			require.Equal(t, tt.noName, got == nil)
 			if !tt.comparison(t, got) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", *got, autoNamingSpec)
 			}
@@ -240,7 +248,11 @@ func Test_getDefaultName_withAutoNameConfig(t *testing.T) {
 				RandomSuffixMinLength: 2,
 			},
 			comparison: within(15, 15),
-			err:        fmt.Errorf("failed to auto-generate value for %[1]q. Prefix: \"myName-\" is too large to fix max length constraint of 4. Please provide a value for %[1]q", sdkName),
+			err: fmt.Errorf(
+				//nolint:lll // Preserve the exact fixture or documentation text.
+				"failed to auto-generate value for %[1]q. Prefix: \"myName-\" is too large to fix max length constraint of 4. Please provide a value for %[1]q",
+				sdkName,
+			),
 		},
 		{
 			name:         "Autoname with constraints on min and max length",
@@ -262,13 +274,19 @@ func Test_getDefaultName_withAutoNameConfig(t *testing.T) {
 			},
 			maxLength:  13,
 			comparison: within(13, 13),
-			err:        fmt.Errorf("failed to auto-generate value for %[1]q. Prefix: \"myReallyLongName-\" is too large to fix max length constraint of 13 with required suffix length 14. Please provide a value for %[1]q", sdkName),
+			err: fmt.Errorf(
+				//nolint:lll // Preserve the exact fixture or documentation text.
+				"failed to auto-generate value for %[1]q. Prefix: \"myReallyLongName-\" is too large to fix max length constraint of 13 with required suffix length 14. Please provide a value for %[1]q",
+				sdkName,
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			urn := resource.URN(fmt.Sprintf("urn:pulumi:dev::test::test-provider:testModule:TestResource::%s", tt.resourceName))
+			urn := resource.URN(
+				fmt.Sprintf("urn:pulumi:dev::test::test-provider:testModule:TestResource::%s", tt.resourceName),
+			)
 			autoNamingSpec := &metadata.AutoNamingSpec{
 				SdkName:   "autoName",
 				MinLength: tt.minLength,
@@ -281,10 +299,9 @@ func Test_getDefaultName_withAutoNameConfig(t *testing.T) {
 			if tt.err != nil {
 				require.EqualError(t, err, tt.err.Error())
 				return
-			} else {
-				require.NoError(t, err)
-				require.True(t, got != nil)
 			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
 			if !tt.comparison(t, got) {
 				t.Errorf("getDefaultName() = %v for spec: %+v", *got, autoNamingSpec)
 			}
@@ -294,7 +311,7 @@ func Test_getDefaultName_withAutoNameConfig(t *testing.T) {
 }
 
 func equals(expected resource.PropertyValue) func(t *testing.T, actual *resource.PropertyValue) bool {
-	return func(t *testing.T, actual *resource.PropertyValue) bool {
+	return func(_ *testing.T, actual *resource.PropertyValue) bool {
 		return expected == *actual
 	}
 }
@@ -305,10 +322,10 @@ func startsWith(prefix string, randomLen int) func(t *testing.T, actual *resourc
 	}
 }
 
-func within(min, max int) func(t *testing.T, value *resource.PropertyValue) bool {
-	return func(t *testing.T, actual *resource.PropertyValue) bool {
+func within(minLength, maxLength int) func(t *testing.T, value *resource.PropertyValue) bool {
+	return func(_ *testing.T, actual *resource.PropertyValue) bool {
 		l := len(actual.V.(string))
-		return min <= l && l <= max
+		return minLength <= l && l <= maxLength
 	}
 }
 

--- a/provider/pkg/autonaming/semantics.go
+++ b/provider/pkg/autonaming/semantics.go
@@ -5,8 +5,9 @@ package autonaming
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func CheckTriviaCondition(props resource.PropertyMap, rule *metadata.NamingRule) (bool, error) {
@@ -19,7 +20,11 @@ func CheckTriviaCondition(props resource.PropertyMap, rule *metadata.NamingRule)
 }
 
 // Checks naming trivia for a resource, returning whether the naming trivia applies and the naming trivia.
-func CheckNamingTrivia(sdkName string, props resource.PropertyMap, spec *metadata.NamingTriviaSpec) (bool, *metadata.NamingTrivia, error) {
+func CheckNamingTrivia(
+	_ string,
+	props resource.PropertyMap,
+	spec *metadata.NamingTriviaSpec,
+) (bool, *metadata.NamingTrivia, error) {
 	if spec == nil {
 		return false, nil, nil
 	}

--- a/provider/pkg/autonaming/spec.go
+++ b/provider/pkg/autonaming/spec.go
@@ -6,11 +6,19 @@ import (
 	"strings"
 
 	jsschema "github.com/pulumi/jsschema"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
-func CreateAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resourceTypeName string, jsonSchemaProperties map[string]*jsschema.Schema, semanticsSpec metadata.SemanticsSpec) *metadata.AutoNamingSpec {
+const schemaTypeString = "string"
+
+func CreateAutoNamingSpec(
+	inputProperties map[string]pschema.PropertySpec,
+	resourceTypeName string,
+	jsonSchemaProperties map[string]*jsschema.Schema,
+	semanticsSpec metadata.SemanticsSpec,
+) *metadata.AutoNamingSpec {
 	type names struct {
 		cfName  string
 		sdkName string
@@ -32,7 +40,7 @@ func CreateAutoNamingSpec(inputProperties map[string]pschema.PropertySpec, resou
 
 	tryMakeSpecForField := func(loweredName string) *metadata.AutoNamingSpec {
 		sdkName := fieldsLowered[loweredName].sdkName
-		if prop, has := inputProperties[sdkName]; !has || prop.Type != "string" {
+		if prop, has := inputProperties[sdkName]; !has || prop.Type != schemaTypeString {
 			return nil
 		}
 		jsonSpec := jsonSchemaProperties[fieldsLowered[loweredName].cfName]

--- a/provider/pkg/autonaming/spec_test.go
+++ b/provider/pkg/autonaming/spec_test.go
@@ -1,12 +1,15 @@
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package autonaming
 
 import (
 	"testing"
 
-	jsschema "github.com/pulumi/jsschema"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
+
+	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func TestCreateAutoNamingSpec(t *testing.T) {
@@ -17,7 +20,12 @@ func TestCreateAutoNamingSpec(t *testing.T) {
 		semanticsSpec        metadata.SemanticsSpec
 	}
 	create := func(args args) *metadata.AutoNamingSpec {
-		return CreateAutoNamingSpec(args.inputProperties, args.resourceTypeName, args.jsonSchemaProperties, args.semanticsSpec)
+		return CreateAutoNamingSpec(
+			args.inputProperties,
+			args.resourceTypeName,
+			args.jsonSchemaProperties,
+			args.semanticsSpec,
+		)
 	}
 
 	t.Run("literal name", func(t *testing.T) {

--- a/provider/pkg/cf2pulumi/format.go
+++ b/provider/pkg/cf2pulumi/format.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/zclconf/go-cty/cty"
 )
 
 // a formatter formats PCL into a canonical style.
@@ -42,12 +43,11 @@ func (f *formatter) indented(fn func()) {
 // - An object with no elements is formatted as `{}`
 // - An object with elements is formatted as
 //
-//       {
-//           key0 = value0,
-//           ...
-//           keyN = valueN
-//       }
-//
+//	{
+//	    key0 = value0,
+//	    ...
+//	    keyN = valueN
+//	}
 func (f *formatter) formatObjectCons(x *model.ObjectConsExpression) {
 	x.Tokens = syntax.NewObjectConsTokens(len(x.Items))
 
@@ -80,12 +80,11 @@ func (f *formatter) formatObjectCons(x *model.ObjectConsExpression) {
 // - A tuple with one element is formatted as `[value]`
 // - A tuple with more than one element is formatted as
 //
-//       [
-//           value0,
-//           ...
-//           valueN
-//       ]
-//
+//	[
+//	    value0,
+//	    ...
+//	    valueN
+//	]
 func (f *formatter) formatTupleCons(x *model.TupleConsExpression) {
 	x.Tokens = syntax.NewTupleConsTokens(len(x.Expressions))
 
@@ -187,7 +186,9 @@ func (f *formatter) formatExpression(x model.Expression) model.Expression {
 					part.SetLeadingTrivia(syntax.TriviaList{syntax.NewTemplateDelimiter(hclsyntax.TokenTemplateSeqEnd)})
 				}
 				if i < len(x.Parts)-1 {
-					part.SetTrailingTrivia(syntax.TriviaList{syntax.NewTemplateDelimiter(hclsyntax.TokenTemplateInterp)})
+					part.SetTrailingTrivia(
+						syntax.TriviaList{syntax.NewTemplateDelimiter(hclsyntax.TokenTemplateInterp)},
+					)
 				}
 			}
 		}
@@ -207,11 +208,11 @@ func (f *formatter) formatExpression(x model.Expression) model.Expression {
 
 // formatBlock formats a PCL block as
 //
-//     type labels... {
-//         item0
-//         ...
-//         itemN
-//     }
+//	type labels... {
+//	    item0
+//	    ...
+//	    itemN
+//	}
 //
 // Unless the block is the first in its containing body, a newline is inserted before the block.
 func (f *formatter) formatBlock(block *model.Block, first bool) {
@@ -233,7 +234,7 @@ func (f *formatter) formatBlock(block *model.Block, first bool) {
 
 // formatAttribute formats a PCL attribute as
 //
-//     name = value
+//	name = value
 //
 // If the attribute follows a block, a newline is inserted before the attribute.
 func (f *formatter) formatAttribute(attr *model.Attribute, afterBlock bool) {

--- a/provider/pkg/cf2pulumi/renderer.go
+++ b/provider/pkg/cf2pulumi/renderer.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package cf2pulumi
 
 import (
@@ -13,13 +14,15 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 )
 
 // null represents PCL's builtin `null` variable
@@ -102,23 +105,24 @@ type renderContext struct {
 //
 // If the argument is a single value and the minimum count is greater than one, the argument is wrapped in an array
 // and returned.
-func (ctx *renderContext) checkArgsArray(name string, v ast.Node, min, max int) ([]ast.Node, error) {
+func (ctx *renderContext) checkArgsArray(name string, v ast.Node, minArgs, maxArgs int) ([]ast.Node, error) {
 	if v.Type() != ast.SequenceType {
-		if min > 1 {
+		if minArgs > 1 {
 			return nil, fmt.Errorf("the argument to '%s' must be an array", name)
 		}
 		return []ast.Node{v}, nil
 	}
 
 	arr := v.(*ast.SequenceNode).Values
-	if len(arr) < min || (max >= 0 && len(arr) > max) {
-		if min == max {
-			return nil, fmt.Errorf("the argument to '%s' must have exactly %v elements", name, min)
+	if len(arr) < minArgs || (maxArgs >= 0 && len(arr) > maxArgs) {
+		if minArgs == maxArgs {
+			return nil, fmt.Errorf("the argument to '%s' must have exactly %v elements", name, minArgs)
 		}
-		if max >= 0 {
-			return nil, fmt.Errorf("the argument to '%s' must have between %v and %v elements", name, min, max)
+		if maxArgs >= 0 {
+			return nil, fmt.Errorf(
+				"the argument to '%s' must have between %v and %v elements", name, minArgs, maxArgs)
 		}
-		return nil, fmt.Errorf("the argument to '%s' must have at least %v elements", name, min)
+		return nil, fmt.Errorf("the argument to '%s' must have at least %v elements", name, minArgs)
 	}
 	return arr, nil
 }
@@ -151,7 +155,7 @@ func (ctx *renderContext) renderRef(name string) (model.Expression, error) {
 
 var holePattern = regexp.MustCompile(`\${([^}]*)}`)
 
-// renderSub renders a call to Fn::Sub. The call is converted to a template expression. If an envrionment map is
+// renderSub renders a call to Fn::Sub. The call is converted to a template expression. If an environment map is
 // provided, references to map elements are replaced with the corresponding elements.
 func (ctx *renderContext) renderSub(name string, value ast.Node) (model.Expression, error) {
 	arr, err := ctx.checkArgsArray(name, value, 1, 2)
@@ -213,7 +217,9 @@ func (ctx *renderContext) renderSub(name string, value ast.Node) (model.Expressi
 	literals = append(literals, text[start:])
 
 	if len(literals) != len(refs)+1 {
-		return nil, fmt.Errorf("the number of literals must be exactly one more than the number of references in 'Fn::Sub'")
+		return nil, fmt.Errorf(
+			"the number of literals must be exactly one more than the number of references in 'Fn::Sub'",
+		)
 	}
 
 	var parts []model.Expression
@@ -227,8 +233,8 @@ func (ctx *renderContext) renderSub(name string, value ast.Node) (model.Expressi
 }
 
 // renderArgsArray validates and renders the argument to a function as an array of expressions.
-func (ctx *renderContext) renderArgsArray(name string, arg ast.Node, min, max int) ([]model.Expression, error) {
-	arr, err := ctx.checkArgsArray(name, arg, min, max)
+func (ctx *renderContext) renderArgsArray(name string, arg ast.Node, minArgs, maxArgs int) ([]model.Expression, error) {
+	arr, err := ctx.checkArgsArray(name, arg, minArgs, maxArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +464,7 @@ func (ctx *renderContext) renderFunctionCall(name string, arg ast.Node) (model.E
 		return &model.ScopeTraversalExpression{
 			Traversal: hcl.Traversal{
 				hcl.TraverseRoot{Name: resourceVar.Name},
-				hcl.TraverseAttr{Name: strings.Replace(sdkName, ".", "", -1)},
+				hcl.TraverseAttr{Name: strings.ReplaceAll(sdkName, ".", "")},
 			},
 			Parts: []model.Traversable{
 				resourceVar,
@@ -692,15 +698,17 @@ func (ctx *renderContext) renderPseudoParameters(items *[]model.BodyItem) {
 
 // renderParameterType converts a CloudFormation parameter type to its equivalent PCL type.
 func renderParameterType(s string) (string, bool) {
+	const stringType = "string"
+
 	switch s {
 	case "String":
-		return "string", true
+		return stringType, true
 	case "Number":
 		return "number", true
 	case "List<Number>":
 		return "list(number)", true
 	case "CommaDelimitedList", "List<String>":
-		return "list(string)", true
+		return "list(" + stringType + ")", true
 	case "AWS::EC2::AvailabilityZone::Name",
 		"AWS::EC2::Image::Id",
 		"AWS::EC2::Instance::Id",
@@ -712,7 +720,7 @@ func renderParameterType(s string) (string, bool) {
 		"AWS::EC2::VPC::Id",
 		"AWS::Route53::HostedZone::Id",
 		"AWS::SSM::Parameter::Name":
-		return "string", true
+		return stringType, true
 	case "List<AWS::EC2::AvailabilityZone::Name>",
 		"List<AWS::EC2::Image::Id>",
 		"List<AWS::EC2::Instance::Id>",
@@ -722,7 +730,7 @@ func renderParameterType(s string) (string, bool) {
 		"List<AWS::EC2::Volume::Id>",
 		"List<AWS::EC2::VPC::Id>",
 		"List<AWS::Route53::HostedZone::Id>":
-		return "list(string)", true
+		return "list(" + stringType + ")", true
 	default:
 		return "", false
 	}
@@ -755,7 +763,7 @@ func (ctx *renderContext) renderParameter(attr *ast.MappingValueNode) ([]model.B
 
 	typeExpr, ok := renderParameterType(typeValue)
 	if !ok {
-		return nil, fmt.Errorf("Unrecognized type '%v' for parameter '%s'", typeValue, name)
+		return nil, fmt.Errorf("unrecognized type '%v' for parameter '%s'", typeValue, name)
 	}
 
 	paramRefVar, ok := ctx.parameters[keyString(attr)]
@@ -920,13 +928,19 @@ func (ctx *renderContext) renderResource(attr *ast.MappingValueNode) (model.Body
 			case ast.SequenceType:
 				arr = f.Value.(*ast.SequenceNode).Values
 			default:
-				return nil, diagnostics, fmt.Errorf("the \"DependsOn\" attribute for resource '%v' must be a string or list of strings", name)
+				return nil, diagnostics, fmt.Errorf(
+					"the \"DependsOn\" attribute for resource '%v' must be a string or list of strings",
+					name,
+				)
 			}
 
 			var refs []model.Expression
 			for _, v := range arr {
 				if v.Type() != ast.StringType {
-					return nil, diagnostics, fmt.Errorf("the \"DependsOn\" attribute for resource '%v' must be a string or list of strings", name)
+					return nil, diagnostics, fmt.Errorf(
+						"the \"DependsOn\" attribute for resource '%v' must be a string or list of strings",
+						name,
+					)
 				}
 				resourceName := v.(*ast.StringNode).Value
 				resourceVar, ok := ctx.resources[resourceName]
@@ -963,7 +977,11 @@ func (ctx *renderContext) renderResource(attr *ast.MappingValueNode) (model.Body
 				diagnostics = append(diagnostics, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
 					Summary:  "Resource not supported",
-					Detail:   fmt.Sprintf("Resource %q is not yet supported by AWS CloudControl API. Code generated for %q is for reference only.", token, resourceVar.Name),
+					Detail: fmt.Sprintf(
+						"Resource %q is not yet supported by AWS CloudControl API. Code generated for %q is for reference only.",
+						token,
+						resourceVar.Name,
+					),
 				})
 			}
 		case "Version":
@@ -1027,7 +1045,10 @@ type objectRenderer func(*ast.MappingValueNode) (model.BodyItem, hcl.Diagnostics
 
 // renderObjects is a helper that renders a set of named objects in a mapping. Each named object is passed to the
 // provided renderer.
-func (ctx *renderContext) renderObjects(attr *ast.MappingValueNode, render objectRenderer) ([]model.BodyItem, hcl.Diagnostics, error) {
+func (ctx *renderContext) renderObjects(
+	attr *ast.MappingValueNode,
+	render objectRenderer,
+) ([]model.BodyItem, hcl.Diagnostics, error) {
 	values, ok := mapValues(attr.Value)
 	if !ok {
 		return nil, nil, fmt.Errorf("%s must be a mapping", keyString(attr))
@@ -1261,7 +1282,7 @@ func RenderTemplate(file *ast.File, metadata *metadata.CloudAPIMetadata) (*model
 			// Ignore this
 		case "Description":
 			if f.Value.Type() != ast.StringType {
-				return nil, diagnostics, fmt.Errorf("Description must be a string")
+				return nil, diagnostics, fmt.Errorf("description must be a string")
 			}
 			//comment = f.Value.(jsonast.String).String()
 		case "Metadata":
@@ -1271,7 +1292,7 @@ func RenderTemplate(file *ast.File, metadata *metadata.CloudAPIMetadata) (*model
 
 			values, ok := mapValues(f.Value)
 			if !ok {
-				return nil, diagnostics, fmt.Errorf("Parameters must be a map")
+				return nil, diagnostics, fmt.Errorf("parameters must be a map")
 			}
 
 			for _, f := range values {
@@ -1344,7 +1365,10 @@ func RenderFile(path string, metadata *metadata.CloudAPIMetadata) (*model.Body, 
 
 // RenderText parses and renders a CloudFormation template to a PCL program body. If there are errors in the template,
 // the function returns an error.
-func RenderText(yaml string, metadata *metadata.CloudAPIMetadata) (body *model.Body, diagnostics hcl.Diagnostics, err error) {
+func RenderText(
+	yaml string,
+	metadata *metadata.CloudAPIMetadata,
+) (body *model.Body, diagnostics hcl.Diagnostics, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("panic recovered during YAML parsing: %v", r)

--- a/provider/pkg/cf2pulumi/utils.go
+++ b/provider/pkg/cf2pulumi/utils.go
@@ -10,8 +10,9 @@ import (
 	"github.com/goccy/go-yaml/ast"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/zclconf/go-cty/cty"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 )
 
 // camel replaces the first contiguous string of upper case runes in the given string with its lower-case equivalent.
@@ -171,9 +172,10 @@ func resourceToken(typ string) string {
 	moduleName, resourceName := components[1], components[2]
 
 	// Override the name of the Config module.
-	if moduleName == "Config" {
+	switch moduleName {
+	case "Config":
 		moduleName = "Configuration"
-	} else if moduleName == "config" {
+	case "config":
 		moduleName = "configuration"
 	}
 	return "aws-native:" + moduleName + ":" + resourceName

--- a/provider/pkg/client/api.go
+++ b/provider/pkg/client/api.go
@@ -26,7 +26,11 @@ type CloudControlApiClient interface {
 	// It returns a ProgressEvent which is the initial progress returned directly from the API call,
 	// without awaiting any long-running operations.
 	// The changes to be applied are expressed as a list of JSON patch operations.
-	UpdateResource(ctx context.Context, cfType, id string, patches []jsonpatch.JsonPatchOperation) (*types.ProgressEvent, error)
+	UpdateResource(
+		ctx context.Context,
+		cfType, id string,
+		patches []jsonpatch.JsonPatchOperation,
+	) (*types.ProgressEvent, error)
 
 	// DeleteResource deletes a resource of the specified type with the given identifier.
 	// It returns a ProgressEvent which is the initial progress returned directly from the API call,
@@ -44,8 +48,12 @@ type CloudControlApiClient interface {
 	// GetResourceRequestStatus returns the current status of a resource operation request.
 	GetResourceRequestStatus(ctx context.Context, requestToken string) (*types.ProgressEvent, error)
 
-	// GetResourceRequestStatusWithHooks returns the current status of a resource operation request with hook information.
-	GetResourceRequestStatusWithHooks(ctx context.Context, requestToken string) (*types.ProgressEvent, []types.HookProgressEvent, error)
+	// GetResourceRequestStatusWithHooks returns the current status of a resource operation request with hook
+	// information.
+	GetResourceRequestStatusWithHooks(
+		ctx context.Context,
+		requestToken string,
+	) (*types.ProgressEvent, []types.HookProgressEvent, error)
 }
 
 // NewCloudControlApiClient creates a wrapper around the AWS SDK's Cloud Control client.
@@ -61,7 +69,10 @@ type ccApiClientImpl struct {
 	roleArn *string
 }
 
-func (client *ccApiClientImpl) CreateResource(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+func (client *ccApiClientImpl) CreateResource(
+	ctx context.Context,
+	cfType, desiredState string,
+) (*types.ProgressEvent, error) {
 	clientToken := uuid.New().String()
 	res, err := client.cctl.CreateResource(ctx, &cloudcontrol.CreateResourceInput{
 		ClientToken:  aws.String(clientToken),
@@ -75,7 +86,11 @@ func (client *ccApiClientImpl) CreateResource(ctx context.Context, cfType, desir
 	return res.ProgressEvent, nil
 }
 
-func (client *ccApiClientImpl) UpdateResource(ctx context.Context, cfType, id string, patches []jsonpatch.JsonPatchOperation) (*types.ProgressEvent, error) {
+func (client *ccApiClientImpl) UpdateResource(
+	ctx context.Context,
+	cfType, id string,
+	patches []jsonpatch.JsonPatchOperation,
+) (*types.ProgressEvent, error) {
 	doc, err := json.Marshal(patches)
 	if err != nil {
 		return nil, fmt.Errorf("serializing patch as json: %w", err)
@@ -110,7 +125,10 @@ func (client *ccApiClientImpl) DeleteResource(ctx context.Context, cfType, id st
 	return res.ProgressEvent, nil
 }
 
-func (client *ccApiClientImpl) GetResource(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+func (client *ccApiClientImpl) GetResource(
+	ctx context.Context,
+	typeName, identifier string,
+) (map[string]interface{}, error) {
 	getRes, err := client.cctl.GetResource(ctx, &cloudcontrol.GetResourceInput{
 		TypeName:   aws.String(typeName),
 		Identifier: aws.String(identifier),
@@ -152,7 +170,10 @@ func (client *ccApiClientImpl) ListResources(
 	return res.ResourceDescriptions, res.NextToken, nil
 }
 
-func (client *ccApiClientImpl) GetResourceRequestStatus(ctx context.Context, requestToken string) (*types.ProgressEvent, error) {
+func (client *ccApiClientImpl) GetResourceRequestStatus(
+	ctx context.Context,
+	requestToken string,
+) (*types.ProgressEvent, error) {
 	res, err := client.cctl.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: aws.String(requestToken),
 	})
@@ -162,7 +183,10 @@ func (client *ccApiClientImpl) GetResourceRequestStatus(ctx context.Context, req
 	return res.ProgressEvent, nil
 }
 
-func (client *ccApiClientImpl) GetResourceRequestStatusWithHooks(ctx context.Context, requestToken string) (*types.ProgressEvent, []types.HookProgressEvent, error) {
+func (client *ccApiClientImpl) GetResourceRequestStatusWithHooks(
+	ctx context.Context,
+	requestToken string,
+) (*types.ProgressEvent, []types.HookProgressEvent, error) {
 	res, err := client.cctl.GetResourceRequestStatus(ctx, &cloudcontrol.GetResourceRequestStatusInput{
 		RequestToken: aws.String(requestToken),
 	})

--- a/provider/pkg/client/awaiter.go
+++ b/provider/pkg/client/awaiter.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const operationStatusFailed = "FAILED"
+
 // CloudControlAwaiter provides a mechanism to poll long-running Cloud Control operations until they resolve
 // to completion or failure.
 type CloudControlAwaiter interface {
@@ -32,7 +34,10 @@ type ccAwaiterImpl struct {
 	client CloudControlApiClient
 }
 
-func (a *ccAwaiterImpl) WaitForResourceOpCompletion(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+func (a *ccAwaiterImpl) WaitForResourceOpCompletion(
+	ctx context.Context,
+	pi *types.ProgressEvent,
+) (*types.ProgressEvent, error) {
 	retryBackoff := retry.NewExponentialJitterBackoff(30 * time.Second)
 	i := 0
 	for {
@@ -48,7 +53,7 @@ func (a *ccAwaiterImpl) WaitForResourceOpCompletion(ctx context.Context, pi *typ
 			err        error
 			hookEvents []types.HookProgressEvent
 		)
-		if status == "FAILED" && pi.RequestToken != nil {
+		if status == operationStatusFailed && pi.RequestToken != nil {
 			pi, hookEvents, err = a.client.GetResourceRequestStatusWithHooks(ctx, *pi.RequestToken)
 			if err != nil {
 				return nil, errors.Wrap(err, "getting resource request status")
@@ -91,7 +96,7 @@ func (a *ccAwaiterImpl) WaitForResourceOpCompletion(ctx context.Context, pi *typ
 		if finished || err != nil {
 			return pi, err
 		}
-		i += 1
+		i++
 	}
 }
 
@@ -104,7 +109,7 @@ func hasFinishedWithHooks(pi *types.ProgressEvent, hookEvents []types.HookProgre
 	switch status {
 	case "SUCCESS":
 		return true, nil
-	case "FAILED":
+	case operationStatusFailed:
 		statusMessage := ""
 		if pi.StatusMessage != nil {
 			statusMessage = *pi.StatusMessage
@@ -118,7 +123,7 @@ func hasFinishedWithHooks(pi *types.ProgressEvent, hookEvents []types.HookProgre
 				hookStatus := aws.ToString(hookEvent.HookStatus)
 				// Check for failed hook statuses
 				if hookStatus == "HOOK_COMPLETE_FAILED" || hookStatus == "HOOK_FAILED" {
-					hookErr.WithHookEvent(hookEvent)
+					hookErr = hookErr.WithHookEvent(hookEvent)
 				}
 			}
 		}

--- a/provider/pkg/client/awaiter_test.go
+++ b/provider/pkg/client/awaiter_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package client
 
 import (
@@ -95,7 +96,10 @@ func TestWaitForResourceOpCompletion_InitialFailedStatusIncludesHookFailureDetai
 
 	requestStatusCalls := 0
 	mockAPI := &awaiterTestAPI{
-		getResourceRequestStatusWithHooksFunc: func(ctx context.Context, token string) (*types.ProgressEvent, []types.HookProgressEvent, error) {
+		getResourceRequestStatusWithHooksFunc: func(
+			_ context.Context,
+			token string,
+		) (*types.ProgressEvent, []types.HookProgressEvent, error) {
 			requestStatusCalls++
 			assert.Equal(t, requestToken, token)
 
@@ -151,22 +155,29 @@ func TestHasFinishedWithHooks_FailedWithoutHookEvents(t *testing.T) {
 }
 
 type awaiterTestAPI struct {
-	getResourceRequestStatusWithHooksFunc func(ctx context.Context, requestToken string) (*types.ProgressEvent, []types.HookProgressEvent, error)
+	getResourceRequestStatusWithHooksFunc func(
+		ctx context.Context,
+		requestToken string,
+	) (*types.ProgressEvent, []types.HookProgressEvent, error)
 }
 
-func (*awaiterTestAPI) CreateResource(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+func (*awaiterTestAPI) CreateResource(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 	panic("unexpected CreateResource call")
 }
 
-func (*awaiterTestAPI) UpdateResource(ctx context.Context, cfType, id string, patches []jsonpatch.JsonPatchOperation) (*types.ProgressEvent, error) {
+func (*awaiterTestAPI) UpdateResource(
+	_ context.Context,
+	_, _ string,
+	_ []jsonpatch.JsonPatchOperation,
+) (*types.ProgressEvent, error) {
 	panic("unexpected UpdateResource call")
 }
 
-func (*awaiterTestAPI) DeleteResource(ctx context.Context, cfType, id string) (*types.ProgressEvent, error) {
+func (*awaiterTestAPI) DeleteResource(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 	panic("unexpected DeleteResource call")
 }
 
-func (*awaiterTestAPI) GetResource(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+func (*awaiterTestAPI) GetResource(_ context.Context, _, _ string) (map[string]interface{}, error) {
 	panic("unexpected GetResource call")
 }
 
@@ -180,11 +191,17 @@ func (*awaiterTestAPI) ListResources(
 	panic("unexpected ListResources call")
 }
 
-func (*awaiterTestAPI) GetResourceRequestStatus(ctx context.Context, requestToken string) (*types.ProgressEvent, error) {
+func (*awaiterTestAPI) GetResourceRequestStatus(
+	_ context.Context,
+	_ string,
+) (*types.ProgressEvent, error) {
 	panic("unexpected GetResourceRequestStatus call")
 }
 
-func (m *awaiterTestAPI) GetResourceRequestStatusWithHooks(ctx context.Context, requestToken string) (*types.ProgressEvent, []types.HookProgressEvent, error) {
+func (m *awaiterTestAPI) GetResourceRequestStatusWithHooks(
+	ctx context.Context,
+	requestToken string,
+) (*types.ProgressEvent, []types.HookProgressEvent, error) {
 	if m.getResourceRequestStatusWithHooksFunc == nil {
 		panic("unexpected GetResourceRequestStatusWithHooks call")
 	}

--- a/provider/pkg/client/client.go
+++ b/provider/pkg/client/client.go
@@ -29,26 +29,40 @@ type Logger interface {
 	LogStatus(ctx context.Context, sev diag.Severity, urn resource.URN, msg string) error
 }
 
-// CloudControlApiClient providers CRUD operations around Cloud Control API, with the mechanics of API calls abstracted away.
+// CloudControlApiClient providers CRUD operations around Cloud Control API, with the mechanics of API calls abstracted
+// away.
 // For instance, it serializes and deserializes wire data and follows the protocol of long-running operations.
 //
 //go:generate mockgen -package client -source client.go -destination mock_client.go CloudControlClient,Logger
 type CloudControlClient interface {
 	// Create creates a resource of the specified type with the desired state.
 	// It awaits the operation until completion and returns a map of output property values.
-	Create(ctx context.Context, urn resource.URN, typeName string, desiredState map[string]any) (identifier *string, resourceState map[string]any, err error)
+	Create(
+		ctx context.Context,
+		urn resource.URN,
+		typeName string,
+		desiredState map[string]any,
+	) (identifier *string, resourceState map[string]any, err error)
 
 	// Read returns the current state of the specified resource. It deserializes
 	// the response from the service into a map of untyped values.
 	// If the resource does not exist, no error is returned but the flag exists is set to false.
-	Read(ctx context.Context, typeName, identifier string) (resourceState map[string]interface{}, exists bool, err error)
+	Read(
+		ctx context.Context,
+		typeName, identifier string,
+	) (resourceState map[string]interface{}, exists bool, err error)
 
 	// List returns one CloudControl page of resource identifiers for a type.
 	List(ctx context.Context, typeName string, request ListRequest) ([]string, *string, error)
 
 	// Update updates a resource of the specified type with the specified changeset.
 	// It awaits the operation until completion and returns a map of output property values.
-	Update(ctx context.Context, urn resource.URN, typeName, identifier string, patches []jsonpatch.JsonPatchOperation) (map[string]interface{}, error)
+	Update(
+		ctx context.Context,
+		urn resource.URN,
+		typeName, identifier string,
+		patches []jsonpatch.JsonPatchOperation,
+	) (map[string]interface{}, error)
 
 	// Delete deletes a resource of the specified type with the given identifier.
 	// It awaits the operation until completion.
@@ -71,7 +85,12 @@ type clientImpl struct {
 	logger  Logger
 }
 
-func NewCloudControlClient(cctl *cloudcontrol.Client, roleArn *string, retryer func() aws.Retryer, logger Logger) CloudControlClient {
+func NewCloudControlClient(
+	cctl *cloudcontrol.Client,
+	roleArn *string,
+	retryer func() aws.Retryer,
+	logger Logger,
+) CloudControlClient {
 	api := NewCloudControlApiClient(cctl, roleArn)
 	return &clientImpl{
 		api:     api,
@@ -81,7 +100,12 @@ func NewCloudControlClient(cctl *cloudcontrol.Client, roleArn *string, retryer f
 	}
 }
 
-func (c *clientImpl) Create(ctx context.Context, urn resource.URN, typeName string, desiredState map[string]any) (identifier *string, resourceState map[string]any, err error) {
+func (c *clientImpl) Create(
+	ctx context.Context,
+	urn resource.URN,
+	typeName string,
+	desiredState map[string]any,
+) (identifier *string, resourceState map[string]any, err error) {
 	// Serialize inputs as a desired state JSON.
 	jsonBytes, err := json.Marshal(desiredState)
 	if err != nil {
@@ -134,7 +158,10 @@ func (c *clientImpl) Create(ctx context.Context, urn resource.URN, typeName stri
 	return pi.Identifier, resourceState, waitErr
 }
 
-func (c *clientImpl) Read(ctx context.Context, typeName, identifier string) (resourceState map[string]interface{}, exists bool, err error) {
+func (c *clientImpl) Read(
+	ctx context.Context,
+	typeName, identifier string,
+) (resourceState map[string]interface{}, exists bool, err error) {
 	resourceState, err = c.api.GetResource(ctx, typeName, identifier)
 	if err != nil {
 		var oe *smithy.OperationError
@@ -164,8 +191,14 @@ func (c *clientImpl) List(
 	descriptions, continuation, err := c.api.ListResources(
 		ctx, typeName, request.ResourceModel, request.NextToken, request.MaxResults)
 	if err != nil {
-		return nil, nil, fmt.Errorf("listing resources of type %s (resourceModel=%t, nextToken=%t, maxResults=%s): %w",
-			typeName, request.ResourceModel != nil, request.NextToken != nil, FormatListMaxResults(request.MaxResults), err)
+		return nil, nil, fmt.Errorf(
+			"listing resources of type %s (resourceModel=%t, nextToken=%t, maxResults=%s): %w",
+			typeName,
+			request.ResourceModel != nil,
+			request.NextToken != nil,
+			FormatListMaxResults(request.MaxResults),
+			err,
+		)
 	}
 	identifiers := make([]string, 0, len(descriptions))
 	for _, description := range descriptions {
@@ -186,7 +219,12 @@ func FormatListMaxResults(maxResults *int32) string {
 	return fmt.Sprintf("%d", *maxResults)
 }
 
-func (c *clientImpl) Update(ctx context.Context, urn resource.URN, typeName, identifier string, patches []jsonpatch.JsonPatchOperation) (map[string]interface{}, error) {
+func (c *clientImpl) Update(
+	ctx context.Context,
+	urn resource.URN,
+	typeName, identifier string,
+	patches []jsonpatch.JsonPatchOperation,
+) (map[string]interface{}, error) {
 	_, err := c.withRetries(ctx, urn, func() (*types.ProgressEvent, error) {
 		res, err := c.api.UpdateResource(ctx, typeName, identifier, patches)
 		if err != nil {

--- a/provider/pkg/client/client_test.go
+++ b/provider/pkg/client/client_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package client
 
 import (
@@ -23,7 +24,10 @@ import (
 
 var testURN = resource.URN("urn:pulumi:stack::project::type::name")
 
-const exampleTypeName = "exampleType"
+const (
+	exampleTypeName = "exampleType"
+	exampleID       = "exampleID"
+)
 
 func TestClientRead(t *testing.T) {
 	ctx := context.TODO()
@@ -38,7 +42,7 @@ func TestClientRead(t *testing.T) {
 
 	t.Run("Resource found", func(t *testing.T) {
 		resourceState := map[string]interface{}{"key": "value"}
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, _ string) (map[string]interface{}, error) {
 			return resourceState, nil
 		}
 
@@ -50,7 +54,7 @@ func TestClientRead(t *testing.T) {
 	})
 
 	t.Run("Resource not found 404", func(t *testing.T) {
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, _ string) (map[string]interface{}, error) {
 			return nil, &smithy.OperationError{
 				Err: &awshttp.ResponseError{
 					ResponseError: &smithyhttp.ResponseError{
@@ -72,7 +76,7 @@ func TestClientRead(t *testing.T) {
 	})
 
 	t.Run("Resource not found ResourceNotFoundException", func(t *testing.T) {
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, _ string) (map[string]interface{}, error) {
 			return nil, &smithy.OperationError{
 				Err: &awshttp.ResponseError{
 					ResponseError: &smithyhttp.ResponseError{
@@ -81,7 +85,7 @@ func TestClientRead(t *testing.T) {
 								StatusCode: 400,
 							},
 						},
-						Err: errors.New("Oh no ResourceNotFoundException happened!"),
+						Err: errors.New("resource ResourceNotFoundException happened"),
 					},
 				},
 			}
@@ -96,7 +100,7 @@ func TestClientRead(t *testing.T) {
 
 	t.Run("Other error", func(t *testing.T) {
 		expectedErr := errors.New("some error")
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, _ string) (map[string]interface{}, error) {
 			return nil, expectedErr
 		}
 
@@ -219,18 +223,21 @@ func TestClientCreate(t *testing.T) {
 	}
 
 	t.Run("Resource creation success", func(t *testing.T) {
-		resourceID := "exampleID"
+		resourceID := exampleID
 		resourceState := map[string]interface{}{"output1": "outvalue1"}
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			pi *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return pi, nil
 		}
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, identifier string) (map[string]interface{}, error) {
 			if identifier != resourceID {
 				return nil, errors.New("unexpected identifier")
 			}
@@ -245,7 +252,7 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource creation failure", func(t *testing.T) {
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return nil, errors.New("creation failed")
 		}
 
@@ -257,14 +264,17 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource await failure no state", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return nil, errors.New("creation failed")
 		}
 
@@ -276,14 +286,17 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource await returns no identifier", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{Identifier: nil}, nil
 		}
 
@@ -295,17 +308,20 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource await and read errors, but with identifier", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{Identifier: &resourceID}, errors.New("await failed")
 		}
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, identifier string) (map[string]interface{}, error) {
 			if identifier != resourceID {
 				return nil, errors.New("unexpected identifier")
 			}
@@ -320,17 +336,20 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource read error", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{Identifier: &resourceID}, nil
 		}
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, identifier string) (map[string]interface{}, error) {
 			if identifier != resourceID {
 				return nil, errors.New("unexpected identifier")
 			}
@@ -345,18 +364,21 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("Resource creation succeeds, including outputs, but await returned an error", func(t *testing.T) {
-		resourceID := "exampleID"
+		resourceID := exampleID
 		resourceState := map[string]interface{}{"output1": "outvalue1"}
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{Identifier: &resourceID}, errors.New("await failed")
 		}
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, identifier string) (map[string]interface{}, error) {
 			if identifier != resourceID {
 				return nil, errors.New("unexpected identifier")
 			}
@@ -371,15 +393,23 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("AlreadyExists returns no resource state despite its existence", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
-			return &types.ProgressEvent{Identifier: &resourceID, ErrorCode: "AlreadyExists"}, errors.New("resource with same id alteady exists")
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			_ *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
+			return &types.ProgressEvent{
+					Identifier: &resourceID,
+					ErrorCode:  "AlreadyExists",
+				}, errors.New(
+					"resource with same id alteady exists",
+				)
 		}
 
 		id, outputs, err := client.Create(ctx, testURN, typeName, desiredState)
@@ -390,18 +420,21 @@ func TestClientCreate(t *testing.T) {
 	})
 
 	t.Run("GetResource is retried if it fails with a ResourceNotFoundException", func(t *testing.T) {
-		resourceID := "exampleID"
-		mockAPI.CreateResourceFunc = func(ctx context.Context, cfType, desiredState string) (*types.ProgressEvent, error) {
+		resourceID := exampleID
+		mockAPI.CreateResourceFunc = func(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 			return &types.ProgressEvent{
 				OperationStatus: types.OperationStatusSuccess,
 				Identifier:      &resourceID,
 			}, nil
 		}
-		mockAPI.WaitForResourceOpCompletionFunc = func(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+		mockAPI.WaitForResourceOpCompletionFunc = func(
+			_ context.Context,
+			pi *types.ProgressEvent,
+		) (*types.ProgressEvent, error) {
 			return pi, nil
 		}
 		getResourceInvocation := 0
-		mockAPI.GetResourceFunc = func(ctx context.Context, typeName, identifier string) (map[string]interface{}, error) {
+		mockAPI.GetResourceFunc = func(_ context.Context, _, _ string) (map[string]interface{}, error) {
 			switch getResourceInvocation {
 			case 0:
 				getResourceInvocation++
@@ -471,28 +504,38 @@ func (m *mockAPI) ListResources(
 // It returns a ProgressEvent which is the initial progress returned directly from the API call,
 // without awaiting any long-running operations.
 // The changes to be applied are expressed as a list of JSON patch operations.
-func (m *mockAPI) UpdateResource(ctx context.Context, cfType, id string, patches []jsonpatch.JsonPatchOperation) (*types.ProgressEvent, error) {
+func (m *mockAPI) UpdateResource(
+	_ context.Context,
+	_, _ string,
+	_ []jsonpatch.JsonPatchOperation,
+) (*types.ProgressEvent, error) {
 	panic("not implemented")
 }
 
 // DeleteResource deletes a resource of the specified type with the given identifier.
 // It returns a ProgressEvent which is the initial progress returned directly from the API call,
 // without awaiting any long-running operations.
-func (m *mockAPI) DeleteResource(ctx context.Context, cfType, id string) (*types.ProgressEvent, error) {
+func (m *mockAPI) DeleteResource(_ context.Context, _, _ string) (*types.ProgressEvent, error) {
 	panic("not implemented")
 }
 
 // GetResourceRequestStatus returns the current status of a resource operation request.
-func (m *mockAPI) GetResourceRequestStatus(ctx context.Context, requestToken string) (*types.ProgressEvent, error) {
+func (m *mockAPI) GetResourceRequestStatus(_ context.Context, _ string) (*types.ProgressEvent, error) {
 	panic("not implemented")
 }
 
 // GetResourceRequestStatusWithHooks returns the current status of a resource operation request with hook information.
-func (m *mockAPI) GetResourceRequestStatusWithHooks(ctx context.Context, requestToken string) (*types.ProgressEvent, []types.HookProgressEvent, error) {
+func (m *mockAPI) GetResourceRequestStatusWithHooks(
+	_ context.Context,
+	_ string,
+) (*types.ProgressEvent, []types.HookProgressEvent, error) {
 	panic("not implemented")
 }
 
-func (m *mockAPI) WaitForResourceOpCompletion(ctx context.Context, pi *types.ProgressEvent) (*types.ProgressEvent, error) {
+func (m *mockAPI) WaitForResourceOpCompletion(
+	ctx context.Context,
+	pi *types.ProgressEvent,
+) (*types.ProgressEvent, error) {
 	return m.WaitForResourceOpCompletionFunc(ctx, pi)
 }
 

--- a/provider/pkg/client/lambda.go
+++ b/provider/pkg/client/lambda.go
@@ -24,18 +24,22 @@ type LambdaClient interface {
 }
 
 type LambdaApi interface {
-	Invoke(ctx context.Context, params *lambda.InvokeInput, optFns ...func(*lambda.Options)) (*lambda.InvokeOutput, error)
+	Invoke(
+		ctx context.Context,
+		params *lambda.InvokeInput,
+		optFns ...func(*lambda.Options),
+	) (*lambda.InvokeOutput, error)
 	GetFunction(context.Context, *lambda.GetFunctionInput, ...func(*lambda.Options)) (*lambda.GetFunctionOutput, error)
 }
 
 type lambdaClientImpl struct {
-	api LambdaApi
+	api                       LambdaApi
 	functionActivationTimeout time.Duration
 }
 
 func NewLambdaClient(api LambdaApi) LambdaClient {
 	return &lambdaClientImpl{
-		api: api,
+		api:                       api,
 		functionActivationTimeout: DefaultFunctionActivationTimeout,
 	}
 }

--- a/provider/pkg/client/lambda_test.go
+++ b/provider/pkg/client/lambda_test.go
@@ -12,6 +12,8 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+const testFunctionName = "test-function"
+
 func lambdaSetup(t *testing.T) (*gomock.Controller, *lambdaClientImpl, *MockLambdaApi) {
 	ctrl := gomock.NewController(t)
 	mockLambdaApi := NewMockLambdaApi(ctrl)
@@ -28,7 +30,7 @@ func TestInvokeAsync_SuccessfulInvocation(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	functionName := "test-function"
+	functionName := testFunctionName
 	payload := []byte(`{"key": "value"}`)
 
 	mockLambdaApi.EXPECT().Invoke(ctx, gomock.Any()).Return(&lambda.InvokeOutput{
@@ -45,7 +47,7 @@ func TestInvokeAsync_FunctionNotReadyInitiallyButBecomesReady(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	functionName := "test-function"
+	functionName := testFunctionName
 	payload := []byte(`{"key": "value"}`)
 
 	mockLambdaApi.EXPECT().Invoke(ctx, gomock.Any()).Return(nil, &lambdaTypes.ResourceNotReadyException{})
@@ -79,7 +81,7 @@ func TestInvokeAsync_FunctionNotReadyAndFailsToBecomeReady(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	functionName := "test-function"
+	functionName := testFunctionName
 	payload := []byte(`{"key": "value"}`)
 
 	mockLambdaApi.EXPECT().Invoke(ctx, gomock.Any()).Return(nil, &lambdaTypes.ResourceNotReadyException{})
@@ -103,7 +105,7 @@ func TestInvokeAsync_InvocationFailsWithNon202StatusCode(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	functionName := "test-function"
+	functionName := testFunctionName
 	payload := []byte(`{"key": "value"}`)
 
 	mockLambdaApi.EXPECT().Invoke(ctx, gomock.Any()).Return(&lambda.InvokeOutput{
@@ -121,7 +123,7 @@ func TestInvokeAsync_FunctionNotReadyInitiallyButBecomesReadyAndThenFails(t *tes
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	functionName := "test-function"
+	functionName := testFunctionName
 	payload := []byte(`{"key": "value"}`)
 
 	mockLambdaApi.EXPECT().Invoke(ctx, gomock.Any()).Return(nil, &lambdaTypes.ResourceNotReadyException{})

--- a/provider/pkg/client/s3.go
+++ b/provider/pkg/client/s3.go
@@ -34,7 +34,11 @@ type S3Api interface {
 }
 
 type S3PresignApi interface {
-	PresignPutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.PresignOptions)) (*signerV4.PresignedHTTPRequest, error)
+	PresignPutObject(
+		ctx context.Context,
+		params *s3.PutObjectInput,
+		optFns ...func(*s3.PresignOptions),
+	) (*signerV4.PresignedHTTPRequest, error)
 }
 
 type s3ClientImpl struct {
@@ -49,7 +53,12 @@ func NewS3Client(api S3Api, presignApi S3PresignApi) S3Client {
 	}
 }
 
-func (c *s3ClientImpl) PresignPutObject(ctx context.Context, bucket string, key string, expiration time.Duration) (string, error) {
+func (c *s3ClientImpl) PresignPutObject(
+	ctx context.Context,
+	bucket string,
+	key string,
+	expiration time.Duration,
+) (string, error) {
 	request, err := c.presignApi.PresignPutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -62,7 +71,12 @@ func (c *s3ClientImpl) PresignPutObject(ctx context.Context, bucket string, key 
 	return request.URL, nil
 }
 
-func (c *s3ClientImpl) WaitForObject(ctx context.Context, bucket string, key string, timeout time.Duration) (io.ReadCloser, error) {
+func (c *s3ClientImpl) WaitForObject(
+	ctx context.Context,
+	bucket string,
+	key string,
+	timeout time.Duration,
+) (io.ReadCloser, error) {
 	err := s3.NewObjectExistsWaiter(c.api, func(o *s3.ObjectExistsWaiterOptions) {
 		// We already aggressively retry SDK errors with plenty retry attempts and
 		// throttling exceptions will be taken care of by the SDK
@@ -87,9 +101,8 @@ func (c *s3ClientImpl) WaitForObject(ctx context.Context, bucket string, key str
 		if errors.As(err, &noKey) {
 			// this could happen if the response object got deleted before we can read it
 			return nil, fmt.Errorf("object %q in bucket %q was deleted before it was retrieved", key, bucket)
-		} else {
-			return nil, errors.Wrapf(err, "failed to get object %q from bucket %q", key, bucket)
 		}
+		return nil, errors.Wrapf(err, "failed to get object %q from bucket %q", key, bucket)
 	}
 
 	return getResponse.Body, nil

--- a/provider/pkg/client/s3_test.go
+++ b/provider/pkg/client/s3_test.go
@@ -17,6 +17,11 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+const (
+	testBucketName = "test-bucket"
+	testObjectKey  = "test-key"
+)
+
 func TestPresignPutObject(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -27,8 +32,8 @@ func TestPresignPutObject(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	expiration := 15 * time.Minute
 	expectedURL := "https://example.com/presigned-url"
 
@@ -54,8 +59,8 @@ func TestPresignPutObject_Error(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	expiration := 15 * time.Minute
 	expectedError := errors.New("presign error")
 
@@ -85,8 +90,8 @@ func TestWaitForObject_Success(t *testing.T) {
 	ctrl, client, ctx := s3Setup(t)
 	defer ctrl.Finish()
 
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	timeout := 2 * time.Second
 	expectedBody := "test content"
 
@@ -117,8 +122,8 @@ func TestWaitForObject_Timeout(t *testing.T) {
 	ctrl, client, ctx := s3Setup(t)
 	defer ctrl.Finish()
 
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	timeout := 2 * time.Second
 
 	mockApi := client.api.(*MockS3Api)
@@ -138,8 +143,8 @@ func TestWaitForObject_Deleted(t *testing.T) {
 	ctrl, client, ctx := s3Setup(t)
 	defer ctrl.Finish()
 
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	timeout := 2 * time.Second
 	expectedError := &s3Types.NoSuchKey{}
 
@@ -165,8 +170,8 @@ func TestWaitForObject_GetObjectError(t *testing.T) {
 	ctrl, client, ctx := s3Setup(t)
 	defer ctrl.Finish()
 
-	bucket := "test-bucket"
-	key := "test-key"
+	bucket := testBucketName
+	key := testObjectKey
 	timeout := 2 * time.Second
 	expectedError := errors.New("get object error")
 

--- a/provider/pkg/default_tags/default_tags.go
+++ b/provider/pkg/default_tags/default_tags.go
@@ -21,16 +21,19 @@ const (
 	// TagsStyleKeyValueArrayCreateOnly is a style where the tags are represented as an array of key-value pairs, but
 	// the tags are create-only.
 	TagsStyleKeyValueArrayCreateOnly TagsStyle = tagStyleKeyValueArrayPrefix + "CreateOnly"
-	// TagsStyleKeyValueArrayWithExtraProperties is a style where the tags are represented as an array of key-value pairs
+	// TagsStyleKeyValueArrayWithExtraProperties is a style where the tags are represented as an array of key-value
+	// pairs
 	// but can have extra properties.
 	TagsStyleKeyValueArrayWithExtraProperties TagsStyle = tagStyleKeyValueArrayPrefix + "WithExtraProperties"
 	// TagsStyleKeyValueArrayWithAlternateType is a style where the tags are represented as an array of key-value pairs
 	// but the value can also be of a different type.
 	TagsStyleKeyValueArrayWithAlternateType TagsStyle = tagStyleKeyValueArrayPrefix + "WithAlternateType"
-	// TagsStyleKeyValueArrayUpperCase is a style where the tags are represented as an array of key-value pairs but the "Key" and "Value" properties are uppercase.
+	// TagsStyleKeyValueArrayUpperCase is a style where the tags are represented as an array of key-value pairs but the
+	// "Key" and "Value" properties are uppercase.
 	TagsStyleKeyValueArrayUpperCase TagsStyle = tagStyleKeyValueArrayPrefix + "UpperCase"
-	// TagsStyleObjectArrayWithResourceType is a style where the tags are represented as an array of objects with a "resourceType" property
-	// for example { tagSpecification: [ { resourceType: 'capacity-reservation' }, tags: [ { key: 'Key', value: 'Value' }]]}
+	// TagsStyleObjectArrayWithResourceType is a style where the tags are represented as an array of objects with a
+	// "resourceType" property for example { tagSpecification: [ { resourceType: 'capacity-reservation' }, tags: [ {
+	// key: 'Key', value: 'Value' }]]}
 	TagsStyleNestedKeyValueArrayWithResourceType TagsStyle = "nestedKeyValueArrayWithResourceType"
 )
 
@@ -43,5 +46,6 @@ func (ts TagsStyle) IsKeyValueArray() bool {
 }
 
 func (ts TagsStyle) IsValid() bool {
-	return ts == TagsStyleUnknown || ts == TagsStyleNone || ts == TagsStyleUntyped || ts.IsStringMap() || ts.IsKeyValueArray()
+	return ts == TagsStyleUnknown || ts == TagsStyleNone || ts == TagsStyleUntyped || ts.IsStringMap() ||
+		ts.IsKeyValueArray()
 }

--- a/provider/pkg/default_tags/merging.go
+++ b/provider/pkg/default_tags/merging.go
@@ -7,7 +7,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string, tagsStyle TagsStyle) (resource.PropertyValue, error) {
+func MergeDefaultTags(
+	tags resource.PropertyValue,
+	defaultTags map[string]string,
+	tagsStyle TagsStyle,
+) (resource.PropertyValue, error) {
 	if len(defaultTags) == 0 {
 		return tags, nil
 	}
@@ -20,7 +24,12 @@ func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string
 			return resource.NewPropertyValue(defaultTags), nil
 		}
 		if !tags.IsObject() {
-			return resource.NewObjectProperty(nil), fmt.Errorf("expected tags to be an object but found %v", tags.TypeString())
+			return resource.NewObjectProperty(
+					nil,
+				), fmt.Errorf(
+					"expected tags to be an object but found %v",
+					tags.TypeString(),
+				)
 		}
 		asObject := tags.ObjectValue()
 		for k, v := range defaultTags {
@@ -44,7 +53,12 @@ func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string
 		if tags.IsArray() {
 			asArray = tags.ArrayValue()
 		} else if !tags.IsNull() {
-			return resource.NewArrayProperty(nil), fmt.Errorf("expected tags to be an array but found %v", tags.TypeString())
+			return resource.NewArrayProperty(
+					nil,
+				), fmt.Errorf(
+					"expected tags to be an array but found %v",
+					tags.TypeString(),
+				)
 		}
 		existingKeys := make(map[string]bool)
 		for _, tag := range asArray {
@@ -53,7 +67,12 @@ func MergeDefaultTags(tags resource.PropertyValue, defaultTags map[string]string
 			}
 			asObject := tag.ObjectValue()
 			if !asObject.HasValue(keyProp) || !asObject.HasValue(valueProp) {
-				return tags, fmt.Errorf("expected tags to be an array of objects with '%s' and '%s' properties but found %v", keyProp, valueProp, tag.TypeString())
+				return tags, fmt.Errorf(
+					"expected tags to be an array of objects with '%s' and '%s' properties but found %v",
+					keyProp,
+					valueProp,
+					tag.TypeString(),
+				)
 			}
 			key := asObject[keyProp]
 			if key.IsString() {

--- a/provider/pkg/default_tags/merging_test.go
+++ b/provider/pkg/default_tags/merging_test.go
@@ -1,10 +1,12 @@
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package default_tags
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestDefaultTags(t *testing.T) {
@@ -24,9 +26,9 @@ func TestDefaultTags(t *testing.T) {
 
 	t.Run("string map empty resource tags", func(t *testing.T) {
 		tags := resource.NewPropertyValue(resource.NewObjectProperty(map[resource.PropertyKey]resource.PropertyValue{}))
-		expected := resource.PropertyValue(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+		expected := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 			"defaultTag": "defaultTagValue",
-		})))
+		}))
 		actual, err := MergeDefaultTags(tags, defaultTags, TagsStyleStringMap)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, actual)

--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -31,7 +31,8 @@ type CloudAPIResource struct {
 	// e.g.
 	// - ReadOnly: [
 	//     'arn', // top level
-	//     'someObjectProp/arn', // the arn value of someObjectProp is an output (but not the other properties of someObjectProp)
+	// 'someObjectProp/arn', // the arn value of someObjectProp is an output (but not the other properties of
+	// someObjectProp)
 	//     'someArrayProp/*/someObjectProp/arn'
 	//   ]
 	//
@@ -111,6 +112,8 @@ type ListHandlerProperty struct {
 
 // ExtensionResourceToken is a Pulumi token for the resource to deploy
 // custom third-party CloudFormation types.
+//
+//nolint:gosec // Pulumi resource token, not a credential.
 const ExtensionResourceToken = "aws-native:index:ExtensionResource"
 
 // CfnCustomResourceToken is a Pulumi token for the resource to deploy

--- a/provider/pkg/naming/convert.go
+++ b/provider/pkg/naming/convert.go
@@ -22,14 +22,23 @@ import (
 
 // SdkToCfn converts Pulumi-SDK-shaped state to CloudFormation-shaped payload. In particular, SDK properties
 // are lowerCamelCase, while CloudFormation is usually (but not always) PascalCase.
-func SdkToCfn(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, properties map[string]interface{}) (map[string]interface{}, error) {
+func SdkToCfn(
+	res *metadata.CloudAPIResource,
+	types map[string]metadata.CloudAPIType,
+	properties map[string]interface{},
+) (map[string]interface{}, error) {
 	converter := sdkToCfnConverter{res, types}
 	return converter.sdkToCfn(properties)
 }
 
-// DiffToPatch converts a Pulumi object diff to a CloudFormation-shaped patch operation slice. Update/add/delete operations are
+// DiffToPatch converts a Pulumi object diff to a CloudFormation-shaped patch operation slice. Update/add/delete
+// operations are
 // mapped to corresponding patch terms, and SDK properties are translated to respective CFN names.
-func DiffToPatch(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, diff *resource.ObjectDiff) ([]jsonpatch.JsonPatchOperation, error) {
+func DiffToPatch(
+	res *metadata.CloudAPIResource,
+	types map[string]metadata.CloudAPIType,
+	diff *resource.ObjectDiff,
+) ([]jsonpatch.JsonPatchOperation, error) {
 	if diff == nil {
 		return []jsonpatch.JsonPatchOperation{}, nil
 	}
@@ -45,7 +54,15 @@ var schemaStringReplacer = strings.NewReplacer(
 	// Paragraph separator
 	"\u2029", "\n")
 
-const schemaTypeObject = "object"
+const (
+	schemaTypeArray   = "array"
+	schemaTypeBoolean = "boolean"
+	schemaTypeInteger = "integer"
+	schemaTypeNumber  = "number"
+	schemaTypeObject  = "object"
+	schemaTypeString  = "string"
+	pulumiAnyTypeRef  = "pulumi.json#/Any"
+)
 
 // SanitizeCfnString ensures that a string from CFN docs meets the requirements for Pulumi schema strings.
 func SanitizeCfnString(str string) string {
@@ -184,7 +201,7 @@ func (c *cfnToSdkConverter) cfnTypedValueToSdk(spec *pschema.TypeSpec, v interfa
 	}
 
 	if spec.Ref != "" {
-		if spec.Ref == "pulumi.json#/Any" {
+		if spec.Ref == pulumiAnyTypeRef {
 			return v, nil
 		}
 
@@ -227,7 +244,7 @@ func (c *cfnToSdkConverter) cfnTypedValueToSdk(spec *pschema.TypeSpec, v interfa
 	}
 
 	switch spec.Type {
-	case "array":
+	case schemaTypeArray:
 		s := reflect.ValueOf(v)
 		if s.Kind() != reflect.Slice && s.Kind() != reflect.Array {
 			return v, nil
@@ -297,7 +314,7 @@ func largestConversionResult(results []any) any {
 
 func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interface{}) (interface{}, error) {
 	if spec.Ref != "" {
-		if spec.Ref == "pulumi.json#/Any" {
+		if spec.Ref == pulumiAnyTypeRef {
 			return v, nil
 		}
 
@@ -306,7 +323,7 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 		switch typSpec.Type {
 		case schemaTypeObject:
 			return c.sdkObjectValueToCfn(typName, typSpec, v)
-		case "string":
+		case schemaTypeString:
 			if _, ok := v.(string); ok {
 				return v, nil
 			}
@@ -346,7 +363,7 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 	}
 
 	switch spec.Type {
-	case "array":
+	case schemaTypeArray:
 		if array, ok := v.([]interface{}); ok {
 			vs := make([]interface{}, len(array))
 			for i, item := range array {
@@ -370,19 +387,19 @@ func (c *sdkToCfnConverter) sdkTypedValueToCfn(spec *pschema.TypeSpec, v interfa
 			}
 			return vs, nil
 		}
-	case "string":
+	case schemaTypeString:
 		if _, ok := v.(string); ok {
 			return v, nil
 		}
-	case "number":
+	case schemaTypeNumber:
 		if isNumberLike(v) {
 			return v, nil
 		}
-	case "integer":
+	case schemaTypeInteger:
 		if isNumberLike(v) {
 			return v, nil
 		}
-	case "boolean":
+	case schemaTypeBoolean:
 		if _, ok := v.(bool); ok {
 			return v, nil
 		}
@@ -400,7 +417,11 @@ func isNumberLike(v interface{}) bool {
 	return false
 }
 
-func (c *sdkToCfnConverter) sdkObjectValueToCfn(typeName string, spec metadata.CloudAPIType, value interface{}) (interface{}, error) {
+func (c *sdkToCfnConverter) sdkObjectValueToCfn(
+	typeName string,
+	spec metadata.CloudAPIType,
+	value interface{},
+) (interface{}, error) {
 	properties, ok := value.(map[string]interface{})
 	if !ok {
 		return nil, &ConversionError{typeName, value}
@@ -424,7 +445,7 @@ func (c *sdkToCfnConverter) diffToPatch(diff *resource.ObjectDiff) ([]jsonpatch.
 	// Sort keys to ensure deterministic ordering of patch operations.
 	sortedKeys := make([]string, 0, len(c.spec.Inputs))
 	for sdkName := range c.spec.Inputs {
-		sortedKeys = append(sortedKeys, string(sdkName))
+		sortedKeys = append(sortedKeys, sdkName)
 	}
 	slices.Sort(sortedKeys)
 	for _, sdkName := range sortedKeys {
@@ -463,12 +484,16 @@ func (c *sdkToCfnConverter) diffToPatch(diff *resource.ObjectDiff) ([]jsonpatch.
 	return ops, nil
 }
 
-func (c *sdkToCfnConverter) valueToPatch(opName, propName string, prop pschema.PropertySpec, value resource.PropertyValue) (*jsonpatch.JsonPatchOperation, error) {
+func (c *sdkToCfnConverter) valueToPatch(
+	opName, propName string,
+	prop pschema.PropertySpec,
+	value resource.PropertyValue,
+) (*jsonpatch.JsonPatchOperation, error) {
 	op := jsonpatch.NewPatch(opName, "/"+propName, nil)
 	switch {
 	case value.IsSecret():
 		return c.valueToPatch(opName, propName, prop, value.SecretValue().Element)
-	case value.IsNumber() && prop.Type == "integer":
+	case value.IsNumber() && prop.Type == schemaTypeInteger:
 		i := int32(value.NumberValue())
 		op.Value = i
 	case value.IsNumber():

--- a/provider/pkg/naming/convert_test.go
+++ b/provider/pkg/naming/convert_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package naming
 
 import (
@@ -67,7 +68,9 @@ func TestCfnToSdkV2(t *testing.T) {
 				map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "s3:GetObject"}}},
 			},
 			"NamedPolicies": map[string]interface{}{
-				"AdminPolicy": map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "*"}}},
+				"AdminPolicy": map[string]interface{}{
+					"Statement": []interface{}{map[string]interface{}{"Action": "*"}},
+				},
 			},
 			"UnknownObject": map[string]interface{}{"NestedKey": "value"},
 		}
@@ -86,7 +89,9 @@ func TestCfnToSdkV2(t *testing.T) {
 				map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "s3:GetObject"}}},
 			},
 			"namedPolicies": map[string]interface{}{
-				"AdminPolicy": map[string]interface{}{"Statement": []interface{}{map[string]interface{}{"Action": "*"}}},
+				"AdminPolicy": map[string]interface{}{
+					"Statement": []interface{}{map[string]interface{}{"Action": "*"}},
+				},
 			},
 			"unknownObject": map[string]interface{}{"nestedKey": "value"},
 		}, actual)
@@ -435,7 +440,9 @@ func TestDiffToPatch(t *testing.T) {
 				"loadBalancers": {
 					New: resource.NewArrayProperty([]resource.PropertyValue{
 						resource.NewObjectProperty(resource.PropertyMap{
-							resource.PropertyKey("targetGroupArn"): resource.MakeSecret(resource.NewStringProperty("arn:mytargetgroup")),
+							resource.PropertyKey("targetGroupArn"): resource.MakeSecret(
+								resource.NewStringProperty("arn:mytargetgroup"),
+							),
 						}),
 					}),
 				},

--- a/provider/pkg/naming/naming.go
+++ b/provider/pkg/naming/naming.go
@@ -75,7 +75,7 @@ func firstUppercaseAcronym(s string) (int, int) {
 	// - we're at the end of the string
 	// - the acronym is followed by a single lowercase 's' (eg. as in "ARNs")
 	// Note: we've defined uppercase to be ASCII [A-Z] so index math is safe here
-	if !(endIndex == len(s) || startsWithIsolatedLowercaseS(s[endIndex:])) {
+	if endIndex != len(s) && !startsWithIsolatedLowercaseS(s[endIndex:]) {
 		endIndex = endIndex - 1
 	}
 
@@ -106,9 +106,8 @@ func findFirstRunOfUppercase(s string, minLength int) (int, int) {
 				// Note: we've defined uppercase to be ASCII [0-9A-Z] so index math is safe here
 				if i-startIndex >= minLength {
 					return startIndex, i
-				} else {
-					startIndex = -1
 				}
+				startIndex = -1
 			}
 		}
 	}

--- a/provider/pkg/naming/naming_test.go
+++ b/provider/pkg/naming/naming_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package naming
 
 import (

--- a/provider/pkg/outputs/previewOutputs.go
+++ b/provider/pkg/outputs/previewOutputs.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package outputs
 
 import (
@@ -5,12 +6,13 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
-	rSchema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+	rSchema "github.com/pulumi/pulumi-aws-native/provider/pkg/schema"
 )
 
 // PreviewOutputs calculates the outputs of a resource based on the inputs and the output
@@ -124,8 +126,10 @@ func populateStableOutputs(
 // e.g. sometimes the arn property does not contain the full resource type name
 // - `aws-native:sagemaker:ModelExplainabilityJobDefinition` has a property `jobDefinitionArn`
 // - `aws-native:securityhub:PolicyAssociation` has a property `associationIdentifier`
-//   - TODO[pulumi/aws-native#1892]: in some cases this property is the `primaryIdentifier`. Could we use that as another heuristic?
-//     a readonly property that is also a primary identifier? It doesn't catch all cases, but would catch more
+// - TODO[pulumi/aws-native#1892]: in some cases this property is the `primaryIdentifier`. Could we use that as another
+// heuristic?
+//
+//	a readonly property that is also a primary identifier? It doesn't catch all cases, but would catch more
 func isStableOutput(propName string, resourceTypeName tokens.TypeName) bool {
 	typeName := naming.ToSdkName(resourceTypeName.String())
 	stableOutputsNameOnly := []string{

--- a/provider/pkg/outputs/previewOutputs_test.go
+++ b/provider/pkg/outputs/previewOutputs_test.go
@@ -1,12 +1,15 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package outputs
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func TestPreviewOutputs(t *testing.T) {
@@ -17,10 +20,10 @@ func TestPreviewOutputs(t *testing.T) {
 			}),
 			map[string]metadata.CloudAPIType{},
 			map[string]schema.PropertySpec{
-				"name": schema.PropertySpec{
+				"name": {
 					TypeSpec: schema.TypeSpec{Type: "string"},
 				},
-				"arn": schema.PropertySpec{
+				"arn": {
 					TypeSpec: schema.TypeSpec{Type: "string"},
 				},
 			},
@@ -46,10 +49,10 @@ func TestPreviewOutputs(t *testing.T) {
 			}),
 			map[string]metadata.CloudAPIType{},
 			map[string]schema.PropertySpec{
-				"name": schema.PropertySpec{
+				"name": {
 					TypeSpec: schema.TypeSpec{Type: "string"},
 				},
-				"arn": schema.PropertySpec{
+				"arn": {
 					TypeSpec: schema.TypeSpec{Type: "string"},
 				},
 			},
@@ -117,10 +120,12 @@ func Test_previewResourceOutputs(t *testing.T) {
 		)
 		assert.Equal(t, resource.PropertyMap{
 			"alias": resource.MakeComputed(resource.NewStringProperty("")),
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"allowedFeatures":          []string{"GetObject-Range"},
-				"cloudWatchMetricsEnabled": true,
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"allowedFeatures":          []string{"GetObject-Range"},
+					"cloudWatchMetricsEnabled": true,
+				}),
+			),
 		}, result)
 	})
 
@@ -159,10 +164,12 @@ func Test_previewResourceOutputs(t *testing.T) {
 			},
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"allowedFeatures":          []string{"GetObject-Range"},
-				"cloudWatchMetricsEnabled": resource.MakeComputed(resource.NewStringProperty("")),
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"allowedFeatures":          []string{"GetObject-Range"},
+					"cloudWatchMetricsEnabled": resource.MakeComputed(resource.NewStringProperty("")),
+				}),
+			),
 		}, result)
 	})
 
@@ -187,9 +194,11 @@ func Test_previewResourceOutputs(t *testing.T) {
 			[]string{},
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"allowedFeatures": "GetObject-Range",
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"allowedFeatures": "GetObject-Range",
+				}),
+			),
 		}, result)
 	})
 
@@ -367,7 +376,9 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 		)
 		assert.Equal(t, resource.PropertyMap{
 			"input": resource.NewStringProperty("value"),
-			"arn":   resource.NewStringProperty("arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/my-access-point"),
+			"arn": resource.NewStringProperty(
+				"arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/my-access-point",
+			),
 		}, result)
 	})
 
@@ -402,10 +413,12 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"alias": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 				"status": resource.MakeComputed(resource.NewStringProperty("")),
 			})),
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"allowedFeatures": []string{"GetObject-Range"},
-				"accessPointArn":  "arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/my-access-point",
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"allowedFeatures": []string{"GetObject-Range"},
+					"accessPointArn":  "arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint/my-access-point",
+				}),
+			),
 		}, result)
 	})
 
@@ -427,9 +440,11 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"arn": resource.MakeComputed(resource.NewStringProperty("")),
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"arn": resource.MakeComputed(resource.NewStringProperty("")),
+				}),
+			),
 		}, result)
 	})
 
@@ -451,9 +466,11 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"id": resource.MakeComputed(resource.NewStringProperty("")),
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"id": resource.MakeComputed(resource.NewStringProperty("")),
+				}),
+			),
 		}, result)
 	})
 
@@ -475,9 +492,11 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"accessPointId": "my-access-point",
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"accessPointId": "my-access-point",
+				}),
+			),
 		}, result)
 	})
 
@@ -499,9 +518,11 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"accessPointName": "my-access-point",
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"accessPointName": "my-access-point",
+				}),
+			),
 		}, result)
 	})
 
@@ -523,9 +544,11 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"name": resource.MakeComputed(resource.NewStringProperty("")),
-			})),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"name": resource.MakeComputed(resource.NewStringProperty("")),
+				}),
+			),
 		}, result)
 	})
 
@@ -573,14 +596,16 @@ func Test_updatePreviewWithOutputs(t *testing.T) {
 			"AccessPoint",
 		)
 		assert.Equal(t, resource.PropertyMap{
-			"objectLambdaConfiguration": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-				"arrayValue": []map[string]interface{}{
-					{
-						"allowedFeatures": []string{"GetObject-Range"},
-						"arn":             resource.MakeComputed(resource.NewStringProperty("")),
+			"objectLambdaConfiguration": resource.NewObjectProperty(
+				resource.NewPropertyMapFromMap(map[string]interface{}{
+					"arrayValue": []map[string]interface{}{
+						{
+							"allowedFeatures": []string{"GetObject-Range"},
+							"arn":             resource.MakeComputed(resource.NewStringProperty("")),
+						},
 					},
-				},
-			})),
+				}),
+			),
 		}, result)
 
 	})

--- a/provider/pkg/provider/list_sessions.go
+++ b/provider/pkg/provider/list_sessions.go
@@ -93,7 +93,10 @@ func (s *listSessionStore) get(
 		return nil, nil, status.Error(codes.FailedPrecondition, "continuation_token is already in use")
 	}
 	if session.resourceToken != resourceToken {
-		return nil, nil, status.Error(codes.InvalidArgument, "continuation_token was created for a different resource type")
+		return nil, nil, status.Error(
+			codes.InvalidArgument,
+			"continuation_token was created for a different resource type",
+		)
 	}
 	if session.queryHash != queryHash {
 		return nil, nil, status.Error(codes.InvalidArgument, "continuation_token was created for a different query")

--- a/provider/pkg/provider/partitions.go
+++ b/provider/pkg/provider/partitions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package provider
 
 import (
@@ -28,27 +29,27 @@ var partitions = []partition{
 	{
 		ID:          "aws",
 		URLSuffix:   "amazonaws.com",
-		RegionRegex: regexp.MustCompile("^(us|eu|ap|sa|ca|me|af)\\-\\w+\\-\\d+$"),
+		RegionRegex: regexp.MustCompile(`^(us|eu|ap|sa|ca|me|af)-\w+-\d+$`),
 	},
 	{
 		ID:          "aws-cn",
 		URLSuffix:   "amazonaws.com.cn",
-		RegionRegex: regexp.MustCompile("^cn\\-\\w+\\-\\d+$"),
+		RegionRegex: regexp.MustCompile(`^cn-\w+-\d+$`),
 	},
 	{
 		ID:          "aws-us-gov",
 		URLSuffix:   "amazonaws.com",
-		RegionRegex: regexp.MustCompile("^us\\-gov\\-\\w+\\-\\d+$"),
+		RegionRegex: regexp.MustCompile(`^us-gov-\w+-\d+$`),
 	},
 	{
 		ID:          "aws-iso",
 		URLSuffix:   "c2s.ic.gov",
-		RegionRegex: regexp.MustCompile("^us\\-iso\\-\\w+\\-\\d+$"),
+		RegionRegex: regexp.MustCompile(`^us-iso-\w+-\d+$`),
 	},
 	{
 		ID:          "aws-iso-b",
 		URLSuffix:   "sc2s.sgov.gov",
-		RegionRegex: regexp.MustCompile("^us\\-isob\\-\\w+\\-\\d+$"),
+		RegionRegex: regexp.MustCompile(`^us-isob-\w+-\d+$`),
 	},
 }
 

--- a/provider/pkg/provider/partitions_test.go
+++ b/provider/pkg/provider/partitions_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package provider
 
 import (

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint: gosec
+//nolint:gosec,goconst // Repeated domain vocabulary is clearer inline; credentials are handled by provider config.
 package provider
 
 import (
@@ -74,7 +74,7 @@ import (
 )
 
 // The APN 1.1 AWS Marketplace identifier to should be used in the User-Agent header.
-var PulumiAWSMarketplaceCode string = "c7qiae2l6usvzoynupds6v7hf"
+var PulumiAWSMarketplaceCode = "c7qiae2l6usvzoynupds6v7hf"
 
 type cancellationContext struct {
 	context context.Context
@@ -162,7 +162,7 @@ func LoadMetadata(metadataBytes []byte) (*metadata.CloudAPIMetadata, error) {
 	return &resourceMap, nil
 }
 
-func (p *cfnProvider) Attach(context context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
+func (p *cfnProvider) Attach(_ context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
 	host, err := provider.NewHostClient(req.GetAddress())
 	if err != nil {
 		return nil, err
@@ -171,7 +171,10 @@ func (p *cfnProvider) Attach(context context.Context, req *pulumirpc.PluginAttac
 	return &pbempty.Empty{}, nil
 }
 
-func (p *cfnProvider) GetSchema(ctx context.Context, req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
+func (p *cfnProvider) GetSchema(
+	_ context.Context,
+	req *pulumirpc.GetSchemaRequest,
+) (*pulumirpc.GetSchemaResponse, error) {
 	if v := req.GetVersion(); v != 0 {
 		return nil, fmt.Errorf("unsupported schema version %d", v)
 	}
@@ -184,7 +187,7 @@ func (p *cfnProvider) GetSchema(ctx context.Context, req *pulumirpc.GetSchemaReq
 }
 
 // CheckConfig validates the configuration for this provider.
-func (p *cfnProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
+func (p *cfnProvider) CheckConfig(_ context.Context, req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{
 		Label:        fmt.Sprintf("%s.CheckConfig.news", p.name),
 		KeepUnknowns: true,
@@ -211,28 +214,28 @@ func (p *cfnProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckReque
 		switch k {
 		case "ignoreTags":
 			failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-				Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/110")})
+				Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/110"})
 		case "insecure":
 			failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-				Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/111")})
+				Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/111"})
 		case "skipGetEc2Platforms":
 			if !truthyValue(k, news) {
 				failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-					Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/115")})
+					Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/115"})
 			}
 		case "skipMetadataApiCheck":
 			if !truthyValue(k, news) {
 				failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-					Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/116")})
+					Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/116"})
 			}
 		case "skipRegionValidation":
 			if !truthyValue(k, news) {
 				failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-					Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/117")})
+					Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/117"})
 			}
 		case "skipRequestingAccountId":
 			failures = append(failures, &pulumirpc.CheckFailure{Property: string(k),
-				Reason: fmt.Sprintf("not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/118")})
+				Reason: "not yet implemented. See https://github.com/pulumi/pulumi-aws-native/issues/118"})
 		}
 	}
 	if failures != nil {
@@ -243,7 +246,7 @@ func (p *cfnProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckReque
 }
 
 // DiffConfig diffs the configuration for this provider.
-func (p *cfnProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
+func (p *cfnProvider) DiffConfig(_ context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
 	urn := resource.URN(req.GetUrn())
 	label := fmt.Sprintf("%s.DiffConfig(%s)", p.name, urn)
 	glog.V(9).Infof("%s executing", label)
@@ -281,8 +284,11 @@ func (p *cfnProvider) DiffConfig(ctx context.Context, req *pulumirpc.DiffRequest
 }
 
 // Configure configures the resource provider with "globals" that control its behavior.
-func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	vars := req.GetVariables()
+func (p *cfnProvider) Configure(
+	ctx context.Context,
+	req *pulumirpc.ConfigureRequest,
+) (*pulumirpc.ConfigureResponse, error) {
+	vars := req.GetVariables() //nolint:staticcheck // ConfigureRequest variables remain the provider's config source.
 
 	// loadOptions are used to override default config loading behavior.
 	var loadOptions []func(*config.LoadOptions) error
@@ -294,6 +300,7 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 	} else {
 		return nil, errors.New("missing required configuration key \"aws-native:region\":" +
 			"The region where AWS operations will take place. Examples are eu-east-1, eu-west-2, etc.\n" +
+			//nolint:lll // Preserve the exact fixture or documentation text.
 			"\tSet a value using the command `pulumi config set aws-native:region <value>`, or by setting the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.")
 	}
 
@@ -304,7 +311,11 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 		glog.V(4).Infof(`using AWS profile: "default"`)
 	}
 
-	if sharedCredentialsFilePath, ok := varsOrEnv(vars, "aws-native:config:sharedCredentialsFile", "AWS_SHARED_CREDENTIALS_FILE"); ok {
+	if sharedCredentialsFilePath, ok := varsOrEnv(
+		vars,
+		"aws-native:config:sharedCredentialsFile",
+		"AWS_SHARED_CREDENTIALS_FILE",
+	); ok {
 		glog.V(4).Infof("using AWS shared credentials file at path: %q", sharedCredentialsFilePath)
 		normalizedPath, err := normalizeFilePath(sharedCredentialsFilePath)
 		if err != nil {
@@ -347,12 +358,17 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 			return nil, fmt.Errorf("failed to unmarshal 'endpoints' config: %w", err)
 		}
 		glog.V(4).Infof("using AWS endpoints: %v", endpoints)
-		resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-			if endpoint, ok := endpoints[strings.ToLower(service)]; ok {
-				return aws.Endpoint{URL: endpoint}, nil
-			}
-			return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-		})
+		// The provider supports a cross-service endpoint map, which the replacement service-specific API cannot model.
+		//nolint:staticcheck // Keep the deprecated global resolver until that configuration contract can be migrated.
+		resolver := aws.EndpointResolverWithOptionsFunc(
+			func(service, _ string, _ ...interface{}) (aws.Endpoint, error) {
+				if endpoint, ok := endpoints[strings.ToLower(service)]; ok {
+					return aws.Endpoint{URL: endpoint}, nil
+				}
+				return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+			},
+		)
+		//nolint:staticcheck // See resolver comment above; this preserves the cross-service endpoint contract.
 		loadOptions = append(loadOptions, config.WithEndpointResolverWithOptions(resolver))
 	}
 
@@ -479,7 +495,11 @@ func (p *cfnProvider) Configure(ctx context.Context, req *pulumirpc.ConfigureReq
 	}
 
 	skipCredentialsValidation := false
-	if skipCredentialsValidationVar, ok := varsOrEnv(vars, "aws-native:config:skipCredentialsValidation", "AWS_SKIP_CREDENTIALS_VALIDATION"); ok {
+	if skipCredentialsValidationVar, ok := varsOrEnv(
+		vars,
+		"aws-native:config:skipCredentialsValidation",
+		"AWS_SKIP_CREDENTIALS_VALIDATION",
+	); ok {
 		if skipCredentialsValidationVar == "true" {
 			skipCredentialsValidation = true
 		}
@@ -655,7 +675,7 @@ func (p *cfnProvider) Invoke(ctx context.Context,
 	return &pulumirpc.InvokeResponse{Return: res}, nil
 }
 
-func (p *cfnProvider) getInvokeFunc(ctx context.Context, tok string) (invokeFunc, bool) {
+func (p *cfnProvider) getInvokeFunc(_ context.Context, tok string) (invokeFunc, bool) {
 	cf, ok := p.resourceMap.Functions[tok]
 	if !ok {
 		return nil, false
@@ -823,7 +843,7 @@ func engineAutonaming(req *pulumirpc.CheckRequest) autonaming.EngineAutoNamingCo
 	return engineAutonaming
 }
 
-func (p *cfnProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
+func (p *cfnProvider) Diff(_ context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
 	urn := resource.URN(req.GetUrn())
 	label := fmt.Sprintf("%s.Diff(%s)", p.name, urn)
 	glog.V(9).Infof("%s executing", label)
@@ -907,12 +927,24 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 			if !hasSpec {
 				return nil, errors.Errorf("Resource type %s not found", resourceToken)
 			}
-			outputs = pOutputs.PreviewOutputs(inputs, p.resourceMap.Types, spec.Outputs, spec.ReadOnly, urn.Type().Name(), nil)
+			outputs = pOutputs.PreviewOutputs(
+				inputs,
+				p.resourceMap.Types,
+				spec.Outputs,
+				spec.ReadOnly,
+				urn.Type().Name(),
+				nil,
+			)
 		}
 
 		previewState, err := plugin.MarshalProperties(
 			outputs,
-			plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
+			plugin.MarshalOptions{
+				Label:        fmt.Sprintf("%s.checkpoint", label),
+				KeepSecrets:  true,
+				KeepUnknowns: true,
+				SkipNulls:    true,
+			},
 		)
 		if err != nil {
 			return nil, err
@@ -953,7 +985,8 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
 		}
-		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent from the inputs.
+		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent
+		// from the inputs.
 		if hasSpec && len(spec.WriteOnly) > 0 {
 			outputProps := resource.NewPropertyMapFromMap(rawOutputs)
 			classifier := resources.NewPathClassifier(&spec, p.resourceMap.Types)
@@ -987,7 +1020,12 @@ func (p *cfnProvider) Create(ctx context.Context, req *pulumirpc.CreateRequest) 
 	// Store both outputs and inputs into the state.
 	checkpoint, err := plugin.MarshalProperties(
 		outputs,
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
+		plugin.MarshalOptions{
+			Label:        fmt.Sprintf("%s.checkpoint", label),
+			KeepSecrets:  true,
+			KeepUnknowns: true,
+			SkipNulls:    true,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1075,7 +1113,12 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 	// Store both outputs and inputs into the state checkpoint.
 	checkpoint, err := plugin.MarshalProperties(
 		newState,
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
+		plugin.MarshalOptions{
+			Label:        fmt.Sprintf("%s.checkpoint", label),
+			KeepSecrets:  true,
+			KeepUnknowns: true,
+			SkipNulls:    true,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1084,7 +1127,13 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 	// Serialize and return the calculated inputs.
 	inputsRecord, err := plugin.MarshalProperties(
 		newInputs,
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.inputs", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true})
+		plugin.MarshalOptions{
+			Label:        fmt.Sprintf("%s.inputs", label),
+			KeepSecrets:  true,
+			KeepUnknowns: true,
+			SkipNulls:    true,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1135,12 +1184,24 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 				return nil, errors.Errorf("Resource type %s not found", resourceToken)
 			}
 			resourceTypeName := urn.Type().Name()
-			outputs = pOutputs.PreviewOutputs(newInputs, p.resourceMap.Types, spec.Outputs, spec.ReadOnly, resourceTypeName, &oldState)
+			outputs = pOutputs.PreviewOutputs(
+				newInputs,
+				p.resourceMap.Types,
+				spec.Outputs,
+				spec.ReadOnly,
+				resourceTypeName,
+				&oldState,
+			)
 		}
 
 		previewState, err := plugin.MarshalProperties(
 			outputs,
-			plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
+			plugin.MarshalOptions{
+				Label:        fmt.Sprintf("%s.checkpoint", label),
+				KeepSecrets:  true,
+				KeepUnknowns: true,
+				SkipNulls:    true,
+			},
 		)
 		if err != nil {
 			return nil, err
@@ -1178,7 +1239,8 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 			return nil, fmt.Errorf("failed to convert value for %s: %w", resourceToken, err)
 		}
 
-		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent from the inputs.
+		// Write-only properties are not returned in the outputs, so we assume they should have the same value we sent
+		// from the inputs.
 		if len(spec.WriteOnly) > 0 {
 			outputProps := resource.NewPropertyMapFromMap(rawOutputs)
 			classifier.AddWriteOnlyOutputFallbacks(outputProps, newInputs)
@@ -1189,7 +1251,12 @@ func (p *cfnProvider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) 
 	// Store both outputs and inputs into the state and return RPC checkpoint.
 	checkpoint, err := plugin.MarshalProperties(
 		outputs,
-		plugin.MarshalOptions{Label: fmt.Sprintf("%s.checkpoint", label), KeepSecrets: true, KeepUnknowns: true, SkipNulls: true},
+		plugin.MarshalOptions{
+			Label:        fmt.Sprintf("%s.checkpoint", label),
+			KeepSecrets:  true,
+			KeepUnknowns: true,
+			SkipNulls:    true,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1220,6 +1287,9 @@ func (p *cfnProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) 
 		state, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{
 			Label: fmt.Sprintf("%s.state", label), KeepUnknowns: true, SkipNulls: true, KeepSecrets: true,
 		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse state for delete")
+		}
 
 		timeout := time.Duration(req.GetTimeout()) * time.Second
 		err = customResource.Delete(ctx, urn, id, oldInputs, state, timeout)
@@ -1531,7 +1601,10 @@ func effectiveCloudControlListMaxResults(pageSize, limit int64) *int32 {
 }
 
 // Construct creates a new component resource.
-func (p *cfnProvider) Construct(_ context.Context, _ *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
+func (p *cfnProvider) Construct(
+	_ context.Context,
+	_ *pulumirpc.ConstructRequest,
+) (*pulumirpc.ConstructResponse, error) {
 	panic("Construct not implemented")
 }
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -56,11 +56,11 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi-go-provider/resourcex"
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
+	sdkprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
@@ -92,7 +92,7 @@ func makeCancellationContext() *cancellationContext {
 type cfnProvider struct {
 	pulumirpc.UnimplementedResourceProviderServer
 
-	host     *provider.HostClient
+	host     *sdkprovider.HostClient
 	name     string
 	canceler *cancellationContext
 
@@ -126,7 +126,7 @@ type cfnProvider struct {
 
 var _ pulumirpc.ResourceProviderServer = (*cfnProvider)(nil)
 
-func NewAwsNativeProvider(host *provider.HostClient, name, version string,
+func NewAwsNativeProvider(host *sdkprovider.HostClient, name, version string,
 	pulumiSchema, cloudAPIResourcesBytes []byte) (pulumirpc.ResourceProviderServer, error) {
 	resourceMap, err := LoadMetadata(cloudAPIResourcesBytes)
 	if err != nil {
@@ -163,7 +163,7 @@ func LoadMetadata(metadataBytes []byte) (*metadata.CloudAPIMetadata, error) {
 }
 
 func (p *cfnProvider) Attach(_ context.Context, req *pulumirpc.PluginAttach) (*emptypb.Empty, error) {
-	host, err := provider.NewHostClient(req.GetAddress())
+	host, err := sdkprovider.NewHostClient(req.GetAddress())
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/provider_2e2_test.go
+++ b/provider/pkg/provider/provider_2e2_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package provider_test
 
 import (
@@ -12,20 +13,23 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	grpcmetadata "google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/pulumi/providertest"
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/assertpreview"
 	"github.com/pulumi/providertest/pulumitest/opttest"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	grpcmetadata "google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
 )
 
 func TestE2eSnapshots(t *testing.T) {
@@ -53,7 +57,8 @@ func TestAutonaming(t *testing.T) {
 	fifoQueueName, ok := up.Outputs["fifoQueueName"].Value.(string)
 	assert.True(t, ok)
 
-	// Check that the queue name matches pattern: ${name}-${alphanum(6)}.fifo (.fifo is the resource's autonaming trivia suffix)
+	// Check that the queue name matches pattern: ${name}-${alphanum(6)}.fifo (.fifo is the resource's autonaming trivia
+	// suffix)
 	assert.Regexp(t, `^queue-[a-zA-Z0-9]{6}\.fifo$`, fifoQueueName)
 }
 
@@ -64,7 +69,7 @@ func TestThrottling(t *testing.T) {
 	skipIfShort(t)
 
 	// Pick a slightly random name so as to not conflict with concurrent CI runs.
-	name := fmt.Sprintf("throttling-queue-%d", rand.Intn(1000))
+	name := fmt.Sprintf("throttling-queue-%d", rand.Intn(1000)) //nolint:gosec // Test resource uniqueness only.
 	test := newAwsTest(t, filepath.Join("testdata", "throttling"))
 	test.SetConfig(t, "queueName", name)
 	_ = test.Up(t)
@@ -95,6 +100,7 @@ func TestListLogStreamsLive(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	//nolint:gosec // The request contains a resource type token, not a credential.
 	listedIDs, err := listAllForTest(t, server, &pulumirpc.ListRequest{
 		Token:    "aws-native:logs:LogStream",
 		Query:    listQueryForTest(t, resource.PropertyMap{"logGroupName": resource.NewStringProperty(logGroupName)}),
@@ -244,7 +250,7 @@ func TestRdsLowercaseTransforms(t *testing.T) {
 	skipIfShort(t)
 
 	// Use a random suffix to avoid naming conflicts
-	clusterSuffix := fmt.Sprintf("%d", rand.Intn(10000))
+	clusterSuffix := fmt.Sprintf("%d", rand.Intn(10000)) //nolint:gosec // Test resource uniqueness only.
 
 	pt := pulumitest.NewPulumiTest(t, filepath.Join("testdata", "rds-lowercase-transforms"),
 		opttest.Env("PULUMI_DEBUG_GRPC", "true"),
@@ -329,9 +335,12 @@ func newAwsTest(t *testing.T, source string, opts ...opttest.Option) *pulumitest
 }
 
 func attachProvider() opttest.Option {
-	return opttest.AttachProviderServer("aws-native", func(pt providers.PulumiTest) (pulumirpc.ResourceProviderServer, error) {
-		return testProviderServer()
-	})
+	return opttest.AttachProviderServer(
+		"aws-native",
+		func(_ providers.PulumiTest) (pulumirpc.ResourceProviderServer, error) {
+			return testProviderServer()
+		},
+	)
 }
 
 func testProviderServer() (pulumirpc.ResourceProviderServer, error) {
@@ -400,10 +409,10 @@ func listAllForTest(
 	var ids []string
 	continuation := ""
 	for {
-		pageReq := *req
+		pageReq := proto.Clone(req).(*pulumirpc.ListRequest)
 		pageReq.ContinuationToken = continuation
 		stream := &listLiveTestStream{}
-		if err := server.List(&pageReq, stream); err != nil {
+		if err := server.List(pageReq, stream); err != nil {
 			return nil, err
 		}
 

--- a/provider/pkg/provider/provider_endpoints_test.go
+++ b/provider/pkg/provider/provider_endpoints_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package provider_test
 
 import (
@@ -5,12 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
 
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/provider"
 )
 
 func TestProviderEndpoints(t *testing.T) {
@@ -29,9 +32,9 @@ func TestProviderEndpoints(t *testing.T) {
 	t.Run("preview calls sts caller identity", func(t *testing.T) {
 		t.Parallel()
 		stsRequestCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			stsRequestCount++
-			w.Write([]byte(stsGetCallerIdentityResponse))
+			_, _ = w.Write([]byte(stsGetCallerIdentityResponse))
 		}))
 		t.Cleanup(server.Close)
 
@@ -60,14 +63,13 @@ func TestProviderEndpoints(t *testing.T) {
 		}, invokeResponse.Return.AsMap())
 	})
 
-
 	t.Run("configure calls set the APN/1.1 marketplace identifier in the User-Agent header", func(t *testing.T) {
 		t.Parallel()
 		requestCount := 0
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "APN/1.1 ("+provider.PulumiAWSMarketplaceCode+")", r.Header.Get("User-Agent"))
 			requestCount++
-			w.Write([]byte(stsGetCallerIdentityResponse))
+			_, _ = w.Write([]byte(stsGetCallerIdentityResponse))
 		}))
 		t.Cleanup(server.Close)
 
@@ -91,9 +93,9 @@ func TestProviderEndpoints(t *testing.T) {
 	t.Run("skipping credentials doesn't break getAccountId", func(t *testing.T) {
 		t.Parallel()
 		stsRequestCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			stsRequestCount++
-			w.Write([]byte(stsGetCallerIdentityResponse))
+			_, _ = w.Write([]byte(stsGetCallerIdentityResponse))
 		}))
 		t.Cleanup(server.Close)
 
@@ -128,10 +130,10 @@ func TestProviderEndpoints(t *testing.T) {
 		t.Parallel()
 
 		reqCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			reqCount++
 			if reqCount == 1 {
-				w.Write([]byte(`
+				_, _ = w.Write([]byte(`
 			{
 				"ProgressEvent": {
 					"Identifier": "CloudApiLogGroup",
@@ -145,7 +147,7 @@ func TestProviderEndpoints(t *testing.T) {
 				return
 			}
 			if reqCount == 2 {
-				w.Write([]byte(`
+				_, _ = w.Write([]byte(`
 			{
 				"ProgressEvent": {
 					"Identifier": "CloudApiLogGroup",
@@ -158,7 +160,7 @@ func TestProviderEndpoints(t *testing.T) {
 			}`))
 				return
 			}
-			w.Write([]byte(`
+			_, _ = w.Write([]byte(`
 			{
 				"ResourceDescription": {
 					"Identifier": "CloudApiLogGroup",

--- a/provider/pkg/provider/provider_intrinsics.go
+++ b/provider/pkg/provider/provider_intrinsics.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package provider
 
 import (
@@ -12,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -46,7 +48,8 @@ func (p *cfnProvider) getAZs(ctx context.Context, inputs resource.PropertyMap) (
 // https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html
 // ipBlock: The user-specified CIDR block to be split into smaller CIDR blocks.
 // count: The number of CIDR blocks to generate. Valid range is between 1 and 256.
-// cidrBits: The number of subnet bits for the CIDR. For example, specifying a value "8" for this parameter will create a CIDR with a mask of "/24".
+// cidrBits: The number of subnet bits for the CIDR. For example, specifying a value "8" for this parameter will create
+// a CIDR with a mask of "/24".
 //
 //	Note: Subnet bits is the inverse of subnet mask. To calculate the required host bits
 //	for a given subnet bits, subtract the subnet bits from 32 for ipv4 or 128 for ipv6.
@@ -93,6 +96,7 @@ func cidr(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 
 	if subnetBits > bits {
 		return nil, fmt.Errorf("cidrBits %d is more than %d bits for an %s address. \n"+
+			//nolint:lll // Preserve the exact fixture or documentation text.
 			"cidrBits is the inverse of subnet mask, e.g. cidrBits=5 would create a subnet mask of '/27'", subnetBits, bits, protocol)
 	}
 
@@ -101,12 +105,20 @@ func cidr(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	current, ok := gocidr.PreviousSubnet(network, prefixLen)
 	// ok is true if we have rolled over (which we don't want)
 	if ok {
-		return nil, fmt.Errorf("not enough remaining address space for a subnet with a prefix of %d bits after %s", len(subnets), current.String())
+		return nil, fmt.Errorf(
+			"not enough remaining address space for a subnet with a prefix of %d bits after %s",
+			len(subnets),
+			current.String(),
+		)
 	}
 	for i := 0; i < len(subnets); i++ {
 		subnet, ok := gocidr.NextSubnet(current, prefixLen)
 		if ok || !network.Contains(subnet.IP) {
-			return nil, fmt.Errorf("not enough remaining address space for a subnet with a prefix of %d bits after %s", len(subnets), current.String())
+			return nil, fmt.Errorf(
+				"not enough remaining address space for a subnet with a prefix of %d bits after %s",
+				len(subnets),
+				current.String(),
+			)
 		}
 		current = subnet
 		subnets[i] = resource.NewStringProperty(subnet.String())
@@ -117,7 +129,7 @@ func cidr(inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	}, nil
 }
 
-func (p *cfnProvider) cidr(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) cidr(_ context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
 	return cidr(inputs)
 }
 

--- a/provider/pkg/provider/provider_intrinsics_test.go
+++ b/provider/pkg/provider/provider_intrinsics_test.go
@@ -1,10 +1,12 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package provider
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func Test_cidr(t *testing.T) {

--- a/provider/pkg/provider/provider_pseudo_parameters.go
+++ b/provider/pkg/provider/provider_pseudo_parameters.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package provider
 
 import (
@@ -7,10 +8,11 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
-func (p *cfnProvider) getAccountID(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getAccountID(ctx context.Context, _ resource.PropertyMap) (resource.PropertyMap, error) {
 	if p.accountID == "" {
 		callerIdentityResp, err := p.sts.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 		if err != nil {
@@ -23,19 +25,19 @@ func (p *cfnProvider) getAccountID(ctx context.Context, inputs resource.Property
 	}), nil
 }
 
-func (p *cfnProvider) getURLSuffix(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getURLSuffix(_ context.Context, _ resource.PropertyMap) (resource.PropertyMap, error) {
 	return resource.NewPropertyMapFromMap(map[string]interface{}{
 		"urlSuffix": p.partition.URLSuffix,
 	}), nil
 }
 
-func (p *cfnProvider) getRegion(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getRegion(_ context.Context, _ resource.PropertyMap) (resource.PropertyMap, error) {
 	return resource.NewPropertyMapFromMap(map[string]interface{}{
 		"region": p.region,
 	}), nil
 }
 
-func (p *cfnProvider) getPartition(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getPartition(_ context.Context, _ resource.PropertyMap) (resource.PropertyMap, error) {
 	return resource.NewPropertyMapFromMap(map[string]interface{}{
 		"partition": p.partition.ID,
 		"dnsSuffix": p.partition.URLSuffix,

--- a/provider/pkg/provider/provider_ssm.go
+++ b/provider/pkg/provider/provider_ssm.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package provider
 
 import (
@@ -10,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
@@ -31,7 +33,10 @@ func (p *cfnProvider) getSSMParameter(ctx context.Context, inputs resource.Prope
 	return out.Parameter, nil
 }
 
-func (p *cfnProvider) getSSMParameterString(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getSSMParameterString(
+	ctx context.Context,
+	inputs resource.PropertyMap,
+) (resource.PropertyMap, error) {
 	param, err := p.getSSMParameter(ctx, inputs)
 	if err != nil {
 		return nil, err
@@ -44,7 +49,10 @@ func (p *cfnProvider) getSSMParameterString(ctx context.Context, inputs resource
 	}, nil
 }
 
-func (p *cfnProvider) getSSMParameterList(ctx context.Context, inputs resource.PropertyMap) (resource.PropertyMap, error) {
+func (p *cfnProvider) getSSMParameterList(
+	ctx context.Context,
+	inputs resource.PropertyMap,
+) (resource.PropertyMap, error) {
 	param, err := p.getSSMParameter(ctx, inputs)
 	if err != nil {
 		return nil, err

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package provider
 
 import (
@@ -37,7 +38,13 @@ type listTestStream struct {
 	responses    []*pulumirpc.ListResponse
 }
 
-const testBucketA = "bucket-a"
+const (
+	testBucketA = "bucket-a"
+
+	// Resource type tokens, not credentials.
+	classicAWSBucketToken          = "aws:s3/bucket:Bucket"          //nolint:gosec
+	classicAWSMissingResourceToken = "aws:missing/resource:Resource" //nolint:gosec
+)
 
 func (s *listTestStream) Send(response *pulumirpc.ListResponse) error {
 	if s.sendErr != nil && (s.sendErrAfter == 0 || len(s.responses) >= s.sendErrAfter) {
@@ -133,7 +140,7 @@ func TestListRejectsNonListableResource(t *testing.T) {
 
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType: "AWS::S3::Bucket",
 			},
 		}},
@@ -141,7 +148,7 @@ func TestListRejectsNonListableResource(t *testing.T) {
 		ccc:             client.NewMockCloudControlClient(ctrl),
 	}
 
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listTestStream{})
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, &listTestStream{})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support List")
@@ -157,7 +164,7 @@ func TestListRejectsUnknownResource(t *testing.T) {
 		ccc:             client.NewMockCloudControlClient(ctrl),
 	}
 
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:missing/resource:Resource"}, &listTestStream{})
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSMissingResourceToken}, &listTestStream{})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -227,7 +234,7 @@ func TestListRejectsQueryWhenListInputsAreEmpty(t *testing.T) {
 
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:            "AWS::S3::Bucket",
 				HasListHandler:    true,
 				ListHandlerSchema: &metadata.ListHandlerSchema{},
@@ -238,7 +245,7 @@ func TestListRejectsQueryWhenListInputsAreEmpty(t *testing.T) {
 	}
 
 	err := provider.List(&pulumirpc.ListRequest{
-		Token: "aws:s3/bucket:Bucket",
+		Token: classicAWSBucketToken,
 		Query: listQueryStruct(t, resource.PropertyMap{
 			"name": resource.NewStringProperty(testBucketA),
 		}),
@@ -321,7 +328,7 @@ func TestListEmptyQueryAndContinuationUsesProviderToken(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -352,7 +359,7 @@ func TestListEmptyQueryAndContinuationUsesProviderToken(t *testing.T) {
 
 	stream := &listTestStream{}
 	err := provider.List(&pulumirpc.ListRequest{
-		Token:    "aws:s3/bucket:Bucket",
+		Token:    classicAWSBucketToken,
 		PageSize: 75,
 		Limit:    50,
 	}, stream)
@@ -367,7 +374,7 @@ func TestListEmptyQueryAndContinuationUsesProviderToken(t *testing.T) {
 
 	continuationStream := &listTestStream{}
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		PageSize:          75,
 		Limit:             50,
 		ContinuationToken: providerContinuation,
@@ -385,7 +392,7 @@ func TestListStoresInitializedSessionBeforeSendingContinuation(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -416,7 +423,7 @@ func TestListStoresInitializedSessionBeforeSendingContinuation(t *testing.T) {
 		},
 	}
 
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, stream)
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, stream)
 
 	require.NoError(t, err)
 	require.Len(t, stream.responses, 2)
@@ -444,7 +451,7 @@ func TestListMaxResults(t *testing.T) {
 			mockCCC := client.NewMockCloudControlClient(ctrl)
 			provider := &cfnProvider{
 				resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-					"aws:s3/bucket:Bucket": {
+					classicAWSBucketToken: {
 						CfType:         "AWS::S3::Bucket",
 						HasListHandler: true,
 					},
@@ -458,7 +465,7 @@ func TestListMaxResults(t *testing.T) {
 				Return(nil, nil, nil)
 
 			err := provider.List(&pulumirpc.ListRequest{
-				Token:    "aws:s3/bucket:Bucket",
+				Token:    classicAWSBucketToken,
 				PageSize: tt.pageSize,
 				Limit:    tt.limit,
 			}, &listTestStream{})
@@ -514,7 +521,7 @@ func TestListContinuationStopsAtLimit(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -545,7 +552,7 @@ func TestListContinuationStopsAtLimit(t *testing.T) {
 
 	stream := &listTestStream{}
 	err := provider.List(&pulumirpc.ListRequest{
-		Token:    "aws:s3/bucket:Bucket",
+		Token:    classicAWSBucketToken,
 		PageSize: 20,
 		Limit:    5,
 	}, stream)
@@ -557,7 +564,7 @@ func TestListContinuationStopsAtLimit(t *testing.T) {
 
 	continuationStream := &listTestStream{}
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		PageSize:          20,
 		Limit:             5,
 		ContinuationToken: providerContinuation,
@@ -568,7 +575,7 @@ func TestListContinuationStopsAtLimit(t *testing.T) {
 	assert.Equal(t, "bucket-5", continuationStream.responses[0].GetResult().GetId())
 
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		PageSize:          20,
 		Limit:             5,
 		ContinuationToken: providerContinuation,
@@ -584,7 +591,7 @@ func TestListRejectsInvalidContinuation(t *testing.T) {
 
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -594,7 +601,7 @@ func TestListRejectsInvalidContinuation(t *testing.T) {
 	}
 
 	err := provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		ContinuationToken: "missing",
 	}, &listTestStream{})
 
@@ -612,7 +619,7 @@ func TestListRejectsExpiredAndInUseContinuation(t *testing.T) {
 			name: "expired",
 			session: &listSession{
 				cloudControlNextToken: "next",
-				resourceToken:         "aws:s3/bucket:Bucket",
+				resourceToken:         classicAWSBucketToken,
 				lastAccess:            time.Now().Add(-2 * defaultListSessionTTL),
 			},
 			wantError: "invalid or expired continuation_token",
@@ -621,7 +628,7 @@ func TestListRejectsExpiredAndInUseContinuation(t *testing.T) {
 			name: "in use",
 			session: &listSession{
 				cloudControlNextToken: "next",
-				resourceToken:         "aws:s3/bucket:Bucket",
+				resourceToken:         classicAWSBucketToken,
 				lastAccess:            time.Now(),
 				inUse:                 true,
 			},
@@ -636,7 +643,7 @@ func TestListRejectsExpiredAndInUseContinuation(t *testing.T) {
 
 			provider := &cfnProvider{
 				resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-					"aws:s3/bucket:Bucket": {
+					classicAWSBucketToken: {
 						CfType:         "AWS::S3::Bucket",
 						HasListHandler: true,
 					},
@@ -648,7 +655,7 @@ func TestListRejectsExpiredAndInUseContinuation(t *testing.T) {
 			provider.listSessions.sessions["provider-token"] = tt.session
 
 			err := provider.List(&pulumirpc.ListRequest{
-				Token:             "aws:s3/bucket:Bucket",
+				Token:             classicAWSBucketToken,
 				ContinuationToken: "provider-token",
 			}, &listTestStream{})
 
@@ -668,6 +675,7 @@ func TestListRejectsContinuationRequestChanges(t *testing.T) {
 	}{
 		{
 			name: "changed token",
+			//nolint:gosec // The request contains a resource type token, not a credential.
 			req: &pulumirpc.ListRequest{
 				Token:             "aws:logs/logGroup:LogGroup",
 				Limit:             5,
@@ -675,7 +683,7 @@ func TestListRejectsContinuationRequestChanges(t *testing.T) {
 			},
 			session: &listSession{
 				cloudControlNextToken: "next",
-				resourceToken:         "aws:s3/bucket:Bucket",
+				resourceToken:         classicAWSBucketToken,
 				limit:                 5,
 			},
 			wantError: "different resource type",
@@ -683,13 +691,13 @@ func TestListRejectsContinuationRequestChanges(t *testing.T) {
 		{
 			name: "changed limit",
 			req: &pulumirpc.ListRequest{
-				Token:             "aws:s3/bucket:Bucket",
+				Token:             classicAWSBucketToken,
 				Limit:             6,
 				ContinuationToken: "provider-token",
 			},
 			session: &listSession{
 				cloudControlNextToken: "next",
-				resourceToken:         "aws:s3/bucket:Bucket",
+				resourceToken:         classicAWSBucketToken,
 				limit:                 5,
 			},
 			wantError: "different limit",
@@ -727,7 +735,7 @@ func TestListRejectsContinuationRequestChanges(t *testing.T) {
 			defer ctrl.Finish()
 
 			resourcesByToken := map[string]metadata.CloudAPIResource{
-				"aws:s3/bucket:Bucket": {
+				classicAWSBucketToken: {
 					CfType:         "AWS::S3::Bucket",
 					HasListHandler: true,
 				},
@@ -763,7 +771,7 @@ func TestListBuffersWhenCloudControlReturnsMoreThanRequested(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -780,7 +788,7 @@ func TestListBuffersWhenCloudControlReturnsMoreThanRequested(t *testing.T) {
 
 	stream := &listTestStream{}
 	err := provider.List(&pulumirpc.ListRequest{
-		Token:    "aws:s3/bucket:Bucket",
+		Token:    classicAWSBucketToken,
 		PageSize: 1,
 	}, stream)
 
@@ -792,7 +800,7 @@ func TestListBuffersWhenCloudControlReturnsMoreThanRequested(t *testing.T) {
 
 	continuationStream := &listTestStream{}
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		PageSize:          1,
 		ContinuationToken: providerContinuation,
 	}, continuationStream)
@@ -809,7 +817,7 @@ func TestListWrapsCloudControlErrorsWithTokenContext(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -823,10 +831,10 @@ func TestListWrapsCloudControlErrorsWithTokenContext(t *testing.T) {
 		List(gomock.Any(), "AWS::S3::Bucket", client.ListRequest{}).
 		Return(nil, nil, expectedErr)
 
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listTestStream{})
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, &listTestStream{})
 
 	require.ErrorIs(t, err, expectedErr)
-	assert.Contains(t, err.Error(), "aws:s3/bucket:Bucket")
+	assert.Contains(t, err.Error(), classicAWSBucketToken)
 	assert.Contains(t, err.Error(), "AWS::S3::Bucket")
 }
 
@@ -839,7 +847,7 @@ func TestListPropagatesProviderCancellation(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -868,7 +876,7 @@ func TestListPropagatesProviderCancellation(t *testing.T) {
 			return nil, nil, ctx.Err()
 		})
 
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listTestStream{})
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, &listTestStream{})
 
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -880,7 +888,7 @@ func TestListReturnsStreamSendError(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -895,7 +903,7 @@ func TestListReturnsStreamSendError(t *testing.T) {
 		Return([]string{id}, nil, nil)
 
 	sendErr := errors.New("send failed")
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listTestStream{sendErr: sendErr})
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, &listTestStream{sendErr: sendErr})
 
 	require.ErrorIs(t, err, sendErr)
 }
@@ -907,7 +915,7 @@ func TestListContinuationSendErrorKeepsOldTokenUsable(t *testing.T) {
 	mockCCC := client.NewMockCloudControlClient(ctrl)
 	provider := &cfnProvider{
 		resourceMap: &metadata.CloudAPIMetadata{Resources: map[string]metadata.CloudAPIResource{
-			"aws:s3/bucket:Bucket": {
+			classicAWSBucketToken: {
 				CfType:         "AWS::S3::Bucket",
 				HasListHandler: true,
 			},
@@ -944,7 +952,7 @@ func TestListContinuationSendErrorKeepsOldTokenUsable(t *testing.T) {
 	)
 
 	stream := &listTestStream{}
-	err := provider.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, stream)
+	err := provider.List(&pulumirpc.ListRequest{Token: classicAWSBucketToken}, stream)
 
 	require.NoError(t, err)
 	require.Len(t, stream.responses, 2)
@@ -952,7 +960,7 @@ func TestListContinuationSendErrorKeepsOldTokenUsable(t *testing.T) {
 
 	sendErr := errors.New("send failed")
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		ContinuationToken: providerContinuation,
 	}, &listTestStream{sendErr: sendErr, sendErrAfter: 1})
 
@@ -960,7 +968,7 @@ func TestListContinuationSendErrorKeepsOldTokenUsable(t *testing.T) {
 
 	retryStream := &listTestStream{}
 	err = provider.List(&pulumirpc.ListRequest{
-		Token:             "aws:s3/bucket:Bucket",
+		Token:             classicAWSBucketToken,
 		ContinuationToken: providerContinuation,
 	}, retryStream)
 
@@ -1329,10 +1337,13 @@ func TestCreatePreview(t *testing.T) {
 
 	t.Run("Outputs are computed", func(t *testing.T) {
 		req := &pulumirpc.CreateRequest{
-			Urn:        string(urn),
-			Preview:    true,
-			Properties: mustMarshalProperties(t, resource.PropertyMap{"bucketName": resource.NewStringProperty("name")}),
-			Timeout:    float64((5 * time.Minute).Seconds()),
+			Urn:     string(urn),
+			Preview: true,
+			Properties: mustMarshalProperties(
+				t,
+				resource.PropertyMap{"bucketName": resource.NewStringProperty("name")},
+			),
+			Timeout: float64((5 * time.Minute).Seconds()),
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws-native:s3:Bucket", "name"))
 
@@ -1349,10 +1360,13 @@ func TestCreatePreview(t *testing.T) {
 
 	t.Run("Outputs are computed for custom resource", func(t *testing.T) {
 		req := &pulumirpc.CreateRequest{
-			Urn:        string(urn),
-			Preview:    true,
-			Properties: mustMarshalProperties(t, resource.PropertyMap{"bucketName": resource.NewStringProperty("name")}),
-			Timeout:    float64((5 * time.Minute).Seconds()),
+			Urn:     string(urn),
+			Preview: true,
+			Properties: mustMarshalProperties(
+				t,
+				resource.PropertyMap{"bucketName": resource.NewStringProperty("name")},
+			),
+			Timeout: float64((5 * time.Minute).Seconds()),
 		}
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "custom:resource", "name"))
 
@@ -1497,10 +1511,10 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("StandardResource", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			stringPtr("bucket-id"), map[string]interface{}{"foo": "bar"}, nil,
@@ -1579,10 +1593,10 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("StandardResource/Error", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
 			nil, nil, assert.AnError,
@@ -1594,10 +1608,10 @@ func TestCreate(t *testing.T) {
 	})
 
 	t.Run("PartialError", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 		req.Properties = mustMarshalProperties(t, resource.PropertyMap{"my": resource.NewStringProperty("input value")})
 
 		mockCCC.EXPECT().Create(ctx, gomock.Any(), "AWS::S3::Bucket", gomock.Any()).Return(
@@ -1698,14 +1712,14 @@ func TestRead(t *testing.T) {
 
 	// In the import case there is no `__inputs` field in the old state.
 	t.Run("StandardResource/Import", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName":        {TypeSpec: schema.TypeSpec{Type: "string"}},
 				"objectLockEnabled": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Read(ctx, "AWS::S3::Bucket", "resource-id").Return(
 			map[string]interface{}{
@@ -1780,10 +1794,10 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("StandardResource/Error", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Read(ctx, "AWS::S3::Bucket", "resource-id").Return(
 			nil, false, assert.AnError,
@@ -1795,14 +1809,14 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("StandardResource/NoDiff", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName":        {TypeSpec: schema.TypeSpec{Type: "string"}},
 				"objectLockEnabled": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		inputs := resource.PropertyMap{
 			"bucketName":        resource.NewStringProperty("my-bucket"),
@@ -1839,14 +1853,14 @@ func TestRead(t *testing.T) {
 	})
 
 	t.Run("StandardResource/Diff", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName":        {TypeSpec: schema.TypeSpec{Type: "string"}},
 				"objectLockEnabled": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		inputs := resource.PropertyMap{
 			"bucketName":        resource.NewStringProperty("my-bucket"),
@@ -1917,9 +1931,11 @@ func TestUpdate(t *testing.T) {
 	}
 
 	t.Run("CustomResource", func(t *testing.T) {
-		mockCustomResource.EXPECT().Update(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any(), 5*time.Minute).Return(
-			resource.PropertyMap{"foo": resource.NewStringProperty("bar")}, nil,
-		)
+		mockCustomResource.EXPECT().
+			Update(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any(), 5*time.Minute).
+			Return(
+				resource.PropertyMap{"foo": resource.NewStringProperty("bar")}, nil,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		assert.NoError(t, err)
@@ -1930,9 +1946,11 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("CustomResource/Error", func(t *testing.T) {
-		mockCustomResource.EXPECT().Update(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any(), 5*time.Minute).Return(
-			nil, assert.AnError,
-		)
+		mockCustomResource.EXPECT().
+			Update(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any(), 5*time.Minute).
+			Return(
+				nil, assert.AnError,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		assert.Error(t, err)
@@ -1940,14 +1958,14 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("StandardResource", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName":        {TypeSpec: schema.TypeSpec{Type: "string"}},
 				"objectLockEnabled": {TypeSpec: schema.TypeSpec{Type: "boolean"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		inputs := resource.PropertyMap{
 			"bucketName":        resource.NewStringProperty("new-bucket"),
@@ -1965,16 +1983,18 @@ func TestUpdate(t *testing.T) {
 			"__inputs":          resource.MakeSecret(resource.NewObjectProperty(oldInputs)),
 		})
 
-		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
-			{Operation: "replace", Path: "/BucketName", Value: "new-bucket"},
-			{Operation: "replace", Path: "/ObjectLockEnabled", Value: false},
-		})).Return(
-			map[string]interface{}{
-				// Change the bucket name and object lock status according to the inputs
-				"bucketName":        resource.NewStringProperty("new-bucket"),
-				"objectLockEnabled": resource.NewBoolProperty(false),
-			}, nil,
-		)
+		mockCCC.EXPECT().
+			Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/BucketName", Value: "new-bucket"},
+				{Operation: "replace", Path: "/ObjectLockEnabled", Value: false},
+			})).
+			Return(
+				map[string]interface{}{
+					// Change the bucket name and object lock status according to the inputs
+					"bucketName":        resource.NewStringProperty("new-bucket"),
+					"objectLockEnabled": resource.NewBoolProperty(false),
+				}, nil,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		assert.NoError(t, err)
@@ -2053,7 +2073,7 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("StandardResource/ActualBaselineRepairDrift", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName": {TypeSpec: schema.TypeSpec{Type: "string"}},
@@ -2062,7 +2082,7 @@ func TestUpdate(t *testing.T) {
 				"bucketName": {TypeSpec: schema.TypeSpec{Type: "string"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 		req.News = mustMarshalProperties(t, resource.PropertyMap{
 			"bucketName": resource.NewStringProperty("desired-bucket"),
 		})
@@ -2073,13 +2093,15 @@ func TestUpdate(t *testing.T) {
 			})),
 		})
 
-		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
-			{Operation: "replace", Path: "/BucketName", Value: "desired-bucket"},
-		})).Return(
-			map[string]interface{}{
-				"bucketName": "desired-bucket",
-			}, nil,
-		)
+		mockCCC.EXPECT().
+			Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/BucketName", Value: "desired-bucket"},
+			})).
+			Return(
+				map[string]interface{}{
+					"bucketName": "desired-bucket",
+				}, nil,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		require.NoError(t, err)
@@ -2112,14 +2134,16 @@ func TestUpdate(t *testing.T) {
 			})),
 		})
 
-		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::RDS::DBInstance", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
-			{Operation: "replace", Path: "/Engine", Value: "mysql"},
-			{Operation: "add", Path: "/Password", Value: "secret"},
-		})).Return(
-			map[string]interface{}{
-				"engine": "mysql",
-			}, nil,
-		)
+		mockCCC.EXPECT().
+			Update(ctx, gomock.Any(), "AWS::RDS::DBInstance", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Engine", Value: "mysql"},
+				{Operation: "add", Path: "/Password", Value: "secret"},
+			})).
+			Return(
+				map[string]interface{}{
+					"engine": "mysql",
+				}, nil,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		require.NoError(t, err)
@@ -2154,13 +2178,15 @@ func TestUpdate(t *testing.T) {
 			})),
 		})
 
-		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::RDS::DBInstance", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
-			{Operation: "replace", Path: "/Engine", Value: "mysql"},
-		})).Return(
-			map[string]interface{}{
-				"engine": "mysql",
-			}, nil,
-		)
+		mockCCC.EXPECT().
+			Update(ctx, gomock.Any(), "AWS::RDS::DBInstance", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/Engine", Value: "mysql"},
+			})).
+			Return(
+				map[string]interface{}{
+					"engine": "mysql",
+				}, nil,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		require.NoError(t, err)
@@ -2170,26 +2196,32 @@ func TestUpdate(t *testing.T) {
 	})
 
 	t.Run("StandardResource/Error", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 			Inputs: map[string]schema.PropertySpec{
 				"bucketName": {TypeSpec: schema.TypeSpec{Type: "string"}},
 			},
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 		req.News = mustMarshalProperties(t, resource.PropertyMap{
 			"bucketName": resource.NewStringProperty("new-bucket"),
 		})
 		req.Olds = mustMarshalProperties(t, resource.PropertyMap{
 			"bucketName": resource.NewStringProperty("old-bucket"),
-			"__inputs":   resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{"bucketName": resource.NewStringProperty("old-bucket")})),
+			"__inputs": resource.MakeSecret(
+				resource.NewObjectProperty(
+					resource.PropertyMap{"bucketName": resource.NewStringProperty("old-bucket")},
+				),
+			),
 		})
 
-		mockCCC.EXPECT().Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
-			{Operation: "replace", Path: "/BucketName", Value: "new-bucket"},
-		})).Return(
-			nil, assert.AnError,
-		)
+		mockCCC.EXPECT().
+			Update(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id", jsonPatchEquals([]jsonpatch.JsonPatchOperation{
+				{Operation: "replace", Path: "/BucketName", Value: "new-bucket"},
+			})).
+			Return(
+				nil, assert.AnError,
+			)
 
 		resp, err := provider.Update(ctx, req)
 		assert.Error(t, err)
@@ -2468,9 +2500,11 @@ func TestStandardResourceDiffUsesActualOutputBaseline(t *testing.T) {
 				"Version": resource.NewStringProperty("2012-10-17"),
 				"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"Effect":    resource.NewStringProperty("Allow"),
-						"Principal": resource.NewObjectProperty(resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")}),
-						"Action":    resource.NewStringProperty("sts:AssumeRole"),
+						"Effect": resource.NewStringProperty("Allow"),
+						"Principal": resource.NewObjectProperty(
+							resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")},
+						),
+						"Action": resource.NewStringProperty("sts:AssumeRole"),
 					}),
 				}),
 			}),
@@ -2481,8 +2515,10 @@ func TestStandardResourceDiffUsesActualOutputBaseline(t *testing.T) {
 						"Version": resource.NewStringProperty("2012-10-17"),
 						"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 							resource.NewObjectProperty(resource.PropertyMap{
-								"Effect":   resource.NewStringProperty("Allow"),
-								"Action":   resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("*")}),
+								"Effect": resource.NewStringProperty("Allow"),
+								"Action": resource.NewArrayProperty(
+									[]resource.PropertyValue{resource.NewStringProperty("*")},
+								),
 								"Resource": resource.NewStringProperty("*"),
 							}),
 						}),
@@ -2997,24 +3033,28 @@ func TestDelete(t *testing.T) {
 	}
 
 	t.Run("CustomResource", func(t *testing.T) {
-		mockCustomResource.EXPECT().Delete(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockCustomResource.EXPECT().
+			Delete(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil)
 
 		_, err := provider.Delete(ctx, req)
 		assert.NoError(t, err)
 	})
 
 	t.Run("CustomResource/Error", func(t *testing.T) {
-		mockCustomResource.EXPECT().Delete(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any()).Return(assert.AnError)
+		mockCustomResource.EXPECT().
+			Delete(ctx, urn, "resource-id", gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(assert.AnError)
 
 		_, err := provider.Delete(ctx, req)
 		assert.Error(t, err)
 	})
 
 	t.Run("StandardResource", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Delete(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id").Return(nil)
 
@@ -3023,10 +3063,10 @@ func TestDelete(t *testing.T) {
 	})
 
 	t.Run("StandardResource/Error", func(t *testing.T) {
-		provider.resourceMap.Resources["aws:s3/bucket:Bucket"] = metadata.CloudAPIResource{
+		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",
 		}
-		req.Urn = string(resource.NewURN("stack", "project", "parent", "aws:s3/bucket:Bucket", "name"))
+		req.Urn = string(resource.NewURN("stack", "project", "parent", classicAWSBucketToken, "name"))
 
 		mockCCC.EXPECT().Delete(ctx, gomock.Any(), "AWS::S3::Bucket", "resource-id").Return(assert.AnError)
 

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -3050,6 +3050,21 @@ func TestDelete(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("CustomResource/MalformedState", func(t *testing.T) {
+		malformedState, err := structpb.NewStruct(map[string]interface{}{
+			"secret": map[string]interface{}{string(resource.SigKey): resource.SecretSig},
+		})
+		require.NoError(t, err)
+
+		_, err = provider.Delete(ctx, &pulumirpc.DeleteRequest{
+			Urn:        string(urn),
+			Id:         "resource-id",
+			Properties: malformedState,
+		})
+		require.ErrorContains(t, err, "failed to parse state for delete")
+		require.ErrorContains(t, err, "malformed RPC secret")
+	})
+
 	t.Run("StandardResource", func(t *testing.T) {
 		provider.resourceMap.Resources[classicAWSBucketToken] = metadata.CloudAPIResource{
 			CfType: "AWS::S3::Bucket",

--- a/provider/pkg/provider/serve.go
+++ b/provider/pkg/provider/serve.go
@@ -15,15 +15,15 @@
 package provider
 
 import (
-	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	sdkprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
 // Serve launches the gRPC server for the native Pulumi AWS resource provider.
 func Serve(version string, pulumiSchema, metadataBytes []byte) {
 	// Start gRPC service.
-	err := provider.Main("aws-native", func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
+	err := sdkprovider.Main("aws-native", func(host *sdkprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 		return NewAwsNativeProvider(host, "aws-native", version, pulumiSchema, metadataBytes)
 	})
 

--- a/provider/pkg/provider/types.go
+++ b/provider/pkg/provider/types.go
@@ -18,6 +18,8 @@ package provider
 // having the provider depend on the SDK.
 
 // The configuration for a Provider to assume a role.
+//
+//nolint:revive // The name must match the corresponding public SDK type.
 type ProviderAssumeRole struct {
 	// Number of seconds to restrict the assume role session duration.
 	DurationSeconds *int `json:"durationSeconds"`
@@ -33,6 +35,7 @@ type ProviderAssumeRole struct {
 	SessionName *string `json:"sessionName"`
 	// Map of assume role session tags.
 	Tags map[string]string `json:"tags"`
-	// A list of keys for session tags that you want to set as transitive. If you set a tag key as transitive, the corresponding key and value passes to subsequent sessions in a role chain.
+	// A list of keys for session tags that you want to set as transitive. If you set a tag key as transitive,
+	// the corresponding key and value passes to subsequent sessions in a role chain.
 	TransitiveTagKeys []string `json:"transitiveTagKeys"`
 }

--- a/provider/pkg/refdb/refdb.go
+++ b/provider/pkg/refdb/refdb.go
@@ -22,11 +22,15 @@ type RefDB struct {
 }
 
 // See [RefDB].
+//
+//nolint:revive // The explicit prefix distinguishes persisted RefDB records from resource metadata.
 type RefDBResource struct {
 	RefReturns RefDBRecord `json:"refReturns"`
 }
 
 // See [RefDB].
+//
+//nolint:revive // The explicit prefix distinguishes persisted RefDB records from resource metadata.
 type RefDBRecord struct {
 	metadata.CfRefBehavior
 

--- a/provider/pkg/resources/cfn_custom_resource.go
+++ b/provider/pkg/resources/cfn_custom_resource.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package resources
 
 import (
@@ -10,19 +11,23 @@ import (
 	"github.com/aws/aws-lambda-go/cfn"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+
 	"github.com/pulumi/pulumi-go-provider/resourcex"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 )
 
 // This is the default timeout for custom resource operations in CloudFormation
 const DefaultCustomResourceTimeout = 60 * time.Minute
 
-var lambdaFunctionArnRegex = regexp.MustCompile(`^arn:[^:]+:lambda:[^:]+:[^:]+:function:[a-zA-Z0-9-_]+(:[a-zA-Z0-9-_]+)?$`)
+var lambdaFunctionArnRegex = regexp.MustCompile(
+	`^arn:[^:]+:lambda:[^:]+:[^:]+:function:[a-zA-Z0-9-_]+(:[a-zA-Z0-9-_]+)?$`,
+)
 
 type Clock interface {
 	Now() time.Time
@@ -95,7 +100,13 @@ var _ CustomResource = (*cfnCustomResource)(nil)
 //	                              └─────►│    S3    │◄──────┘
 //	                           Poll for  │  Bucket  │ Response
 //	                           Response  └──────────┘
-func NewCfnCustomResource(providerName string, s3Client client.S3Client, lambdaClient client.LambdaClient) *cfnCustomResource {
+//
+//nolint:revive // The concrete return type is used by package tests and internal configuration.
+func NewCfnCustomResource(
+	providerName string,
+	s3Client client.S3Client,
+	lambdaClient client.LambdaClient,
+) *cfnCustomResource {
 	return &cfnCustomResource{
 		providerName: providerName,
 		s3Client:     s3Client,
@@ -115,7 +126,8 @@ type CfnCustomResourceInputs struct {
 	CustomResourceProperties map[string]interface{}
 	// The CloudFormation type of the custom resource (e.g. "Custom::MyCustomResource")
 	ResourceType string
-	// A stand-in value for the CloudFormation stack ID required by the custom resource. If not provided, the project ID is used.
+	// A stand-in value for the CloudFormation stack ID required by the custom resource. If not provided, the project ID
+	// is used.
 	StackID *string
 }
 
@@ -146,6 +158,7 @@ func CfnCustomResourceSpec(description string) pschema.ResourceSpec {
 			Description: description,
 			Properties: map[string]pschema.PropertySpec{
 				"physicalResourceId": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The name or unique identifier that corresponds to the `PhysicalResourceId` included in the Custom Resource response. If no `PhysicalResourceId` is provided in the response, a random ID will be generated.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
@@ -163,6 +176,7 @@ func CfnCustomResourceSpec(description string) pschema.ResourceSpec {
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"serviceToken": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The service token, such as a Lambda function ARN, that is invoked when the resource is created, updated, or deleted.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
@@ -175,15 +189,25 @@ func CfnCustomResourceSpec(description string) pschema.ResourceSpec {
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"noEcho": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Whether the response data contains sensitive information that should be marked as secret and not logged.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 			},
-			Required: []string{"physicalResourceId", "data", "stackId", "serviceToken", "bucket", "resourceType", "noEcho"},
+			Required: []string{
+				"physicalResourceId",
+				"data",
+				"stackId",
+				"serviceToken",
+				"bucket",
+				"resourceType",
+				"noEcho",
+			},
 		},
 		InputProperties: map[string]pschema.PropertySpec{
 			"bucketName": {
 				Description: "The name of the S3 bucket to use for storing the response from the Custom Resource.\n\n" +
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"The IAM principal configured for the provider must have `s3:PutObject`, `s3:HeadObject` and `s3:GetObject` permissions on this bucket.",
 				TypeSpec: pschema.TypeSpec{Type: "string"},
 			},
@@ -192,12 +216,15 @@ func CfnCustomResourceSpec(description string) pschema.ResourceSpec {
 				TypeSpec:    pschema.TypeSpec{Type: "string"},
 			},
 			"serviceToken": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "The service token to use for the Custom Resource. The service token is invoked when the resource is created, updated, or deleted.\n" +
 					"This can be a Lambda Function ARN with optional version or alias identifiers.\n\n" +
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"The IAM principal configured for the provider must have `lambda:InvokeFunction` permissions on this service token.",
 				TypeSpec: pschema.TypeSpec{Type: "string"},
 			},
 			"customResourceProperties": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "The properties to pass as an input to the Custom Resource.\nThe properties are passed as a map of key-value pairs whereas all " +
 					"primitive values (number, boolean) are converted to strings for CloudFormation interoperability.",
 				TypeSpec: pschema.TypeSpec{
@@ -213,12 +240,19 @@ func CfnCustomResourceSpec(description string) pschema.ResourceSpec {
 				TypeSpec: pschema.TypeSpec{Type: "string"},
 			},
 			"stackId": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "A stand-in value for the CloudFormation stack ID. This is required for CloudFormation interoperability.\n" +
 					"If not provided, the Pulumi Stack ID is used.",
 				TypeSpec: pschema.TypeSpec{Type: "string"},
 			},
 		},
-		RequiredInputs: []string{"bucketName", "bucketKeyPrefix", "serviceToken", "customResourceProperties", "resourceType"},
+		RequiredInputs: []string{
+			"bucketName",
+			"bucketKeyPrefix",
+			"serviceToken",
+			"customResourceProperties",
+			"resourceType",
+		},
 	}
 }
 
@@ -233,7 +267,14 @@ type customResourceInvokeData struct {
 
 // Check validates the inputs of the resource and applies default values if necessary.
 // It returns the inputs, validation failures, and an error if the inputs cannot be unmarshalled.
-func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming.EngineAutoNamingConfig, inputs resource.PropertyMap, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
+func (c *cfnCustomResource) Check(
+	_ context.Context,
+	urn urn.URN,
+	_ autonaming.EngineAutoNamingConfig,
+	inputs resource.PropertyMap,
+	_ resource.PropertyMap,
+	_ map[string]string,
+) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -243,7 +284,8 @@ func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming
 	var failures []ValidationFailure
 
 	serviceTokenInput, hasServiceToken := inputs[resource.PropertyKey("serviceToken")]
-	if (!hasServiceToken || !serviceTokenInput.ContainsUnknowns()) && !lambdaFunctionArnRegex.MatchString(typedInputs.ServiceToken) {
+	if (!hasServiceToken || !serviceTokenInput.ContainsUnknowns()) &&
+		!lambdaFunctionArnRegex.MatchString(typedInputs.ServiceToken) {
 		failures = append(failures, ValidationFailure{
 			Path:   "serviceToken",
 			Reason: "serviceToken must be a valid Lambda function ARN.",
@@ -291,7 +333,12 @@ func (c *cfnCustomResource) Check(ctx context.Context, urn urn.URN, _ autonaming
 //   - On success: Returns PhysicalResourceId and properties
 //   - On failure: Returns error with reason
 //   - Handles `NoEcho` for sensitive data
-func (c *cfnCustomResource) Create(ctx context.Context, urn urn.URN, inputs resource.PropertyMap, timeout time.Duration) (*string, resource.PropertyMap, error) {
+func (c *cfnCustomResource) Create(
+	ctx context.Context,
+	urn urn.URN,
+	inputs resource.PropertyMap,
+	timeout time.Duration,
+) (*string, resource.PropertyMap, error) {
 	var typedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -332,7 +379,8 @@ func (c *cfnCustomResource) Create(ctx context.Context, urn urn.URN, inputs reso
 		// this could happen if parts of the custom resource creation succeeded but the overall operation failed
 		if response.PhysicalResourceID != "" {
 			partialID = &response.PhysicalResourceID
-			glog.V(9).Infof("%s custom resource creation partially succeeded, physical resource ID: %s", label, *partialID)
+			glog.V(9).
+				Infof("%s custom resource creation partially succeeded, physical resource ID: %s", label, *partialID)
 		}
 
 		return partialID, outputs, fmt.Errorf("failed to create custom resource: %s", response.Reason)
@@ -369,7 +417,13 @@ func (c *cfnCustomResource) Create(ctx context.Context, urn urn.URN, inputs reso
 // 4. Handles response:
 //   - Success: Completes deletion
 //   - Failure: Returns error with reason from Lambda
-func (c *cfnCustomResource) Delete(ctx context.Context, urn urn.URN, id string, inputs, state resource.PropertyMap, timeout time.Duration) error {
+func (c *cfnCustomResource) Delete(
+	ctx context.Context,
+	urn urn.URN,
+	_ string,
+	inputs, state resource.PropertyMap,
+	timeout time.Duration,
+) error {
 	var typedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -415,7 +469,8 @@ func (c *cfnCustomResource) Delete(ctx context.Context, urn urn.URN, id string, 
 	return nil
 }
 
-// Update updates the custom resource with the given inputs and state by invoking the Lambda function with the UPDATE request type.
+// Update updates the custom resource with the given inputs and state by invoking the Lambda function with the UPDATE
+// request type.
 // If the update is successful and the physical resource ID has changed,
 // it deletes the old resource. The function returns the updated resource properties or an error.
 //
@@ -460,7 +515,13 @@ func (c *cfnCustomResource) Delete(ctx context.Context, urn urn.URN, id string, 
 //   - Sends DELETE event for old PhysicalResourceId
 //
 // 5. Returns updated properties and new PhysicalResourceId
-func (c *cfnCustomResource) Update(ctx context.Context, urn urn.URN, id string, inputs, oldInputs, state resource.PropertyMap, timeout time.Duration) (resource.PropertyMap, error) {
+func (c *cfnCustomResource) Update(
+	ctx context.Context,
+	urn urn.URN,
+	_ string,
+	inputs, oldInputs, state resource.PropertyMap,
+	timeout time.Duration,
+) (resource.PropertyMap, error) {
 	var oldTypedInputs CfnCustomResourceInputs
 	_, err := resourcex.Unmarshal(&oldTypedInputs, oldInputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -516,7 +577,9 @@ func (c *cfnCustomResource) Update(ctx context.Context, urn urn.URN, id string, 
 
 	// if the physical resource ID has changed, we need to delete the old resource
 	if response.PhysicalResourceID != typedState.PhysicalResourceID {
-		glog.V(9).Infof("%s physical resource ID changed from %q to %q, deleting old resource", label, typedState.PhysicalResourceID, response.PhysicalResourceID)
+		glog.V(9).
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			Infof("%s physical resource ID changed from %q to %q, deleting old resource", label, typedState.PhysicalResourceID, response.PhysicalResourceID)
 
 		deleteEvent := cfn.Event{
 			PhysicalResourceID: typedState.PhysicalResourceID,
@@ -532,9 +595,14 @@ func (c *cfnCustomResource) Update(ctx context.Context, urn urn.URN, id string, 
 		// otherwise we allow it to take the default timeout
 		if timeout != 0 {
 			deleteTimeout = timeout - updateDuration
-			glog.V(9).Infof("%s custom resource update took %s, clean up of the old resource is allowed to take %s", label, updateDuration, deleteTimeout)
+			glog.V(9).
+				//nolint:lll // Preserve the exact fixture or documentation text.
+				Infof("%s custom resource update took %s, clean up of the old resource is allowed to take %s", label, updateDuration, deleteTimeout)
 			if deleteTimeout <= 0 {
-				return nil, fmt.Errorf("failed to clean up old custom resource: not enough time left to delete the old resource. Consider increasing the timeout")
+				return nil, fmt.Errorf(
+					//nolint:lll // Preserve the exact fixture or documentation text.
+					"failed to clean up old custom resource: not enough time left to delete the old resource. Consider increasing the timeout",
+				)
 			}
 		}
 
@@ -551,7 +619,11 @@ func (c *cfnCustomResource) Update(ctx context.Context, urn urn.URN, id string, 
 			return nil, fmt.Errorf("failed to clean up old custom resource: %w", err)
 		}
 		if deleteResponse.Status == cfn.StatusFailed {
-			return nil, fmt.Errorf("failed to clean up old custom resource %q: %s", typedState.PhysicalResourceID, deleteResponse.Reason)
+			return nil, fmt.Errorf(
+				"failed to clean up old custom resource %q: %s",
+				typedState.PhysicalResourceID,
+				deleteResponse.Reason,
+			)
 		}
 		glog.V(9).Infof("%s old custom resource %q successfully cleaned up", label, typedState.PhysicalResourceID)
 	}
@@ -562,7 +634,13 @@ func (c *cfnCustomResource) Update(ctx context.Context, urn urn.URN, id string, 
 
 // Read returns the current inputs and outputs of the custom resource because CFN custom resources do not store state.
 // They are just a stateless wrapper around a Lambda function or SNS topic.
-func (c *cfnCustomResource) Read(ctx context.Context, urn urn.URN, id string, oldInputs resource.PropertyMap, oldState resource.PropertyMap) (resource.PropertyMap, resource.PropertyMap, bool, error) {
+func (c *cfnCustomResource) Read(
+	_ context.Context,
+	_ urn.URN,
+	_ string,
+	oldInputs resource.PropertyMap,
+	oldState resource.PropertyMap,
+) (resource.PropertyMap, resource.PropertyMap, bool, error) {
 	// Assuming that Read without old state is an import operation
 	if len(oldState) == 0 {
 		// We can't support import because CustomResources do not store any state
@@ -572,7 +650,10 @@ func (c *cfnCustomResource) Read(ctx context.Context, urn urn.URN, id string, ol
 	return oldState, oldInputs, true, nil
 }
 
-func (c *cfnCustomResource) invokeCustomResource(ctx context.Context, invokeData customResourceInvokeData) (*cfn.Response, error) {
+func (c *cfnCustomResource) invokeCustomResource(
+	ctx context.Context,
+	invokeData customResourceInvokeData,
+) (*cfn.Response, error) {
 	timeout := invokeData.timeout
 	if timeout == 0 {
 		timeout = DefaultCustomResourceTimeout
@@ -586,7 +667,8 @@ func (c *cfnCustomResource) invokeCustomResource(ctx context.Context, invokeData
 		// presigning is not an API call, it should not fail unless there's issues with the SDK or crypto libs
 		return nil, fmt.Errorf("failed to generate response URL: %w", err)
 	}
-	glog.V(9).Infof("%s created presigned response URL for s3://%s/%s", invokeData.loggingLabel, invokeData.bucket, bucketKey)
+	glog.V(9).
+		Infof("%s created presigned response URL for s3://%s/%s", invokeData.loggingLabel, invokeData.bucket, bucketKey)
 
 	event := invokeData.event
 	event.RequestID = requestID
@@ -673,9 +755,11 @@ func sanitizeCustomResourceResponse(event *cfn.Event, response *cfn.Response) *c
 
 	// ensure PhysicalResourceID is set. For Create requests we fall back to the RequestID,
 	// for Update and Delete requests we fall back to the PhysicalResourceID from state
-	if response.PhysicalResourceID == "" && (event.RequestType == cfn.RequestDelete || event.RequestType == cfn.RequestUpdate) {
+	if response.PhysicalResourceID == "" &&
+		(event.RequestType == cfn.RequestDelete || event.RequestType == cfn.RequestUpdate) {
 		response.PhysicalResourceID = event.PhysicalResourceID
-	} else if response.PhysicalResourceID == "" && event.RequestType == cfn.RequestCreate {
+	} else if response.PhysicalResourceID == "" &&
+		event.RequestType == cfn.RequestCreate {
 		response.PhysicalResourceID = event.RequestID
 	}
 

--- a/provider/pkg/resources/cfn_custom_resource_test.go
+++ b/provider/pkg/resources/cfn_custom_resource_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
@@ -12,14 +13,26 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/cfn"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gomock "go.uber.org/mock/gomock"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+)
+
+const (
+	testStackID            = "stack-id"
+	testServiceToken       = "arn:aws:lambda:us-west-2:123456789012:function:my-function" //nolint:gosec // Test fixture.
+	testBucketKeyPrefix    = "bucket-key-prefix"
+	testBucketName         = "bucket-name"
+	testPhysicalResourceID = "physical-resource-id"
+	testResourceType       = "Custom::MyResource"
+	testResponseURL        = "https://example.com"
 )
 
 func TestCfnCustomResource_Check(t *testing.T) {
@@ -34,12 +47,16 @@ func TestCfnCustomResource_Check(t *testing.T) {
 		{
 			name: "Valid inputs",
 			inputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"stackId":      resource.NewStringProperty("testProject"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"stackId": resource.NewStringProperty("testProject"),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"stackId":      resource.NewStringProperty("testProject"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"stackId": resource.NewStringProperty("testProject"),
 			},
 		},
 		{
@@ -70,22 +87,30 @@ func TestCfnCustomResource_Check(t *testing.T) {
 		{
 			name: "Default StackID",
 			inputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"stackId":      resource.NewStringProperty("testProject"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"stackId": resource.NewStringProperty("testProject"),
 			},
 		},
 		{
 			name: "Stringify CustomResourceProperties",
 			inputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"stackId":      resource.NewStringProperty("testProject"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"stackId": resource.NewStringProperty("testProject"),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"stackId":      resource.NewStringProperty("testProject"),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"stackId": resource.NewStringProperty("testProject"),
 			},
 		},
 		{
@@ -102,12 +127,16 @@ func TestCfnCustomResource_Check(t *testing.T) {
 		{
 			name: "Preserves Secrets",
 			inputs: resource.PropertyMap{
-				"serviceToken": resource.MakeSecret(resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function")),
-				"stackId":      resource.MakeSecret(resource.NewStringProperty("testProject")),
+				"serviceToken": resource.MakeSecret(
+					resource.NewStringProperty(testServiceToken),
+				),
+				"stackId": resource.MakeSecret(resource.NewStringProperty("testProject")),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken": resource.MakeSecret(resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function")),
-				"stackId":      resource.MakeSecret(resource.NewStringProperty("testProject")),
+				"serviceToken": resource.MakeSecret(
+					resource.NewStringProperty(testServiceToken),
+				),
+				"stackId": resource.MakeSecret(resource.NewStringProperty("testProject")),
 			},
 		},
 	}
@@ -255,12 +284,12 @@ func TestCfnCustomResource_Create(t *testing.T) {
 			mockLambdaClient := client.NewMockLambdaClient(ctrl)
 			mockS3Client := client.NewMockS3Client(ctrl)
 
-			stackID := "stack-id"
-			serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-			bucketKeyPrefix := "bucket-key-prefix"
-			bucketName := "bucket-name"
-			physicalResourceID := "physical-resource-id"
-			resourceType := "Custom::MyResource"
+			stackID := testStackID
+			serviceToken := testServiceToken
+			bucketKeyPrefix := testBucketKeyPrefix
+			bucketName := testBucketName
+			physicalResourceID := testPhysicalResourceID
+			resourceType := testResourceType
 
 			expectedTimeout := DefaultCustomResourceTimeout
 			if tt.timeout != 0 {
@@ -268,7 +297,7 @@ func TestCfnCustomResource_Create(t *testing.T) {
 			}
 
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
-			responseUrl := "https://example.com"
+			responseUrl := testResponseURL
 			expectedPayload := cfn.Event{
 				RequestType:        cfn.RequestCreate,
 				ResponseURL:        responseUrl,
@@ -282,7 +311,7 @@ func TestCfnCustomResource_Create(t *testing.T) {
 				gomock.Any(),
 				serviceToken,
 				gomock.Any(),
-			).DoAndReturn(func(ctx context.Context, functionName string, payload []byte) error {
+			).DoAndReturn(func(_ context.Context, _ string, payload []byte) error {
 				var event cfn.Event
 				err := json.Unmarshal(payload, &event)
 				require.NoError(t, err)
@@ -292,7 +321,9 @@ func TestCfnCustomResource_Create(t *testing.T) {
 				return nil
 			})
 
-			mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return(responseUrl, nil)
+			mockS3Client.EXPECT().
+				PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+				Return(responseUrl, nil)
 
 			response := cfn.Response{
 				Status:             cfn.StatusSuccess,
@@ -322,12 +353,14 @@ func TestCfnCustomResource_Create(t *testing.T) {
 			ctx := context.Background()
 
 			inputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(tt.customResourceInputs)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(tt.customResourceInputs),
+				),
 			}
 
 			id, outputs, err := c.Create(ctx, urn, inputs, tt.timeout)
@@ -376,7 +409,7 @@ func TestCfnCustomResource_Create_PartialError(t *testing.T) {
 	}{
 		{
 			name:               "With PhysicalResourceID",
-			physicalResourceID: "physical-resource-id",
+			physicalResourceID: testPhysicalResourceID,
 			expectedError:      "some error occurred",
 			customResourceData: map[string]interface{}{"key": "value"},
 		},
@@ -398,14 +431,16 @@ func TestCfnCustomResource_Create_PartialError(t *testing.T) {
 			mockLambdaClient := client.NewMockLambdaClient(ctrl)
 			mockS3Client := client.NewMockS3Client(ctrl)
 
-			stackID := "stack-id"
-			serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-			bucketKeyPrefix := "bucket-key-prefix"
-			bucketName := "bucket-name"
-			resourceType := "Custom::MyResource"
+			stackID := testStackID
+			serviceToken := testServiceToken
+			bucketKeyPrefix := testBucketKeyPrefix
+			bucketName := testBucketName
+			resourceType := testResourceType
 
 			mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(nil)
-			mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
+			mockS3Client.EXPECT().
+				PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+				Return(testResponseURL, nil)
 
 			response := cfn.Response{
 				Status:             cfn.StatusFailed,
@@ -436,12 +471,14 @@ func TestCfnCustomResource_Create_PartialError(t *testing.T) {
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
 
 			inputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{"key": "value"})),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(map[string]interface{}{"key": "value"}),
+				),
 			}
 
 			id, outputs, err := c.Create(ctx, urn, inputs, 0)
@@ -478,13 +515,15 @@ func TestCfnCustomResource_Create_PresignPutObjectFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to presign put object")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
 
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("", expectedError)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return("", expectedError)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -522,14 +561,16 @@ func TestCfnCustomResource_Create_LambdaInvokeFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to invoke lambda")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(expectedError)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return(testResponseURL, nil)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -567,15 +608,19 @@ func TestCfnCustomResource_Create_S3WaitForObjectFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to fetch custom resource response")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(nil)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
-	mockS3Client.EXPECT().WaitForObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), DefaultCustomResourceTimeout).Return(nil, expectedError)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return(testResponseURL, nil)
+	mockS3Client.EXPECT().
+		WaitForObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), DefaultCustomResourceTimeout).
+		Return(nil, expectedError)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -643,12 +688,12 @@ func TestCfnCustomResource_Update(t *testing.T) {
 			mockLambdaClient := client.NewMockLambdaClient(ctrl)
 			mockS3Client := client.NewMockS3Client(ctrl)
 
-			stackID := "stack-id"
-			serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-			bucketKeyPrefix := "bucket-key-prefix"
-			bucketName := "bucket-name"
-			physicalResourceID := "physical-resource-id"
-			resourceType := "Custom::MyResource"
+			stackID := testStackID
+			serviceToken := testServiceToken
+			bucketKeyPrefix := testBucketKeyPrefix
+			bucketName := testBucketName
+			physicalResourceID := testPhysicalResourceID
+			resourceType := testResourceType
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
 			expectedTimeout := DefaultCustomResourceTimeout
 			if tt.timeout != 0 {
@@ -664,7 +709,7 @@ func TestCfnCustomResource_Update(t *testing.T) {
 				"key":    42,
 			}
 
-			responseUrl := "https://example.com"
+			responseUrl := testResponseURL
 			expectedPayload := cfn.Event{
 				RequestType:           cfn.RequestUpdate,
 				ResponseURL:           responseUrl,
@@ -680,7 +725,7 @@ func TestCfnCustomResource_Update(t *testing.T) {
 				gomock.Any(),
 				serviceToken,
 				gomock.Any(),
-			).DoAndReturn(func(ctx context.Context, functionName string, payload []byte) error {
+			).DoAndReturn(func(_ context.Context, _ string, payload []byte) error {
 				var event cfn.Event
 				err := json.Unmarshal(payload, &event)
 				require.NoError(t, err)
@@ -690,7 +735,9 @@ func TestCfnCustomResource_Update(t *testing.T) {
 				return nil
 			})
 
-			mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).Return("https://example.com", nil)
+			mockS3Client.EXPECT().
+				PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).
+				Return(testResponseURL, nil)
 
 			response := cfn.Response{
 				Status:             cfn.StatusSuccess,
@@ -721,21 +768,25 @@ func TestCfnCustomResource_Update(t *testing.T) {
 			ctx := context.Background()
 
 			oldInputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(oldResourceProperties)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(oldResourceProperties),
+				),
 			}
 
 			inputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(newResourceProperties)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(newResourceProperties),
+				),
 			}
 
 			oldState := CfnCustomResourceState{
@@ -749,7 +800,15 @@ func TestCfnCustomResource_Update(t *testing.T) {
 				ResourceType: resourceType,
 			}
 
-			outputs, err := c.Update(ctx, urn, physicalResourceID, inputs, oldInputs, CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()), tt.timeout)
+			outputs, err := c.Update(
+				ctx,
+				urn,
+				physicalResourceID,
+				inputs,
+				oldInputs,
+				CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()),
+				tt.timeout,
+			)
 
 			require.NoError(t, err)
 
@@ -786,15 +845,17 @@ func TestCfnCustomResource_Update_LambdaInvokeFailure(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to invoke lambda")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	physicalResourceID := "physical-resource-id"
-	resourceType := "Custom::MyResource"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	physicalResourceID := testPhysicalResourceID
+	resourceType := testResourceType
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(expectedError)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return(testResponseURL, nil)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -838,7 +899,15 @@ func TestCfnCustomResource_Update_LambdaInvokeFailure(t *testing.T) {
 		ResourceType: resourceType,
 	}
 
-	outputs, err := c.Update(ctx, urn, physicalResourceID, inputs, oldInputs, CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()), 0)
+	outputs, err := c.Update(
+		ctx,
+		urn,
+		physicalResourceID,
+		inputs,
+		oldInputs,
+		CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()),
+		0,
+	)
 
 	require.Error(t, err)
 	assert.Nil(t, outputs)
@@ -894,12 +963,12 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 			mockLambdaClient := client.NewMockLambdaClient(ctrl)
 			mockS3Client := client.NewMockS3Client(ctrl)
 
-			stackID := "stack-id"
-			serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-			bucketKeyPrefix := "bucket-key-prefix"
-			bucketName := "bucket-name"
-			physicalResourceID := "physical-resource-id"
-			resourceType := "Custom::MyResource"
+			stackID := testStackID
+			serviceToken := testServiceToken
+			bucketKeyPrefix := testBucketKeyPrefix
+			bucketName := testBucketName
+			physicalResourceID := testPhysicalResourceID
+			resourceType := testResourceType
 			expectedTimeout := DefaultCustomResourceTimeout
 			if tt.timeout != 0 {
 				expectedTimeout = tt.timeout
@@ -914,7 +983,7 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
 
-			responseUrl := "https://example.com"
+			responseUrl := testResponseURL
 			expectedUpdatePayload := cfn.Event{
 				RequestType:           cfn.RequestUpdate,
 				ResponseURL:           responseUrl,
@@ -930,7 +999,7 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 				gomock.Any(),
 				serviceToken,
 				gomock.Any(),
-			).DoAndReturn(func(ctx context.Context, functionName string, payload []byte) error {
+			).DoAndReturn(func(_ context.Context, _ string, payload []byte) error {
 				var event cfn.Event
 				err := json.Unmarshal(payload, &event)
 				require.NoError(t, err)
@@ -954,7 +1023,7 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 				gomock.Any(),
 				serviceToken,
 				gomock.Any(),
-			).DoAndReturn(func(ctx context.Context, functionName string, payload []byte) error {
+			).DoAndReturn(func(_ context.Context, _ string, payload []byte) error {
 				var event cfn.Event
 				err := json.Unmarshal(payload, &event)
 				require.NoError(t, err)
@@ -964,7 +1033,10 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 				return nil
 			})
 
-			mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).Return("https://example.com", nil).Times(2)
+			mockS3Client.EXPECT().
+				PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).
+				Return(testResponseURL, nil).
+				Times(2)
 
 			response := cfn.Response{
 				Status:             cfn.StatusSuccess,
@@ -1012,21 +1084,25 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 			ctx := context.Background()
 
 			oldInputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(oldResourceProperties)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(oldResourceProperties),
+				),
 			}
 
 			inputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(newResourceProperties)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(newResourceProperties),
+				),
 			}
 
 			oldState := CfnCustomResourceState{
@@ -1040,7 +1116,15 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChange(t *testing.T) {
 				ResourceType: resourceType,
 			}
 
-			outputs, err := c.Update(ctx, urn, physicalResourceID, inputs, oldInputs, CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()), tt.timeout)
+			outputs, err := c.Update(
+				ctx,
+				urn,
+				physicalResourceID,
+				inputs,
+				oldInputs,
+				CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()),
+				tt.timeout,
+			)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)
@@ -1083,15 +1167,17 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChangeDeleteTimeout(t *testi
 	mockLambdaClient := client.NewMockLambdaClient(ctrl)
 	mockS3Client := client.NewMockS3Client(ctrl)
 
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	physicalResourceID := "physical-resource-id"
-	resourceType := "Custom::MyResource"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	physicalResourceID := testPhysicalResourceID
+	resourceType := testResourceType
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(nil)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).Return("https://example.com", nil)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), expectedTimeout).
+		Return(testResponseURL, nil)
 
 	response := cfn.Response{
 		Status:             cfn.StatusSuccess,
@@ -1155,10 +1241,23 @@ func TestCfnCustomResource_Update_PhysicalResourceIDChangeDeleteTimeout(t *testi
 		ResourceType: resourceType,
 	}
 
-	outputs, err := c.Update(ctx, urn, physicalResourceID, inputs, oldInputs, CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()), expectedTimeout)
+	outputs, err := c.Update(
+		ctx,
+		urn,
+		physicalResourceID,
+		inputs,
+		oldInputs,
+		CheckpointPropertyMap(oldInputs, oldState.ToPropertyMap()),
+		expectedTimeout,
+	)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to clean up old custom resource: not enough time left to delete the old resource. Consider increasing the timeout")
+	assert.Contains(
+		t,
+		err.Error(),
+		//nolint:lll // Preserve the exact fixture or documentation text.
+		"failed to clean up old custom resource: not enough time left to delete the old resource. Consider increasing the timeout",
+	)
 	assert.Nil(t, outputs)
 }
 
@@ -1176,44 +1275,56 @@ func TestCfnCustomResource_Read(t *testing.T) {
 		{
 			name: "Success",
 			oldState: resource.PropertyMap{
-				"physicalResourceId": resource.NewStringProperty("physical-resource-id"),
+				"physicalResourceId": resource.NewStringProperty(testPhysicalResourceID),
 				"data": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"key": "value",
 				})),
-				"stackId":      resource.NewStringProperty("stack-id"),
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"bucket":       resource.NewStringProperty("bucket-name"),
-				"resourceType": resource.NewStringProperty("Custom::MyResource"),
+				"stackId": resource.NewStringProperty(testStackID),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"bucket":       resource.NewStringProperty(testBucketName),
+				"resourceType": resource.NewStringProperty(testResourceType),
 			},
 			oldInputs: resource.PropertyMap{
-				"serviceToken":    resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"resourceType":    resource.NewStringProperty("Custom::MyResource"),
-				"stackID":         resource.NewStringProperty("stack-id"),
-				"bucketName":      resource.NewStringProperty("bucket-name"),
-				"bucketKeyPrefix": resource.NewStringProperty("bucket-key-prefix"),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-					"key": "value",
-				})),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"resourceType":    resource.NewStringProperty(testResourceType),
+				"stackID":         resource.NewStringProperty(testStackID),
+				"bucketName":      resource.NewStringProperty(testBucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(testBucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(map[string]interface{}{
+						"key": "value",
+					}),
+				),
 			},
 			expectedState: resource.PropertyMap{
-				"physicalResourceId": resource.NewStringProperty("physical-resource-id"),
+				"physicalResourceId": resource.NewStringProperty(testPhysicalResourceID),
 				"data": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
 					"key": "value",
 				})),
-				"stackId":      resource.NewStringProperty("stack-id"),
-				"serviceToken": resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"bucket":       resource.NewStringProperty("bucket-name"),
-				"resourceType": resource.NewStringProperty("Custom::MyResource"),
+				"stackId": resource.NewStringProperty(testStackID),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"bucket":       resource.NewStringProperty(testBucketName),
+				"resourceType": resource.NewStringProperty(testResourceType),
 			},
 			expectedInputs: resource.PropertyMap{
-				"serviceToken":    resource.NewStringProperty("arn:aws:lambda:us-west-2:123456789012:function:my-function"),
-				"resourceType":    resource.NewStringProperty("Custom::MyResource"),
-				"stackID":         resource.NewStringProperty("stack-id"),
-				"bucketName":      resource.NewStringProperty("bucket-name"),
-				"bucketKeyPrefix": resource.NewStringProperty("bucket-key-prefix"),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
-					"key": "value",
-				})),
+				"serviceToken": resource.NewStringProperty(
+					testServiceToken,
+				),
+				"resourceType":    resource.NewStringProperty(testResourceType),
+				"stackID":         resource.NewStringProperty(testStackID),
+				"bucketName":      resource.NewStringProperty(testBucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(testBucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(map[string]interface{}{
+						"key": "value",
+					}),
+				),
 			},
 		},
 		{
@@ -1236,7 +1347,7 @@ func TestCfnCustomResource_Read(t *testing.T) {
 			}
 			expectedState := CheckpointPropertyMap(tt.expectedInputs, tt.expectedState)
 
-			state, inputs, supported, err := c.Read(ctx, urn, "physical-resource-id", tt.oldInputs, oldState)
+			state, inputs, supported, err := c.Read(ctx, urn, testPhysicalResourceID, tt.oldInputs, oldState)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)
@@ -1300,12 +1411,12 @@ func TestCfnCustomResource_Delete(t *testing.T) {
 			mockLambdaClient := client.NewMockLambdaClient(ctrl)
 			mockS3Client := client.NewMockS3Client(ctrl)
 
-			stackID := "stack-id"
-			serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-			bucketKeyPrefix := "bucket-key-prefix"
-			bucketName := "bucket-name"
-			physicalResourceID := "physical-resource-id"
-			resourceType := "Custom::MyResource"
+			stackID := testStackID
+			serviceToken := testServiceToken
+			bucketKeyPrefix := testBucketKeyPrefix
+			bucketName := testBucketName
+			physicalResourceID := testPhysicalResourceID
+			resourceType := testResourceType
 
 			expectedTimeout := DefaultCustomResourceTimeout
 			if tt.timeout != 0 {
@@ -1313,7 +1424,7 @@ func TestCfnCustomResource_Delete(t *testing.T) {
 			}
 
 			urn := urn.URN("urn:pulumi:testProject::test::aws-native:cloudformation:CfnCustomResource::dummy")
-			responseUrl := "https://example.com"
+			responseUrl := testResponseURL
 			expectedPayload := cfn.Event{
 				RequestType:        cfn.RequestDelete,
 				ResponseURL:        responseUrl,
@@ -1328,7 +1439,7 @@ func TestCfnCustomResource_Delete(t *testing.T) {
 				gomock.Any(),
 				serviceToken,
 				gomock.Any(),
-			).DoAndReturn(func(ctx context.Context, functionName string, payload []byte) error {
+			).DoAndReturn(func(_ context.Context, _ string, payload []byte) error {
 				var event cfn.Event
 				err := json.Unmarshal(payload, &event)
 				require.NoError(t, err)
@@ -1338,7 +1449,9 @@ func TestCfnCustomResource_Delete(t *testing.T) {
 				return nil
 			})
 
-			mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return(responseUrl, nil)
+			mockS3Client.EXPECT().
+				PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+				Return(responseUrl, nil)
 
 			response := cfn.Response{
 				Status:             cfn.StatusSuccess,
@@ -1367,21 +1480,25 @@ func TestCfnCustomResource_Delete(t *testing.T) {
 			ctx := context.Background()
 
 			inputs := resource.PropertyMap{
-				"serviceToken":             resource.NewStringProperty(serviceToken),
-				"resourceType":             resource.NewStringProperty(resourceType),
-				"stackID":                  resource.NewStringProperty(stackID),
-				"bucketName":               resource.NewStringProperty(bucketName),
-				"bucketKeyPrefix":          resource.NewStringProperty(bucketKeyPrefix),
-				"customResourceProperties": resource.NewObjectProperty(resource.NewPropertyMapFromMap(tt.customResourceInputs)),
+				"serviceToken":    resource.NewStringProperty(serviceToken),
+				"resourceType":    resource.NewStringProperty(resourceType),
+				"stackID":         resource.NewStringProperty(stackID),
+				"bucketName":      resource.NewStringProperty(bucketName),
+				"bucketKeyPrefix": resource.NewStringProperty(bucketKeyPrefix),
+				"customResourceProperties": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(tt.customResourceInputs),
+				),
 			}
 
 			state := resource.PropertyMap{
 				"physicalResourceId": resource.NewStringProperty(physicalResourceID),
-				"data":               resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{})),
-				"stackId":            resource.NewStringProperty(stackID),
-				"serviceToken":       resource.NewStringProperty(serviceToken),
-				"bucket":             resource.NewStringProperty(bucketName),
-				"resourceType":       resource.NewStringProperty(resourceType),
+				"data": resource.NewObjectProperty(
+					resource.NewPropertyMapFromMap(map[string]interface{}{}),
+				),
+				"stackId":      resource.NewStringProperty(stackID),
+				"serviceToken": resource.NewStringProperty(serviceToken),
+				"bucket":       resource.NewStringProperty(bucketName),
+				"resourceType": resource.NewStringProperty(resourceType),
 			}
 
 			err = c.Delete(ctx, urn, physicalResourceID, inputs, state, tt.timeout)
@@ -1405,14 +1522,16 @@ func TestCfnCustomResource_Delete_PresignPutObjectFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to presign put object")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
-	physicalResourceID := "physical-resource-id"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
+	physicalResourceID := testPhysicalResourceID
 
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("", expectedError)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return("", expectedError)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -1457,15 +1576,17 @@ func TestCfnCustomResource_Delete_LambdaInvokeFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to invoke lambda")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
-	physicalResourceID := "physical-resource-id"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
+	physicalResourceID := testPhysicalResourceID
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(expectedError)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return(testResponseURL, nil)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -1510,16 +1631,20 @@ func TestCfnCustomResource_Delete_S3WaitForObjectFail(t *testing.T) {
 	mockS3Client := client.NewMockS3Client(ctrl)
 
 	expectedError := fmt.Errorf("failed to fetch custom resource response")
-	stackID := "stack-id"
-	serviceToken := "arn:aws:lambda:us-west-2:123456789012:function:my-function"
-	bucketKeyPrefix := "bucket-key-prefix"
-	bucketName := "bucket-name"
-	resourceType := "Custom::MyResource"
-	physicalResourceID := "physical-resource-id"
+	stackID := testStackID
+	serviceToken := testServiceToken
+	bucketKeyPrefix := testBucketKeyPrefix
+	bucketName := testBucketName
+	resourceType := testResourceType
+	physicalResourceID := testPhysicalResourceID
 
 	mockLambdaClient.EXPECT().InvokeAsync(gomock.Any(), serviceToken, gomock.Any()).Return(nil)
-	mockS3Client.EXPECT().PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).Return("https://example.com", nil)
-	mockS3Client.EXPECT().WaitForObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), DefaultCustomResourceTimeout).Return(nil, expectedError)
+	mockS3Client.EXPECT().
+		PresignPutObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), gomock.Any()).
+		Return(testResponseURL, nil)
+	mockS3Client.EXPECT().
+		WaitForObject(gomock.Any(), bucketName, matchesBucketKeyPrefix(bucketKeyPrefix), DefaultCustomResourceTimeout).
+		Return(nil, expectedError)
 
 	c := &cfnCustomResource{
 		providerName: "testProvider",
@@ -1572,6 +1697,6 @@ func (c *MockClock) Now() time.Time {
 	return c.freezeTime
 }
 
-func (c *MockClock) Since(t time.Time) time.Duration {
+func (c *MockClock) Since(_ time.Time) time.Duration {
 	return c.customDuration
 }

--- a/provider/pkg/resources/checkpoint_test.go
+++ b/provider/pkg/resources/checkpoint_test.go
@@ -1,10 +1,12 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 func TestCheckpointObject(t *testing.T) {

--- a/provider/pkg/resources/custom.go
+++ b/provider/pkg/resources/custom.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 )
 
 //go:generate mockgen -package resources -source custom.go -destination mock_custom_resource.go CustomResource
@@ -16,13 +17,36 @@ type CustomResource interface {
 	Check(ctx context.Context, urn resource.URN, engineAutonaming autonaming.EngineAutoNamingConfig,
 		inputs, state resource.PropertyMap, defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error)
 	// Create creates a new resource in the cloud provider and returns its unique identifier and outputs.
-	Create(ctx context.Context, urn resource.URN, inputs resource.PropertyMap, timeout time.Duration) (identifier *string, outputs resource.PropertyMap, err error)
+	Create(
+		ctx context.Context,
+		urn resource.URN,
+		inputs resource.PropertyMap,
+		timeout time.Duration,
+	) (identifier *string, outputs resource.PropertyMap, err error)
 	// Read returns the outputs and the updated inputs of the resource.
-	Read(ctx context.Context, urn resource.URN, id string, oldInputs, oldOutputs resource.PropertyMap) (outputs resource.PropertyMap, inputs resource.PropertyMap, exists bool, err error)
+	Read(
+		ctx context.Context,
+		urn resource.URN,
+		id string,
+		oldInputs, oldOutputs resource.PropertyMap,
+	) (outputs resource.PropertyMap, inputs resource.PropertyMap, exists bool, err error)
 	// Update applies the diff of the inputs to the resource and returns the updated outputs.
-	Update(ctx context.Context, urn resource.URN, id string, inputs, oldInputs, state resource.PropertyMap, timeout time.Duration) (resource.PropertyMap, error)
+	Update(
+		ctx context.Context,
+		urn resource.URN,
+		id string,
+		inputs, oldInputs, state resource.PropertyMap,
+		timeout time.Duration,
+	) (resource.PropertyMap, error)
 	// Delete removes the resource from the cloud provider.
-	Delete(ctx context.Context, urn resource.URN, id string, inputs, state resource.PropertyMap, timeout time.Duration) error
-	// PreviewCustomResourceOutputs returns the outputs of the resource based on the inputs and the output properties in the resource schema.
+	Delete(
+		ctx context.Context,
+		urn resource.URN,
+		id string,
+		inputs, state resource.PropertyMap,
+		timeout time.Duration,
+	) error
+	// PreviewCustomResourceOutputs returns the outputs of the resource based on the inputs and the output properties in
+	// the resource schema.
 	PreviewCustomResourceOutputs() resource.PropertyMap
 }

--- a/provider/pkg/resources/extension_resource.go
+++ b/provider/pkg/resources/extension_resource.go
@@ -1,5 +1,6 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package resources
 
 import (
@@ -7,13 +8,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pulumi/pulumi-go-provider/resourcex"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/autonaming"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/client"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-go-provider/resourcex"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
 type AutoNaming struct {
@@ -39,13 +41,14 @@ type extensionResource struct {
 // Check extensionResource implements CustomResource
 var _ CustomResource = (*extensionResource)(nil)
 
+//nolint:revive // The concrete return type is used by package tests and internal configuration.
 func NewExtensionResource(client client.CloudControlClient) *extensionResource {
 	return &extensionResource{
 		client: client,
 	}
 }
 
-func (r *extensionResource) Check(ctx context.Context, urn resource.URN,
+func (r *extensionResource) Check(_ context.Context, urn resource.URN,
 	engineAutonaming autonaming.EngineAutoNamingConfig, inputs, state resource.PropertyMap,
 	defaultTags map[string]string) (resource.PropertyMap, []ValidationFailure, error) {
 	var typedInputs ExtensionResourceInputs
@@ -72,7 +75,8 @@ func (r *extensionResource) Check(ctx context.Context, urn resource.URN,
 	}
 
 	// Merge default tags into the inputs if the resource supports tags and the user has not overridden them.
-	if len(defaultTags) > 0 && typedInputs.TagsProperty != "" && typedInputs.TagsStyle != default_tags.TagsStyleUnknown {
+	if len(defaultTags) > 0 && typedInputs.TagsProperty != "" &&
+		typedInputs.TagsStyle != default_tags.TagsStyleUnknown {
 		tagsKey := resource.PropertyKey(typedInputs.TagsProperty)
 		inputProperties := resource.NewPropertyMapFromMap(typedInputs.Properties)
 		tagsStyle := typedInputs.TagsStyle
@@ -108,14 +112,20 @@ func ApplyDefaults(typedInputs ExtensionResourceInputs) (ExtensionResourceInputs
 
 	// If the tags property is unset then we'll default to "Tags" which is the most common property name.
 	// Except if the tags style is explicitly set to none, in which case we'll ignore the tags property.
-	if typedInputs.TagsProperty == "" && typedInputs.TagsStyle != default_tags.TagsStyleNone && typedInputs.TagsStyle != default_tags.TagsStyleUnknown {
+	if typedInputs.TagsProperty == "" && typedInputs.TagsStyle != default_tags.TagsStyleNone &&
+		typedInputs.TagsStyle != default_tags.TagsStyleUnknown {
 		typedInputs.TagsProperty = "Tags"
 	}
 
 	return typedInputs, nil
 }
 
-func (r *extensionResource) Create(ctx context.Context, urn resource.URN, inputs resource.PropertyMap, timeout time.Duration) (identifier *string, outputs resource.PropertyMap, err error) {
+func (r *extensionResource) Create(
+	ctx context.Context,
+	urn resource.URN,
+	inputs resource.PropertyMap,
+	_ time.Duration,
+) (identifier *string, outputs resource.PropertyMap, err error) {
 	var typedInputs ExtensionResourceInputs
 	_, err = resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -131,7 +141,12 @@ func (r *extensionResource) Create(ctx context.Context, urn resource.URN, inputs
 	return id, CheckpointObject(inputs, rawOutputs), nil
 }
 
-func (r *extensionResource) Read(ctx context.Context, urn resource.URN, id string, oldInputs, oldState resource.PropertyMap) (outputs resource.PropertyMap, inputs resource.PropertyMap, exists bool, err error) {
+func (r *extensionResource) Read(
+	ctx context.Context,
+	_ resource.URN,
+	id string,
+	oldInputs, oldState resource.PropertyMap,
+) (outputs resource.PropertyMap, inputs resource.PropertyMap, exists bool, err error) {
 	if len(oldState) == 0 {
 		// We can't yet support import because the type would not be known.
 		return nil, nil, false, fmt.Errorf("ExtensionResource import not implemented")
@@ -169,7 +184,13 @@ func (r *extensionResource) Read(ctx context.Context, urn resource.URN, id strin
 	return CheckpointObject(newInputs, rawState), newInputs, true, nil
 }
 
-func (r *extensionResource) Update(ctx context.Context, urn resource.URN, id string, inputs, oldInputs, state resource.PropertyMap, timeout time.Duration) (resource.PropertyMap, error) {
+func (r *extensionResource) Update(
+	ctx context.Context,
+	urn resource.URN,
+	id string,
+	inputs, oldInputs, _ resource.PropertyMap,
+	_ time.Duration,
+) (resource.PropertyMap, error) {
 	var typedOldInputs ExtensionResourceInputs
 	_, err := resourcex.Unmarshal(&typedOldInputs, oldInputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -200,7 +221,13 @@ func (r *extensionResource) Update(ctx context.Context, urn resource.URN, id str
 	return CheckpointObject(inputs, rawState), nil
 }
 
-func (r *extensionResource) Delete(ctx context.Context, urn resource.URN, id string, inputs, state resource.PropertyMap, timeout time.Duration) error {
+func (r *extensionResource) Delete(
+	ctx context.Context,
+	urn resource.URN,
+	id string,
+	inputs, _ resource.PropertyMap,
+	_ time.Duration,
+) error {
 	var typedInputs ExtensionResourceInputs
 	_, err := resourcex.Unmarshal(&typedInputs, inputs, resourcex.UnmarshalOptions{})
 	if err != nil {
@@ -215,7 +242,7 @@ func (r *extensionResource) Delete(ctx context.Context, urn resource.URN, id str
 	return nil
 }
 
-const AutoNamingTypeToken = "aws-native:index:AutoNaming"
+const AutoNamingTypeToken = "aws-native:index:AutoNaming" //nolint:gosec // Pulumi type token, not a credential.
 
 func AutoNamingTypeSpec() pschema.ObjectTypeSpec {
 	return pschema.ObjectTypeSpec{
@@ -241,6 +268,7 @@ func AutoNamingTypeSpec() pschema.ObjectTypeSpec {
 func ExtensionResourceSpec() pschema.ResourceSpec {
 	return pschema.ResourceSpec{
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			//nolint:lll // Preserve the exact fixture or documentation text.
 			Description: "A special resource that enables deploying CloudFormation Extensions (third-party resources). An extension has to be pre-registered in your AWS account in order to use this resource.",
 			Properties: map[string]pschema.PropertySpec{
 				"outputs": {
@@ -257,6 +285,7 @@ func ExtensionResourceSpec() pschema.ResourceSpec {
 		},
 		InputProperties: map[string]pschema.PropertySpec{
 			"type": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "CloudFormation type name. This has three parts, each separated by two colons. For AWS resources this starts with `AWS::` e.g. `AWS::Logs::LogGroup`. Third party resources should use a namespace prefix e.g. `MyCompany::MyService::MyResource`.",
 				TypeSpec: pschema.TypeSpec{
 					Type: "string",
@@ -264,6 +293,7 @@ func ExtensionResourceSpec() pschema.ResourceSpec {
 				ReplaceOnChanges: true,
 			},
 			"properties": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Property bag containing the properties for the resource. These should be defined using the casing expected by the CloudControl API as these values are sent exact as provided.",
 				TypeSpec: pschema.TypeSpec{
 					Type: "object",
@@ -273,6 +303,7 @@ func ExtensionResourceSpec() pschema.ResourceSpec {
 				},
 			},
 			"createOnly": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Property names as defined by `createOnlyProperties` in the CloudFormation schema. Create-only properties can't be set during updates, so will not be included in patches even if they are also marked as write-only, and will cause an error if attempted to be updated. Therefore any property here should also be included in the `replaceOnChanges` resource option too.\nIn the CloudFormation schema these are fully qualified property paths (e.g. `/properties/AccessToken`) whereas here we only include the top-level property name (e.g. `AccessToken`).",
 				TypeSpec: pschema.TypeSpec{
 					Type: "array",
@@ -282,6 +313,7 @@ func ExtensionResourceSpec() pschema.ResourceSpec {
 				},
 			},
 			"writeOnly": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Property names as defined by `writeOnlyProperties` in the CloudFormation schema. Write-only properties are not returned during read operations and have to be included in all update operations as CloudControl itself can't read their previous values.\nIn the CloudFormation schema these are fully qualified property paths (e.g. `/properties/AccessToken`) whereas here we only include the top-level property name (e.g. `AccessToken`).",
 				TypeSpec: pschema.TypeSpec{
 					Type: "array",
@@ -291,18 +323,21 @@ func ExtensionResourceSpec() pschema.ResourceSpec {
 				},
 			},
 			"tagsProperty": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Optional name of the property containing the tags. Defaults to \"Tags\" if the `tagsStyle` is set to either \"stringMap\" or \"keyValueArray\". This is used to apply default tags to the resource and can be ignored if not using default tags.",
 				TypeSpec: pschema.TypeSpec{
 					Type: "string",
 				},
 			},
 			"tagsStyle": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Optional style of tags this resource uses. Valid values are \"stringMap\", \"keyValueArray\" or \"none\". Defaults to `keyValueArray` if `tagsProperty` is set. This is used to apply default tags to the resource and can be ignored if not using default tags.",
 				TypeSpec: pschema.TypeSpec{
 					Type: "string",
 				},
 			},
 			"autoNaming": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Optional auto-naming specification for the resource.\nIf provided and the name is not specified manually, the provider will automatically generate a name based on the Pulumi resource name and a random suffix.",
 				TypeSpec:    pschema.TypeSpec{Ref: fmt.Sprint("#/types/", AutoNamingTypeToken)},
 			},

--- a/provider/pkg/resources/extension_resource_test.go
+++ b/provider/pkg/resources/extension_resource_test.go
@@ -1,12 +1,14 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 )
 
 func TestExtensionResourceDefaults(t *testing.T) {
@@ -59,6 +61,12 @@ func TestExtensionResourceDefaults(t *testing.T) {
 		_, failures := ApplyDefaults(ExtensionResourceInputs{
 			TagsStyle: "invalid",
 		})
-		assert.Equal(t, []ValidationFailure{{Path: "tagsStyle", Reason: "tagsStyle is invalid, must be one of: stringMap, keyValueArray, none"}}, failures)
+		assert.Equal(
+			t,
+			[]ValidationFailure{
+				{Path: "tagsStyle", Reason: "tagsStyle is invalid, must be one of: stringMap, keyValueArray, none"},
+			},
+			failures,
+		)
 	})
 }

--- a/provider/pkg/resources/jsonata_integration_test.go
+++ b/provider/pkg/resources/jsonata_integration_test.go
@@ -1,14 +1,17 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 // Integration tests for propertyTransform support.
@@ -177,6 +180,7 @@ func TestIntegration_EFS_FileSystem_ReplicationTransform(t *testing.T) {
 	spec := &metadata.CloudAPIResource{
 		CfType: "AWS::EFS::FileSystem",
 		PropertyTransforms: map[string]string{
+			//nolint:lll // Preserve the exact fixture or documentation text.
 			"fileSystemProtection/replicationOverwriteProtection": "$uppercase(ReplicationOverwriteProtection)='DISABLED' ? 'REPLICATING' : $uppercase(ReplicationOverwriteProtection)",
 		},
 	}

--- a/provider/pkg/resources/jsonata_transform.go
+++ b/provider/pkg/resources/jsonata_transform.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/blues/jsonata-go"
 	"github.com/golang/glog"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 // TransformCache holds compiled JSONata expressions per resource type.
@@ -166,7 +168,11 @@ func (tc *TransformCache) compile(resourceToken string, transformSpecs map[strin
 // Returns the transformed value and any error. ErrUndefined from JSONata is treated
 // as "no transformation needed" and returns the original value. Nil results are also
 // treated as "no transformation" since functions like $lookup return nil for missing keys.
-func EvaluateTransform(transform CompiledTransform, value interface{}, context map[string]interface{}) (interface{}, error) {
+func EvaluateTransform(
+	transform CompiledTransform,
+	value interface{},
+	context map[string]interface{},
+) (interface{}, error) {
 	// Build the evaluation context by merging the value with sibling context
 	evalContext := make(map[string]interface{})
 	for k, v := range context {
@@ -317,7 +323,9 @@ func ExtractPropertyContext(props map[string]interface{}, path string) map[strin
 			// Parse array index
 			var idx int
 			if _, err := fmt.Sscanf(seg, "%d", &idx); err != nil || idx < 0 || idx >= len(v) {
-				glog.V(9).Infof("Failed to parse array index %q in path %s: invalid format or out of bounds (array len=%d)", seg, path, len(v))
+				glog.V(9).
+					//nolint:lll // Preserve the exact fixture or documentation text.
+					Infof("Failed to parse array index %q in path %s: invalid format or out of bounds (array len=%d)", seg, path, len(v))
 				return nil
 			}
 			current = v[idx]

--- a/provider/pkg/resources/jsonata_transform_test.go
+++ b/provider/pkg/resources/jsonata_transform_test.go
@@ -1,15 +1,18 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-go-provider/resourcex"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-go-provider/resourcex"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func TestPathMatcher(t *testing.T) {
@@ -186,6 +189,7 @@ func TestValuesEquivalent(t *testing.T) {
 	t.Run("CloudFormation KMS ARN transform pattern", func(t *testing.T) {
 		// Transform from metadata:
 		// $join(["arn:(aws)...[:]{1}key\\/", KmsKeyId])
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		pattern := "arn:(aws)[-]{0,1}[a-z]{0,2}[-]{0,1}[a-z]{0,3}:kms:[a-z]{2}[-]{1}[a-z]{3,10}[-]{0,1}[a-z]{0,10}[-]{1}[1-3]{1}:[0-9]{12}[:]{1}key\\/12345"
 		assert.True(t, ValuesEquivalent("arn:aws:kms:us-east-1:123456789012:key/12345", pattern))
 		assert.False(t, ValuesEquivalent("arn:aws:kms:us-east-1:123456789012:key/98765", pattern))
@@ -222,10 +226,10 @@ func TestValuesEquivalent(t *testing.T) {
 			{"float64 vs float64 different", float64(6.0), float64(7.0), false},
 			{"float64 decimal", float64(6.5), float64(6.5), true},
 
-				// Cross-type numeric comparisons (common when comparing decoded AWS responses)
-				// are handled by DeepEquals via Pulumi PropertyValue normalization.
-				{"int vs float64 equal", int(6), float64(6.0), true},
-				{"float64 vs int equal", float64(6.0), int(6), true},
+			// Cross-type numeric comparisons (common when comparing decoded AWS responses)
+			// are handled by DeepEquals via Pulumi PropertyValue normalization.
+			{"int vs float64 equal", int(6), float64(6.0), true},
+			{"float64 vs int equal", float64(6.0), int(6), true},
 
 			// Cross-type number/string comparisons are intentionally strict.
 			{"string number vs float64", "6", float64(6.0), false},
@@ -352,7 +356,13 @@ func TestSuppressPropertyTransformDiffs(t *testing.T) {
 			"engine": resource.NewStringProperty("MYSQL"),
 		}
 
-		result := suppressPropertyTransformDiffs("aws-native:rds:DBCluster", spec, diff, originalInputs, NewTransformCache())
+		result := suppressPropertyTransformDiffs(
+			"aws-native:rds:DBCluster",
+			spec,
+			diff,
+			originalInputs,
+			NewTransformCache(),
+		)
 		assert.Empty(t, result.Updates, "Diff should be suppressed for case-insensitive match")
 	})
 
@@ -376,13 +386,20 @@ func TestSuppressPropertyTransformDiffs(t *testing.T) {
 			"engine": resource.NewStringProperty("mysql"),
 		}
 
-		result := suppressPropertyTransformDiffs("aws-native:rds:DBCluster", spec, diff, originalInputs, NewTransformCache())
+		result := suppressPropertyTransformDiffs(
+			"aws-native:rds:DBCluster",
+			spec,
+			diff,
+			originalInputs,
+			NewTransformCache(),
+		)
 		assert.Len(t, result.Updates, 1, "Real diff should be preserved")
 	})
 
 	t.Run("handles nested object diff", func(t *testing.T) {
 		spec := &metadata.CloudAPIResource{
 			PropertyTransforms: map[string]string{
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				"fileSystemProtection/replicationOverwriteProtection": "$uppercase(ReplicationOverwriteProtection)='DISABLED' ? 'REPLICATING' : $uppercase(ReplicationOverwriteProtection)",
 			},
 		}

--- a/provider/pkg/resources/patching.go
+++ b/provider/pkg/resources/patching.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package resources
 
 import (
@@ -6,14 +7,21 @@ import (
 	"strings"
 
 	"github.com/mattbaird/jsonpatch"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
+	"github.com/wI2L/jsondiff"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/wI2L/jsondiff"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 )
 
-func CalcPatch(oldInputs resource.PropertyMap, newInputs resource.PropertyMap, spec metadata.CloudAPIResource, types map[string]metadata.CloudAPIType) ([]jsonpatch.JsonPatchOperation, error) {
+func CalcPatch(
+	oldInputs resource.PropertyMap,
+	newInputs resource.PropertyMap,
+	spec metadata.CloudAPIResource,
+	types map[string]metadata.CloudAPIType,
+) ([]jsonpatch.JsonPatchOperation, error) {
 	return calcPatchFromBaseline(oldInputs, oldInputs, newInputs, spec, types, "", nil)
 }
 
@@ -48,7 +56,15 @@ func calcPatchFromBaseline(
 ) ([]jsonpatch.JsonPatchOperation, error) {
 	diff := baseline.Diff(newInputs)
 	if resourceToken != "" {
-		diff = SuppressAWSManagedDiffsWithContext(resourceToken, &spec, diff, oldInputs, baseline, newInputs, transformCache)
+		diff = SuppressAWSManagedDiffsWithContext(
+			resourceToken,
+			&spec,
+			diff,
+			oldInputs,
+			baseline,
+			newInputs,
+			transformCache,
+		)
 	}
 
 	// Write-only properties can't even be read internally within the CloudControl service so they must be included in
@@ -97,7 +113,10 @@ func calcPatchFromBaseline(
 	return naming.DiffToPatch(&spec, types, diff)
 }
 
-func CalculateUntypedPatch(typedOldInputs ExtensionResourceInputs, typedInputs ExtensionResourceInputs) ([]jsonpatch.JsonPatchOperation, error) {
+func CalculateUntypedPatch(
+	typedOldInputs ExtensionResourceInputs,
+	typedInputs ExtensionResourceInputs,
+) ([]jsonpatch.JsonPatchOperation, error) {
 	jsonDiffPatch, err := jsondiff.Compare(typedOldInputs.Properties, typedInputs.Properties)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compare properties: %w", err)

--- a/provider/pkg/resources/patching_test.go
+++ b/provider/pkg/resources/patching_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
@@ -470,9 +471,11 @@ func TestCalcPatchWithActualOutputs(t *testing.T) {
 				"Version": resource.NewStringProperty("2012-10-17"),
 				"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"Effect":    resource.NewStringProperty("Allow"),
-						"Principal": resource.NewObjectProperty(resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")}),
-						"Action":    resource.NewStringProperty("sts:AssumeRole"),
+						"Effect": resource.NewStringProperty("Allow"),
+						"Principal": resource.NewObjectProperty(
+							resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")},
+						),
+						"Action": resource.NewStringProperty("sts:AssumeRole"),
 					}),
 				}),
 			}),
@@ -483,8 +486,10 @@ func TestCalcPatchWithActualOutputs(t *testing.T) {
 						"Version": resource.NewStringProperty("2012-10-17"),
 						"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 							resource.NewObjectProperty(resource.PropertyMap{
-								"Effect":   resource.NewStringProperty("Allow"),
-								"Action":   resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("*")}),
+								"Effect": resource.NewStringProperty("Allow"),
+								"Action": resource.NewArrayProperty(
+									[]resource.PropertyValue{resource.NewStringProperty("*")},
+								),
 								"Resource": resource.NewStringProperty("*"),
 							}),
 						}),

--- a/provider/pkg/resources/path_classifier.go
+++ b/provider/pkg/resources/path_classifier.go
@@ -169,7 +169,15 @@ func SuppressBaselineDiffs(
 	transformCache *TransformCache,
 ) resource.PropertyMap {
 	diff := oldDesired.Diff(baseline)
-	diff = SuppressAWSManagedDiffsWithContext(resourceToken, spec, diff, oldDesired, oldDesired, baseline, transformCache)
+	diff = SuppressAWSManagedDiffsWithContext(
+		resourceToken,
+		spec,
+		diff,
+		oldDesired,
+		oldDesired,
+		baseline,
+		transformCache,
+	)
 	return ApplyDiff(oldDesired, diff)
 }
 
@@ -238,7 +246,11 @@ func (c *PathClassifier) classifyType(
 
 // projectValue recursively projects one output value through an input type
 // shape, dropping read-only and write-only child paths along the way.
-func (c *PathClassifier) projectValue(path string, typ pschema.TypeSpec, value resource.PropertyValue) (resource.PropertyValue, bool) {
+func (c *PathClassifier) projectValue(
+	path string,
+	typ pschema.TypeSpec,
+	value resource.PropertyValue,
+) (resource.PropertyValue, bool) {
 	if typ.Ref != "" && typ.Ref != anyRef {
 		if !value.IsObject() {
 			return value, true

--- a/provider/pkg/resources/path_classifier_test.go
+++ b/provider/pkg/resources/path_classifier_test.go
@@ -1,13 +1,16 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func TestPathClassifierProjectWritableOutputState(t *testing.T) {
@@ -359,7 +362,12 @@ func TestPathHelpersSetPathWithShapeUsesArrayGuide(t *testing.T) {
 		}),
 	}
 	m := resource.PropertyMap{}
-	SetPathWithShape(m, shape, "defaultActions/0/authenticateOidcConfig/clientSecret", resource.NewStringProperty("secret"))
+	SetPathWithShape(
+		m,
+		shape,
+		"defaultActions/0/authenticateOidcConfig/clientSecret",
+		resource.NewStringProperty("secret"),
+	)
 
 	require.True(t, m["defaultActions"].IsArray())
 	secret, ok := GetPath(m, "defaultActions/0/authenticateOidcConfig/clientSecret")
@@ -413,7 +421,9 @@ func TestPathClassifierWriteOnlyWildcardFallback(t *testing.T) {
 		"aws-native:test:Action": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
-				"authenticateOidcConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:AuthenticateOidcConfig"}},
+				"authenticateOidcConfig": {
+					TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:AuthenticateOidcConfig"},
+				},
 			},
 		},
 		"aws-native:test:AuthenticateOidcConfig": {
@@ -478,7 +488,9 @@ func TestPathClassifierWriteOnlyOutputFallbackPreservesCreateOnlyAndArrayShape(t
 		"aws-native:test:Action": {
 			Type: "object",
 			Properties: map[string]pschema.PropertySpec{
-				"authenticateOidcConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:AuthenticateOidcConfig"}},
+				"authenticateOidcConfig": {
+					TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:AuthenticateOidcConfig"},
+				},
 			},
 		},
 		"aws-native:test:AuthenticateOidcConfig": {

--- a/provider/pkg/resources/path_set.go
+++ b/provider/pkg/resources/path_set.go
@@ -16,11 +16,6 @@ func newPathSet(paths []string) pathSet {
 	return pathSet{paths: append([]string(nil), paths...)}
 }
 
-// add records another slash-delimited metadata path.
-func (s *pathSet) add(path string) {
-	s.paths = append(s.paths, path)
-}
-
 // matches reports whether path is matched by any stored metadata path.
 //
 // For example, a stored pattern
@@ -52,7 +47,8 @@ func (s pathSet) covers(path string) bool {
 // pathMatches reports whether one metadata path pattern matches one concrete
 // path with the same number of segments.
 func pathMatches(pattern, path string) bool {
-	return slashPath(pattern).Contains(slashPath(path)) && len(strings.Split(pattern, "/")) == len(strings.Split(path, "/"))
+	return slashPath(pattern).Contains(slashPath(path)) &&
+		len(strings.Split(pattern, "/")) == len(strings.Split(path, "/"))
 }
 
 // slashPath converts a slash-delimited metadata path into a PropertyPath.

--- a/provider/pkg/resources/suppress_diff.go
+++ b/provider/pkg/resources/suppress_diff.go
@@ -1,5 +1,6 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package resources
 
 import (
@@ -37,7 +38,15 @@ func SuppressAWSManagedDiffs(
 	originalInputs resource.PropertyMap,
 	transformCache *TransformCache,
 ) *resource.ObjectDiff {
-	return SuppressAWSManagedDiffsWithContext(resourceToken, spec, diff, originalInputs, originalInputs, originalInputs, transformCache)
+	return SuppressAWSManagedDiffsWithContext(
+		resourceToken,
+		spec,
+		diff,
+		originalInputs,
+		originalInputs,
+		originalInputs,
+		transformCache,
+	)
 }
 
 // SuppressAWSManagedDiffsWithContext is SuppressAWSManagedDiffs with explicit
@@ -129,7 +138,10 @@ func suppressAWSManagedTagAdditions(
 // normalizeKeyValueArrayTagOrder sorts key/value-array tags for comparison.
 // CloudControl can return tags in arbitrary order, while Pulumi array diffs are
 // order-sensitive.
-func normalizeKeyValueArrayTagOrder(tags resource.PropertyValue, tagsStyle default_tags.TagsStyle) resource.PropertyValue {
+func normalizeKeyValueArrayTagOrder(
+	tags resource.PropertyValue,
+	tagsStyle default_tags.TagsStyle,
+) resource.PropertyValue {
 	if !tagsStyle.IsKeyValueArray() || !tags.IsArray() {
 		return tags
 	}
@@ -430,7 +442,14 @@ func suppressPropertyTransformDiffsWithContext(
 	for key, valueDiff := range diff.Updates {
 		path := string(key)
 
-		if shouldSuppressValueDiff(transforms, path, valueDiff, actualInputsMap, desiredInputsMap, spec.IrreversibleNames) {
+		if shouldSuppressValueDiff(
+			transforms,
+			path,
+			valueDiff,
+			actualInputsMap,
+			desiredInputsMap,
+			spec.IrreversibleNames,
+		) {
 			glog.V(7).Infof("Suppressing diff for %s.%s via propertyTransform", resourceToken, path)
 			delete(diff.Updates, key)
 		}
@@ -464,7 +483,14 @@ func shouldSuppressValueDiff(
 		// Recursively check all property updates
 		for k, childDiff := range diff.Object.Updates {
 			childPath := path + "/" + string(k)
-			if !shouldSuppressValueDiff(transforms, childPath, childDiff, actualInputsMap, desiredInputsMap, irreversibleNames) {
+			if !shouldSuppressValueDiff(
+				transforms,
+				childPath,
+				childDiff,
+				actualInputsMap,
+				desiredInputsMap,
+				irreversibleNames,
+			) {
 				return false
 			}
 		}
@@ -480,7 +506,14 @@ func shouldSuppressValueDiff(
 		// Recursively check all element updates
 		for idx, childDiff := range diff.Array.Updates {
 			childPath := fmt.Sprintf("%s/%d", path, idx)
-			if !shouldSuppressValueDiff(transforms, childPath, childDiff, actualInputsMap, desiredInputsMap, irreversibleNames) {
+			if !shouldSuppressValueDiff(
+				transforms,
+				childPath,
+				childDiff,
+				actualInputsMap,
+				desiredInputsMap,
+				irreversibleNames,
+			) {
 				return false
 			}
 		}
@@ -557,7 +590,12 @@ func evaluateAndCompare(
 //
 // This allows JSONata expressions like "$uppercase(FileSystemProtection.ReplicationOverwriteProtection)"
 // to work correctly.
-func buildCfnContext(baseContext map[string]interface{}, path string, value interface{}, irreversibleNames map[string]string) map[string]interface{} {
+func buildCfnContext(
+	baseContext map[string]interface{},
+	path string,
+	value interface{},
+	irreversibleNames map[string]string,
+) map[string]interface{} {
 	ctx := make(map[string]interface{})
 
 	// Copy base context (sibling properties)
@@ -600,7 +638,12 @@ func buildCfnContext(baseContext map[string]interface{}, path string, value inte
 //
 //	ctx["fileSystemProtection"] = {"replicationOverwriteProtection": "DISABLED"}
 //	ctx["FileSystemProtection"] = {"ReplicationOverwriteProtection": "DISABLED"}
-func buildNestedContext(ctx map[string]interface{}, segments []string, value interface{}, irreversibleNames map[string]string) {
+func buildNestedContext(
+	ctx map[string]interface{},
+	segments []string,
+	value interface{},
+	irreversibleNames map[string]string,
+) {
 	if len(segments) < 2 {
 		return
 	}
@@ -629,7 +672,12 @@ func buildNestedContext(ctx map[string]interface{}, segments []string, value int
 // CloudFormation uses PascalCase with uppercase acronyms (DBClusterIdentifier, IpProtocol).
 // The irreversibleNames lookup table provides the exact CFN name for properties where
 // simple PascalCase conversion doesn't work (e.g., dbClusterIdentifier -> DBClusterIdentifier).
-func addCfnNameVariations(ctx map[string]interface{}, sdkName string, value interface{}, irreversibleNames map[string]string) {
+func addCfnNameVariations(
+	ctx map[string]interface{},
+	sdkName string,
+	value interface{},
+	irreversibleNames map[string]string,
+) {
 	// Use ToCfnName which checks the lookup table first, then falls back to PascalCase
 	cfnName := naming.ToCfnName(sdkName, irreversibleNames)
 	ctx[cfnName] = value

--- a/provider/pkg/resources/suppress_diff_test.go
+++ b/provider/pkg/resources/suppress_diff_test.go
@@ -1,5 +1,6 @@
 // Copyright 2024, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package resources
 
 import (
@@ -176,7 +177,12 @@ func TestSuppressAWSManagedTagAdditions(t *testing.T) {
 
 		originalInputs := resource.PropertyMap{}
 
-		result := suppressAWSManagedTagAdditions("fileSystemTags", default_tags.TagsStyleKeyValueArray, diff, originalInputs)
+		result := suppressAWSManagedTagAdditions(
+			"fileSystemTags",
+			default_tags.TagsStyleKeyValueArray,
+			diff,
+			originalInputs,
+		)
 
 		_, hasAdd := result.Adds["fileSystemTags"]
 		assert.False(t, hasAdd, "aws: prefixed tag addition should be removed")
@@ -269,7 +275,12 @@ func TestSuppressAWSManagedTagAdditions(t *testing.T) {
 			}),
 		}
 
-		result := suppressAWSManagedTagAdditions("tags", default_tags.TagsStyleKeyValueArrayUpperCase, diff, originalInputs)
+		result := suppressAWSManagedTagAdditions(
+			"tags",
+			default_tags.TagsStyleKeyValueArrayUpperCase,
+			diff,
+			originalInputs,
+		)
 
 		_, hasUpdate := result.Updates["tags"]
 		assert.False(t, hasUpdate, "aws: tag in the old actual baseline should not become removal drift")
@@ -384,7 +395,12 @@ func TestSuppressAWSManagedTagAdditions(t *testing.T) {
 			"tags": oldTags,
 		}
 
-		result := suppressAWSManagedTagAdditions("tags", default_tags.TagsStyleKeyValueArrayUpperCase, diff, originalInputs)
+		result := suppressAWSManagedTagAdditions(
+			"tags",
+			default_tags.TagsStyleKeyValueArrayUpperCase,
+			diff,
+			originalInputs,
+		)
 
 		_, hasUpdate := result.Updates["tags"]
 		assert.False(t, hasUpdate, "uppercase reordered key/value tags should not register as drift")
@@ -515,7 +531,13 @@ func TestBuildCfnContext(t *testing.T) {
 func TestSuppressAWSManagedDiffs(t *testing.T) {
 	t.Run("handles nil diff", func(t *testing.T) {
 		spec := &metadata.CloudAPIResource{TagsProperty: "tags"}
-		result := SuppressAWSManagedDiffs("aws-native:s3:Bucket", spec, nil, resource.PropertyMap{}, NewTransformCache())
+		result := SuppressAWSManagedDiffs(
+			"aws-native:s3:Bucket",
+			spec,
+			nil,
+			resource.PropertyMap{},
+			NewTransformCache(),
+		)
 		assert.Nil(t, result)
 	})
 
@@ -535,7 +557,13 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 			Sames:   resource.PropertyMap{},
 		}
 
-		result := SuppressAWSManagedDiffs("aws-native:s3:Bucket", spec, diff, resource.PropertyMap{}, NewTransformCache())
+		result := SuppressAWSManagedDiffs(
+			"aws-native:s3:Bucket",
+			spec,
+			diff,
+			resource.PropertyMap{},
+			NewTransformCache(),
+		)
 
 		_, hasAdd := result.Adds["tags"]
 		assert.False(t, hasAdd)
@@ -544,11 +572,13 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 	t.Run("applies EFS-specific suppression via propertyTransform", func(t *testing.T) {
 		// EFS replication protection is now handled via propertyTransform
 		// The transform normalizes DISABLED -> REPLICATING for comparison
-		// NOTE: The actual CloudFormation expression uses nested path: FileSystemProtection.ReplicationOverwriteProtection
+		// NOTE: The actual CloudFormation expression uses nested path:
+		// FileSystemProtection.ReplicationOverwriteProtection
 		// This tests that buildCfnContext correctly builds the nested context structure
 		spec := &metadata.CloudAPIResource{
 			TagsProperty: "fileSystemTags",
 			PropertyTransforms: map[string]string{
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				"fileSystemProtection/replicationOverwriteProtection": "$uppercase(FileSystemProtection.ReplicationOverwriteProtection)='DISABLED' ? 'REPLICATING' : $uppercase(FileSystemProtection.ReplicationOverwriteProtection)",
 			},
 		}
@@ -636,9 +666,13 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 				"Version": resource.NewStringProperty("2012-10-17"),
 				"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"Effect":    resource.NewStringProperty("Allow"),
-						"Action":    resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("sts:AssumeRole")}),
-						"Principal": resource.NewObjectProperty(resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")}),
+						"Effect": resource.NewStringProperty("Allow"),
+						"Action": resource.NewArrayProperty(
+							[]resource.PropertyValue{resource.NewStringProperty("sts:AssumeRole")},
+						),
+						"Principal": resource.NewObjectProperty(
+							resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")},
+						),
 					}),
 				}),
 			}),
@@ -649,8 +683,10 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 						"Version": resource.NewStringProperty("2012-10-17"),
 						"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 							resource.NewObjectProperty(resource.PropertyMap{
-								"Effect":   resource.NewStringProperty("Allow"),
-								"Action":   resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("*")}),
+								"Effect": resource.NewStringProperty("Allow"),
+								"Action": resource.NewArrayProperty(
+									[]resource.PropertyValue{resource.NewStringProperty("*")},
+								),
 								"Resource": resource.NewStringProperty("*"),
 							}),
 						}),
@@ -691,9 +727,13 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 				"Version": resource.NewStringProperty("2012-10-17"),
 				"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"Effect":    resource.NewStringProperty("Allow"),
-						"Action":    resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("sts:AssumeRole")}),
-						"Principal": resource.NewObjectProperty(resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")}),
+						"Effect": resource.NewStringProperty("Allow"),
+						"Action": resource.NewArrayProperty(
+							[]resource.PropertyValue{resource.NewStringProperty("sts:AssumeRole")},
+						),
+						"Principal": resource.NewObjectProperty(
+							resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")},
+						),
 					}),
 				}),
 			}),
@@ -703,9 +743,11 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 				"Version": resource.NewStringProperty("2012-10-17"),
 				"Statement": resource.NewArrayProperty([]resource.PropertyValue{
 					resource.NewObjectProperty(resource.PropertyMap{
-						"Effect":    resource.NewStringProperty("Allow"),
-						"Action":    resource.NewStringProperty("sts:AssumeRole"),
-						"Principal": resource.NewObjectProperty(resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")}),
+						"Effect": resource.NewStringProperty("Allow"),
+						"Action": resource.NewStringProperty("sts:AssumeRole"),
+						"Principal": resource.NewObjectProperty(
+							resource.PropertyMap{"Service": resource.NewStringProperty("ec2.amazonaws.com")},
+						),
 					}),
 				}),
 			}),
@@ -730,7 +772,13 @@ func TestSuppressAWSManagedDiffs(t *testing.T) {
 			Sames:   resource.PropertyMap{},
 		}
 
-		result := SuppressAWSManagedDiffs("aws-native:some:Resource", spec, diff, resource.PropertyMap{}, NewTransformCache())
+		result := SuppressAWSManagedDiffs(
+			"aws-native:some:Resource",
+			spec,
+			diff,
+			resource.PropertyMap{},
+			NewTransformCache(),
+		)
 
 		// Should pass through unchanged
 		_, hasAdd := result.Adds["someProperty"]

--- a/provider/pkg/resources/validate.go
+++ b/provider/pkg/resources/validate.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package resources
 
 import (
@@ -8,10 +9,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 type ValidationFailure struct {
@@ -19,7 +22,11 @@ type ValidationFailure struct {
 	Reason string
 }
 
-func validatePrimitive(primitiveType string, path string, property resource.PropertyValue) ([]ValidationFailure, error) {
+func validatePrimitive(
+	primitiveType string,
+	path string,
+	property resource.PropertyValue,
+) ([]ValidationFailure, error) {
 	// If the property is secret, inspect its element.
 	for property.IsSecret() {
 		property = property.SecretValue().Element
@@ -51,7 +58,13 @@ func validatePrimitive(primitiveType string, path string, property resource.Prop
 	return nil, nil
 }
 
-func validateProperty(types map[string]metadata.CloudAPIType, required codegen.StringSet, spec *pschema.TypeSpec, path string, property resource.PropertyValue) ([]ValidationFailure, error) {
+func validateProperty(
+	types map[string]metadata.CloudAPIType,
+	required codegen.StringSet,
+	spec *pschema.TypeSpec,
+	path string,
+	property resource.PropertyValue,
+) ([]ValidationFailure, error) {
 	// If the property is secret, inspect its element.
 	for property.IsSecret() {
 		property = property.SecretValue().Element
@@ -121,7 +134,13 @@ func validateProperty(types map[string]metadata.CloudAPIType, required codegen.S
 	}
 }
 
-func validateProperties(types map[string]metadata.CloudAPIType, required codegen.StringSet, propertySpecs map[string]pschema.PropertySpec, path string, properties resource.PropertyMap) ([]ValidationFailure, error) {
+func validateProperties(
+	types map[string]metadata.CloudAPIType,
+	required codegen.StringSet,
+	propertySpecs map[string]pschema.PropertySpec,
+	path string,
+	properties resource.PropertyMap,
+) ([]ValidationFailure, error) {
 	// Do a schema-directed check first.
 	var failures []ValidationFailure
 	remainingProperties := properties.Mappable()
@@ -132,7 +151,13 @@ func validateProperties(types map[string]metadata.CloudAPIType, required codegen
 		} else {
 			propertyPath = fmt.Sprintf("%s/%s", path, k)
 		}
-		fs, err := validateProperty(types, required, &propertySpec.TypeSpec, propertyPath, properties[resource.PropertyKey(k)])
+		fs, err := validateProperty(
+			types,
+			required,
+			&propertySpec.TypeSpec,
+			propertyPath,
+			properties[resource.PropertyKey(k)],
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -144,17 +169,24 @@ func validateProperties(types map[string]metadata.CloudAPIType, required codegen
 	for k := range remainingProperties {
 		var propertyPath string
 		if path == "" {
-			propertyPath = string(k)
+			propertyPath = k
 		} else {
 			propertyPath = fmt.Sprintf("%s.%s", path, k)
 		}
-		failures = append(failures, ValidationFailure{Path: propertyPath, Reason: fmt.Sprintf("unknown property %v", propertyPath)})
+		failures = append(
+			failures,
+			ValidationFailure{Path: propertyPath, Reason: fmt.Sprintf("unknown property %v", propertyPath)},
+		)
 	}
 
 	return failures, nil
 }
 
-func ValidateResource(res *metadata.CloudAPIResource, types map[string]metadata.CloudAPIType, properties resource.PropertyMap) ([]ValidationFailure, error) {
+func ValidateResource(
+	res *metadata.CloudAPIResource,
+	types map[string]metadata.CloudAPIType,
+	properties resource.PropertyMap,
+) ([]ValidationFailure, error) {
 	required := codegen.NewStringSet(res.Required...)
 	return validateProperties(types, required, res.Inputs, "", properties)
 }

--- a/provider/pkg/schema/compression.go
+++ b/provider/pkg/schema/compression.go
@@ -9,6 +9,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -31,7 +32,11 @@ func DecompressSchema(compressedSchema []byte) ([]byte, error) {
 		return nil, errors.Wrap(err, "expand compressed schema")
 	}
 	uncompressedBuf := bytes.Buffer{}
-	if _, err = io.Copy(&uncompressedBuf, uncompressed); err != nil {
+	//nolint:gosec // Reads trusted provider schema data.
+	if _, err = io.Copy(
+		&uncompressedBuf,
+		uncompressed,
+	); err != nil {
 		return nil, err
 	}
 	if err = uncompressed.Close(); err != nil {

--- a/provider/pkg/schema/config.go
+++ b/provider/pkg/schema/config.go
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:goconst // Schema definitions intentionally repeat user-facing type and description text.
 package schema
 
 import (
 	"sort"
 	"strings"
 
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
 )
 
 func configToProvider(config pschema.ComplexTypeSpec) pschema.ComplexTypeSpec {
@@ -52,6 +54,7 @@ var assumeRole = pschema.ComplexTypeSpec{
 				TypeSpec:    pschema.TypeSpec{Type: "string"},
 			},
 			"policyArns": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the role.",
 				TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 			},
@@ -70,6 +73,7 @@ var assumeRole = pschema.ComplexTypeSpec{
 					AdditionalProperties: &pschema.TypeSpec{Type: "string"}},
 			},
 			"transitiveTagKeys": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "A list of keys for session tags that you want to set as transitive. If you set a tag key as transitive, the corresponding key and value passes to subsequent sessions in a role chain.",
 				TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 			},
@@ -80,6 +84,7 @@ var assumeRole = pschema.ComplexTypeSpec{
 
 var defaultTags = pschema.ComplexTypeSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		Description: "The configuration with resource tag settings to apply across all resources handled by this provider. This is designed to replace redundant per-resource `tags` configurations. Provider tags can be overridden with new values, but not excluded from specific resources. To override provider tag values, use the `tags` argument within a resource to configure new tag values for matching keys.",
 		Properties: map[string]pschema.PropertySpec{
 			"tags": {
@@ -124,13 +129,16 @@ var endpoints = pschema.ComplexTypeSpec{
 
 var ignoreTags = pschema.ComplexTypeSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		Description: "The configuration with resource tag settings to ignore across all resources handled by this provider (except any individual service tag resources such as `ec2.Tag`) for situations where external systems are managing certain resource tags.",
 		Properties: map[string]pschema.PropertySpec{
 			"keyPrefixes": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "List of exact resource tag keys to ignore across all resources handled by this provider. This configuration prevents Pulumi from returning the tag in any `tags` attributes and displaying any configuration difference for the tag value. If any resource configuration still has this tag key configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or `ignoreChanges` is also used.",
 				TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 			},
 			"keys": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "List of resource tag key prefixes to ignore across all resources handled by this provider. This configuration prevents Pulumi from returning any tag key matching the prefixes in any `tags` attributes and displaying any configuration difference for those tag values. If any resource configuration still has a tag matching one of the prefixes configured in the `tags` argument, it will display a perpetual difference until the tag is removed from the argument or `ignoreChanges` is also used.",
 				TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 			},

--- a/provider/pkg/schema/convert_examples_test.go
+++ b/provider/pkg/schema/convert_examples_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package schema
 
 import (
@@ -7,9 +8,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDynamoKeySchemaConversion(t *testing.T) {

--- a/provider/pkg/schema/docs/custom.go
+++ b/provider/pkg/schema/docs/custom.go
@@ -3,9 +3,10 @@
 package docs
 
 import (
-	_ "embed"
+	_ "embed" // Required by the go:embed directive below.
 )
 
 // TODO[pulumi/pulumi-cdk#109] Add examples for the other languages.
+//
 //go:embed content/cfn-custom-resource.md
 var CfnCustomResourceEmulatorDocs string

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Schema definitions intentionally repeat configuration and documentation text.
 package schema
 
 import (
@@ -30,10 +31,11 @@ import (
 )
 
 const packageName = "aws-native"
-const globalTagToken = "aws-native:index:Tag"
-const globalCreateOnlyTagToken = "aws-native:index:CreateOnlyTag"
+const globalTagToken = "aws-native:index:Tag"                     //nolint:gosec // Pulumi type token, not a credential.
+const globalCreateOnlyTagToken = "aws-native:index:CreateOnlyTag" //nolint:gosec // Pulumi type token.
 
-// The documentation of some resources/properties is incomplete or incorrect in the AWS CloudFormation schema. The CloudFormation docs are more complete and accurate in these cases.
+// The documentation of some resources/properties is incomplete or incorrect in the AWS CloudFormation schema. The
+// CloudFormation docs are more complete and accurate in these cases.
 var forceDocumentationAugmentation = map[string]bool{
 	// Documentation is truncated
 	"AWS::EC2::Volume":      true,
@@ -71,8 +73,16 @@ func GatherPackage(
 		Type:        "object",
 		Description: "A set of tags to apply to the resource.",
 		Properties: map[string]pschema.PropertySpec{
-			"key":   {TypeSpec: primitiveTypeSpec("String"), Description: "The key name of the tag", ReplaceOnChanges: true},
-			"value": {TypeSpec: primitiveTypeSpec("String"), Description: "The value of the tag", ReplaceOnChanges: true},
+			"key": {
+				TypeSpec:         primitiveTypeSpec("String"),
+				Description:      "The key name of the tag",
+				ReplaceOnChanges: true,
+			},
+			"value": {
+				TypeSpec:         primitiveTypeSpec("String"),
+				Description:      "The value of the tag",
+				ReplaceOnChanges: true,
+			},
 		},
 		Required: []string{"key", "value"},
 	}
@@ -96,11 +106,13 @@ func GatherPackage(
 		Config: pschema.ConfigSpec{
 			Variables: map[string]pschema.PropertySpec{
 				"accessKey": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The access key for API operations. You can retrieve this from the ‘Security & Credentials’ section of the AWS console.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 					Secret:      true,
 				},
 				"allowedAccountIds": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one. Conflicts with `forbiddenAccountIds`.",
 					TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 				},
@@ -109,10 +121,12 @@ func GatherPackage(
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:config:AssumeRole"},
 				},
 				"roleArn": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role for Cloud Control API to use when performing this resource operation. Note, this is a unique feature for server side security enforcement, not to be confused with assumeRole, which is used to obtain temporary client credentials. If you do not specify a role, Cloud Control API uses a temporary session created using your AWS user credentials instead.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"defaultTags": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Configuration block with resource tag settings to apply across all resources handled by this provider. This is designed to replace redundant per-resource `tags` configurations. Provider tags can be overridden with new values, but not excluded from specific resources. To override provider tag values, use the `tags` argument within a resource to configure new tag values for matching keys.",
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:config:DefaultTags"},
 				},
@@ -121,22 +135,27 @@ func GatherPackage(
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:config:Endpoints"},
 				},
 				"forbiddenAccountIds": {
-					TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
+					TypeSpec: pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "List of forbidden AWS account IDs to prevent you from mistakenly using the wrong one (and potentially end up destroying a live environment). Conflicts with `allowedAccountIds`.",
 				},
 				"ignoreTags": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Configuration block with resource tag settings to ignore across all resources handled by this provider (except any individual service tag resources such as `ec2.Tag`) for situations where external systems are managing certain resource tags.",
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:config:IgnoreTags"},
 				},
 				"insecure": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted,default value is `false`.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"maxRetries": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.",
 					TypeSpec:    pschema.TypeSpec{Type: "integer"},
 				},
 				"profile": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The profile for API operations. If not set, the default profile created with `aws configure` will be used.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
@@ -148,10 +167,12 @@ func GatherPackage(
 					},
 				},
 				"s3UsePathStyle": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Set this to true to use path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing when possible (`http://BUCKET.s3.amazonaws.com/KEY`). Specific to the Amazon S3 service.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"secretKey": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 					Secret:      true,
@@ -161,30 +182,36 @@ func GatherPackage(
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"skipCredentialsValidation": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipGetEc2Platforms": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip getting the supported EC2 platforms. Used by users that don't have `ec2:DescribeAccountAttributes` permissions.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipMetadataApiCheck": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. Setting to true prevents Pulumi from authenticating via the Metadata API. You may need to use other authentication methods like static credentials, configuration variables, or environment variables.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipRegionValidation": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip static validation of region name. Used by users of alternative AWS-like APIs or users with access to regions that are not public.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipRequestingAccountId": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"token": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Session token for validating temporary credentials. Typically provided after successful identity federation or Multi-Factor Authentication (MFA) login. With MFA login, this is the session token provided afterward, not the 6 digit MFA code used to get temporary credentials.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 					Secret:      true,
@@ -200,9 +227,11 @@ func GatherPackage(
 		},
 		Provider: &pschema.ResourceSpec{
 			ObjectTypeSpec: pschema.ObjectTypeSpec{
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "The provider type for the AWS Cloud Control package. By default, resources use package-wide configuration settings, however an explicit `Provider` instance may be created and passed during resource construction to achieve fine-grained programmatic control over provider settings. See the [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.",
 				Properties: map[string]pschema.PropertySpec{
 					"allowedAccountIds": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one. Conflicts with `forbiddenAccountIds`.",
 						TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 					},
@@ -211,34 +240,44 @@ func GatherPackage(
 						TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderAssumeRole"},
 					},
 					"roleArn": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role for Cloud Control API to use when performing this resource operation. Note, this is a unique feature for server side security enforcement, not to be confused with assumeRole, which is used to obtain temporary client credentials. If you do not specify a role, Cloud Control API uses a temporary session created using your AWS user credentials instead.",
 						TypeSpec:    pschema.TypeSpec{Type: "string"},
 					},
 					"defaultTags": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Configuration block with resource tag settings to apply across all resources handled by this provider. This is designed to replace redundant per-resource `tags` configurations. Provider tags can be overridden with new values, but not excluded from specific resources. To override provider tag values, use the `tags` argument within a resource to configure new tag values for matching keys.",
 						TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderDefaultTags"},
 					},
 					"endpoints": {
 						Description: "Configuration block for customizing service endpoints.",
-						TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderEndpoint"}},
+						TypeSpec: pschema.TypeSpec{
+							Type:  "array",
+							Items: &pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderEndpoint"},
+						},
 					},
 					"forbiddenAccountIds": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "List of forbidden AWS account IDs to prevent you from mistakenly using the wrong one (and potentially end up destroying a live environment). Conflicts with `allowedAccountIds`.",
 						TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 					},
 					"ignoreTags": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Configuration block with resource tag settings to ignore across all resources handled by this provider (except any individual service tag resources such as `ec2.Tag`) for situations where external systems are managing certain resource tags.",
 						TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderIgnoreTags"},
 					},
 					"insecure": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted,default value is `false`.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
 					"maxRetries": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.",
 						TypeSpec:    pschema.TypeSpec{Type: "integer"},
 					},
 					"profile": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "The profile for API operations. If not set, the default profile created with `aws configure` will be used.",
 						TypeSpec:    pschema.TypeSpec{Type: "string"},
 					},
@@ -250,6 +289,7 @@ func GatherPackage(
 						},
 					},
 					"s3UsePathStyle": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Set this to true to use path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing when possible (`http://BUCKET.s3.amazonaws.com/KEY`). Specific to the Amazon S3 service.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
@@ -258,22 +298,27 @@ func GatherPackage(
 						TypeSpec:    pschema.TypeSpec{Type: "string"},
 					},
 					"skipCredentialsValidation": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
 					"skipGetEc2Platforms": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Skip getting the supported EC2 platforms. Used by users that don't have `ec2:DescribeAccountAttributes` permissions.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
 					"skipMetadataApiCheck": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. Setting to true prevents Pulumi from authenticating via the Metadata API. You may need to use other authentication methods like static credentials, configuration variables, or environment variables.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
 					"skipRegionValidation": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Skip static validation of region name. Used by users of alternative AWS-like APIs or users with access to regions that are not public.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
 					"skipRequestingAccountId": {
+						//nolint:lll // Preserve the exact fixture or documentation text.
 						Description: "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 						TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 					},
@@ -285,11 +330,13 @@ func GatherPackage(
 			},
 			InputProperties: map[string]pschema.PropertySpec{
 				"accessKey": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The access key for API operations. You can retrieve this from the ‘Security & Credentials’ section of the AWS console.",
 					Secret:      true,
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"allowedAccountIds": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "List of allowed AWS account IDs to prevent you from mistakenly using an incorrect one. Conflicts with `forbiddenAccountIds`.",
 					TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 				},
@@ -298,30 +345,39 @@ func GatherPackage(
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderAssumeRole"},
 				},
 				"roleArn": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role for Cloud Control API to use when performing this resource operation. Note, this is a unique feature for server side security enforcement, not to be confused with assumeRole, which is used to obtain temporary client credentials. If you do not specify a role, Cloud Control API uses a temporary session created using your AWS user credentials instead.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"defaultTags": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Configuration block with resource tag settings to apply across all resources handled by this provider. This is designed to replace redundant per-resource `tags` configurations. Provider tags can be overridden with new values, but not excluded from specific resources. To override provider tag values, use the `tags` argument within a resource to configure new tag values for matching keys.",
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderDefaultTags"},
 				},
 				"endpoints": {
 					Description: "Configuration block for customizing service endpoints.",
-					TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderEndpoint"}},
+					TypeSpec: pschema.TypeSpec{
+						Type:  "array",
+						Items: &pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderEndpoint"},
+					},
 				},
 				"forbiddenAccountIds": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "List of forbidden AWS account IDs to prevent you from mistakenly using the wrong one (and potentially end up destroying a live environment). Conflicts with `allowedAccountIds`.",
 					TypeSpec:    pschema.TypeSpec{Type: "array", Items: &pschema.TypeSpec{Type: "string"}},
 				},
 				"ignoreTags": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Configuration block with resource tag settings to ignore across all resources handled by this provider (except any individual service tag resources such as `ec2.Tag`) for situations where external systems are managing certain resource tags.",
 					TypeSpec:    pschema.TypeSpec{Ref: "#/types/aws-native:index:ProviderIgnoreTags"},
 				},
 				"insecure": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted,default value is `false`.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"maxRetries": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.",
 					TypeSpec:    pschema.TypeSpec{Type: "integer"},
 				},
@@ -331,6 +387,7 @@ func GatherPackage(
 							"AWS_PROFILE",
 						},
 					},
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The profile for API operations. If not set, the default profile created with `aws configure` will be used.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
@@ -348,10 +405,12 @@ func GatherPackage(
 					},
 				},
 				"s3UsePathStyle": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Set this to true to use path-style addressing, i.e., `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use virtual hosted bucket addressing when possible (`http://BUCKET.s3.amazonaws.com/KEY`). Specific to the Amazon S3 service.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"secretKey": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.",
 					Secret:      true,
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
@@ -366,30 +425,36 @@ func GatherPackage(
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
 				},
 				"skipCredentialsValidation": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipGetEc2Platforms": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip getting the supported EC2 platforms. Used by users that don't have `ec2:DescribeAccountAttributes` permissions.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipMetadataApiCheck": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip the AWS Metadata API check. Useful for AWS API implementations that do not have a metadata API endpoint. Setting to true prevents Pulumi from authenticating via the Metadata API. You may need to use other authentication methods like static credentials, configuration variables, or environment variables.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipRegionValidation": {
-					Default:     true,
+					Default: true,
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip static validation of region name. Used by users of alternative AWS-like APIs or users with access to regions that are not public.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"skipRequestingAccountId": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"token": {
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Session token for validating temporary credentials. Typically provided after successful identity federation or Multi-Factor Authentication (MFA) login. With MFA login, this is the session token provided afterward, not the 6 digit MFA code used to get temporary credentials.",
 					Secret:      true,
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
@@ -507,7 +572,7 @@ func GatherPackage(
 			if val == "0" {
 				continue
 			}
-			missingCount += 1
+			missingCount++
 		}
 	}
 	fmt.Printf("Number of docs augmented: %d\n", reports.DocsUpdated)
@@ -544,7 +609,8 @@ func GatherPackage(
 					Description: "Identifier of the current partition (e.g., `aws` in AWS Commercial, `aws-cn` in AWS China).",
 				},
 				"dnsSuffix": {
-					TypeSpec:    primitiveTypeSpec("String"),
+					TypeSpec: primitiveTypeSpec("String"),
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					Description: "Base DNS domain name for the current partition (e.g., `amazonaws.com` in AWS Commercial, `amazonaws.com.cn` in AWS China).",
 				},
 			},
@@ -677,19 +743,37 @@ type cfSchemaContext struct {
 	docs             *Docs
 }
 
-func (ctx *cfSchemaContext) markCreateOnlyProperties(createOnlyProperties codegen.StringSet, resource *pschema.ResourceSpec) error {
+func (ctx *cfSchemaContext) markCreateOnlyProperties(
+	createOnlyProperties codegen.StringSet,
+	resource *pschema.ResourceSpec,
+) error {
 	errs := []error{}
 	for _, propPath := range createOnlyProperties.SortedValues() {
 		// each path in createOnlyProperties is delimited with "/"
 		path := strings.Split(propPath, "/")
 		prop, ok := resource.Properties[path[0]]
 		if !ok {
-			errs = append(errs, errors.Errorf("Could not mark createOnlyProperty %s in %s as replaceOnChanges: property not found on Resource", propPath, ctx.cfTypeName))
+			errs = append(
+				errs,
+				errors.Errorf(
+					"Could not mark createOnlyProperty %s in %s as replaceOnChanges: property not found on Resource",
+					propPath,
+					ctx.cfTypeName,
+				),
+			)
 			continue
 		}
 		err := ctx.markCreateOnlyProperty(path[1:], &prop)
 		if err != nil {
-			errs = append(errs, errors.Wrapf(err, "Could not mark createOnlyProperty %s in %s as replaceOnChanges", propPath, ctx.cfTypeName))
+			errs = append(
+				errs,
+				errors.Wrapf(
+					err,
+					"Could not mark createOnlyProperty %s in %s as replaceOnChanges",
+					propPath,
+					ctx.cfTypeName,
+				),
+			)
 		}
 		resource.Properties[path[0]] = prop
 	}
@@ -717,7 +801,8 @@ func (ctx *cfSchemaContext) markCreateOnlyProperty(propPath []string, property *
 	}
 
 	// Next try looking at it as an array of objects
-	if property.Items != nil && len(property.Items.Ref) != 0 && !strings.HasPrefix(property.Items.Ref, "#/types/aws-native:index") {
+	if property.Items != nil && len(property.Items.Ref) != 0 &&
+		!strings.HasPrefix(property.Items.Ref, "#/types/aws-native:index") {
 		typeRef := property.Items.Ref
 		if len(typeRef) == 0 {
 			return errors.Errorf("Property does not reference an array: %v", property)
@@ -968,7 +1053,12 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 
 	}
 
-	autoNamingSpec := autonaming.CreateAutoNamingSpec(inputProperties, resourceTypeName, ctx.resourceSpec.Properties, ctx.semantics.Resources[ctx.resourceToken])
+	autoNamingSpec := autonaming.CreateAutoNamingSpec(
+		inputProperties,
+		resourceTypeName,
+		ctx.resourceSpec.Properties,
+		ctx.semantics.Resources[ctx.resourceToken],
+	)
 	// If a field can be auto-named, its no longer required.
 	if autoNamingSpec != nil {
 		delete(requiredInputs, autoNamingSpec.SdkName)
@@ -982,7 +1072,11 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 	ctx.updateDesc(ctx.cfTypeName, "", ctx.resourceSpec)
 	var deprecationMessage string
 	if !ctx.isSupported {
-		deprecationMessage = fmt.Sprintf("%s is not yet supported by AWS Cloud Control, so its creation will currently fail. Please use the classic AWS provider, if possible.", resourceTypeName)
+		deprecationMessage = fmt.Sprintf(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"%s is not yet supported by AWS Cloud Control, so its creation will currently fail. Please use the classic AWS provider, if possible.",
+			resourceTypeName,
+		)
 	}
 	resourceSpec := pschema.ResourceSpec{
 		ObjectTypeSpec: pschema.ObjectTypeSpec{
@@ -1231,7 +1325,11 @@ func (ctx *cfSchemaContext) gatherListHandlerSchema() (*metadata.ListHandlerSche
 		}
 		prop := ctx.listHandlerPropertyFromResourceProperty(requiredName)
 		if prop.Description == "" && prop.Type == "" {
-			return nil, fmt.Errorf("required list handler property %q for %s has no schema", requiredName, ctx.cfTypeName)
+			return nil, fmt.Errorf(
+				"required list handler property %q for %s has no schema",
+				requiredName,
+				ctx.cfTypeName,
+			)
 		}
 		if result.Properties == nil {
 			result.Properties = map[string]metadata.ListHandlerProperty{}
@@ -1401,7 +1499,11 @@ func addUntypedPropDocs(propertySpec *pschema.PropertySpec, cfTypeName string) {
 		if propertySpec.Description != "" {
 			propertySpec.Description += "\n\n"
 		}
-		propertySpec.Description += fmt.Sprintf("Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `%s` for more information about the expected schema for this property.", cfTypeName)
+		propertySpec.Description += fmt.Sprintf(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"Search the [CloudFormation User Guide](https://docs.aws.amazon.com/cloudformation/) for `%s` for more information about the expected schema for this property.",
+			cfTypeName,
+		)
 	}
 }
 
@@ -1421,7 +1523,10 @@ func (ctx *cfSchemaContext) reportMissingDocs(desc, propName string) {
 	}
 }
 
-func (ctx *cfSchemaContext) propertySpec(propName, resourceTypeName string, spec *jsschema.Schema) (*pschema.PropertySpec, error) {
+func (ctx *cfSchemaContext) propertySpec(
+	propName, resourceTypeName string,
+	spec *jsschema.Schema,
+) (*pschema.PropertySpec, error) {
 	typeSpec, err := ctx.propertyTypeSpec(naming.LowerAcronyms(propName), spec)
 	if err != nil {
 		return nil, err
@@ -1437,7 +1542,7 @@ func (ctx *cfSchemaContext) propertySpec(propName, resourceTypeName string, spec
 	// If the property name is the same as the resource type name, we need to rename the property's C# name
 	// to avoid 'member names cannot be the same as their enclosing type'. We normalize the property and resource
 	// type names to lowercase to avoid case sensitivity issues.
-	if strings.ToLower(resourceTypeName) == strings.ToLower(propName) {
+	if strings.EqualFold(resourceTypeName, propName) {
 		propertySpec.Language = map[string]pschema.RawMessage{
 			"csharp": rawMessage(dotnetgen.CSharpPropertyInfo{
 				Name: propName + "Value",
@@ -1460,7 +1565,7 @@ func (ctx *cfSchemaContext) updateDesc(refName, propName string, spec *jsschema.
 		spec.Description = desc
 		// if it has been updated then increment the count
 		if spec.Description != "" {
-			ctx.reports.DocsUpdated += 1
+			ctx.reports.DocsUpdated++
 		}
 
 		if !found {
@@ -1475,10 +1580,13 @@ func (ctx *cfSchemaContext) updateDesc(refName, propName string, spec *jsschema.
 	} else if _, ok := forceDocumentationAugmentation[fullyQualifiedPropertyName]; ok {
 		if desc, found := ctx.docs.GetPropertyDesc(refName, propName); found {
 			spec.Description = desc
-			ctx.reports.DocsUpdated += 1
+			ctx.reports.DocsUpdated++
 		} else {
 			ctx.reportMissingDocs(desc, propName)
-			fmt.Printf("Description augmentation configured for type %s but CloudFormation Docs do not include description\n", fullyQualifiedPropertyName)
+			fmt.Printf(
+				"Description augmentation configured for type %s but CloudFormation Docs do not include description\n",
+				fullyQualifiedPropertyName,
+			)
 		}
 	}
 }
@@ -1513,7 +1621,7 @@ func (ctx *cfSchemaContext) augmentDocumentation(referenceName, propName string,
 			refName := fmt.Sprintf("%s.%s", ctx.cfTypeName, schemaName)
 
 			if len(typeSchema.Type) == 1 {
-				if typeSchema.PatternProperties != nil && len(typeSchema.PatternProperties) == 1 {
+				if len(typeSchema.PatternProperties) == 1 {
 					for _, schema := range typeSchema.PatternProperties {
 						ctx.augmentDocumentation(refName, schemaName, schema)
 					}
@@ -1547,7 +1655,7 @@ func (ctx *cfSchemaContext) augmentDocumentation(referenceName, propName string,
 		}
 	}
 
-	if spec.PatternProperties != nil && len(spec.PatternProperties) == 1 {
+	if len(spec.PatternProperties) == 1 {
 		for _, schema := range spec.PatternProperties {
 			ctx.augmentDocumentation(referenceName, propName, schema)
 		}
@@ -1569,7 +1677,10 @@ func (ctx *cfSchemaContext) augmentDocumentation(referenceName, propName string,
 }
 
 // propertyTypeSpec converts a JSON type definition to a Pulumi type definition.
-func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jsschema.Schema) (*pschema.TypeSpec, error) {
+func (ctx *cfSchemaContext) propertyTypeSpec(
+	parentName string,
+	propSchema *jsschema.Schema,
+) (*pschema.TypeSpec, error) {
 	propSchema = NormaliseTypes(propSchema)
 
 	// References to other type definitions.
@@ -1606,7 +1717,7 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 		var mapType *jsschema.Schema
 		if typeSchema.AdditionalProperties != nil && typeSchema.AdditionalProperties.Schema != nil {
 			mapType = typeSchema.AdditionalProperties.Schema
-		} else if typeSchema.PatternProperties != nil && len(typeSchema.PatternProperties) == 1 {
+		} else if len(typeSchema.PatternProperties) == 1 {
 			// TODO: Capture pattern add add to documentation or even provider metadata for early validation feedback.
 			// https://github.com/pulumi/pulumi-aws-native/issues/1346
 			for _, schema := range typeSchema.PatternProperties {
@@ -1620,7 +1731,8 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 				return nil, err
 			}
 
-			// Where a map type has a value which is either a map or a list, replace the value with "Any" to appease Go codegen
+			// Where a map type has a value which is either a map or a list, replace the value with "Any" to appease Go
+			// codegen
 			// TODO: remove once Go codegen issue is solved: https://github.com/pulumi/pulumi/issues/15478
 			if valueType.Items != nil || valueType.AdditionalProperties != nil {
 				valueType = &pschema.TypeSpec{
@@ -1664,9 +1776,8 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 
 			referencedTypeName := fmt.Sprintf("#/types/%s", tok)
 			return &pschema.TypeSpec{Ref: referencedTypeName}, nil
-		} else {
-			return ctx.propertyTypeSpec(typName, typeSchema)
 		}
+		return ctx.propertyTypeSpec(typName, typeSchema)
 	}
 
 	// Inline properties.
@@ -1740,9 +1851,8 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 
 		if len(types) == 1 {
 			return &types[0], nil
-		} else {
-			return &pschema.TypeSpec{OneOf: types}, nil
 		}
+		return &pschema.TypeSpec{OneOf: types}, nil
 	}
 
 	if len(propSchema.Enum) > 0 {
@@ -1758,7 +1868,7 @@ func (ctx *cfSchemaContext) propertyTypeSpec(parentName string, propSchema *jssc
 	var mapType *jsschema.Schema
 	if propSchema.AdditionalProperties != nil && propSchema.AdditionalProperties.Schema != nil {
 		mapType = propSchema.AdditionalProperties.Schema
-	} else if propSchema.PatternProperties != nil && len(propSchema.PatternProperties) == 1 {
+	} else if len(propSchema.PatternProperties) == 1 {
 		// TODO: Capture pattern add add to documentation or even provider metadata for early validation feedback.
 		// https://github.com/pulumi/pulumi-aws-native/issues/1346
 		for _, schema := range propSchema.PatternProperties {
@@ -1830,7 +1940,10 @@ func parseJsonType(t jsschema.PrimitiveType) pschema.TypeSpec {
 	}
 }
 
-func (ctx *cfSchemaContext) genProperties(parentName string, typeSchema *jsschema.Schema) (map[string]pschema.PropertySpec, codegen.StringSet, map[string]string, error) {
+func (ctx *cfSchemaContext) genProperties(
+	parentName string,
+	typeSchema *jsschema.Schema,
+) (map[string]pschema.PropertySpec, codegen.StringSet, map[string]string, error) {
 	specs := map[string]pschema.PropertySpec{}
 	requiredSpecs := codegen.NewStringSet()
 	irreversibleNames := map[string]string{}
@@ -1935,7 +2048,9 @@ func (ctx *cfSchemaContext) genEnumType(enumName string, propSchema *jsschema.Sc
 		}
 
 		// Enum values cannot end in `*Input` or `*Output`. Special casing these instances
-		if (typName == "FlowNodeType" || typName == "FlowVersionFlowNodeType" || typName == "ConfiguredModelAlgorithmAssociationTrainedModelExportFileType") && (str == "Input" || str == "Output") {
+		//nolint:lll // Preserve the exact fixture or documentation text.
+		if (typName == "FlowNodeType" || typName == "FlowVersionFlowNodeType" || typName == "ConfiguredModelAlgorithmAssociationTrainedModelExportFileType") &&
+			(str == "Input" || str == "Output") {
 			str = str + "Type"
 		}
 		values.Add(str)
@@ -1985,7 +2100,7 @@ var pseudoParameters = map[string]string{
 
 func rawMessage(v interface{}) pschema.RawMessage {
 	bytes, err := json.Marshal(v)
-	contract.Assert(err == nil)
+	contract.Assertf(err == nil, "converting enum value: %v", err)
 	return bytes
 }
 

--- a/provider/pkg/schema/gen_examples_test.go
+++ b/provider/pkg/schema/gen_examples_test.go
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation.
 
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package schema
 
 import (
@@ -11,9 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	jsschema "github.com/pulumi/jsschema"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 type PropertyTypeSpecTestCase struct {
@@ -109,7 +111,7 @@ func TestPropertyTypeSpec(t *testing.T) {
 			}`,
 		expected: pschema.TypeSpec{Type: "string"},
 	}))
-	t.Run("oneOf-primatives", test(PropertyTypeSpecTestCase{
+	t.Run("oneOf-primitives", test(PropertyTypeSpecTestCase{
 		json: `{
 				"oneOf": [
 					{"type": "string"},
@@ -120,7 +122,7 @@ func TestPropertyTypeSpec(t *testing.T) {
 			OneOf: []pschema.TypeSpec{{Type: "string"}, {Type: "number"}},
 		},
 	}))
-	t.Run("anyOf-primatives", test(PropertyTypeSpecTestCase{
+	t.Run("anyOf-primitives", test(PropertyTypeSpecTestCase{
 		json: `{
 				"anyOf": [
 					{"type": "string"},
@@ -418,12 +420,12 @@ func TestMarkCreateOnlyProperties(t *testing.T) {
 
 	typesWithReplaceOnChangesBar := newBaseTypes()
 	modifedObjT := typesWithReplaceOnChangesBar["obj"]
-	modifedObjT.ObjectTypeSpec.Properties["bar"] = pschema.PropertySpec{ReplaceOnChanges: true}
+	modifedObjT.Properties["bar"] = pschema.PropertySpec{ReplaceOnChanges: true}
 	typesWithReplaceOnChangesBar["obj"] = modifedObjT
 
 	typesWithReplaceOnChangesZZ := newBaseTypes()
 	modifedObj2T := typesWithReplaceOnChangesZZ["obj2"]
-	modifedObj2T.ObjectTypeSpec.Properties["zz"] = pschema.PropertySpec{ReplaceOnChanges: true}
+	modifedObj2T.Properties["zz"] = pschema.PropertySpec{ReplaceOnChanges: true}
 	typesWithReplaceOnChangesZZ["obj2"] = modifedObj2T
 
 	cases := []MarkCreateOnlyPropertiesTestCase{
@@ -437,13 +439,15 @@ func TestMarkCreateOnlyProperties(t *testing.T) {
 			createOnlyProperties: codegen.NewStringSet("obj/quxx"),
 			resourceSpec:         newBaseResourceSpec(),
 			types:                newBaseTypes(),
-			expectedErr:          "Could not mark createOnlyProperty obj/quxx in  as replaceOnChanges: Type #/types/obj does not have property named 'quxx'",
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			expectedErr: "Could not mark createOnlyProperty obj/quxx in  as replaceOnChanges: Type #/types/obj does not have property named 'quxx'",
 		},
 		{
 			createOnlyProperties: codegen.NewStringSet("foo/quxx"),
 			resourceSpec:         newBaseResourceSpec(),
 			types:                newBaseTypes(),
-			expectedErr:          "Could not mark createOnlyProperty foo/quxx in  as replaceOnChanges: Property is not a Ref or Array[Ref], can't traverse",
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			expectedErr: "Could not mark createOnlyProperty foo/quxx in  as replaceOnChanges: Property is not a Ref or Array[Ref], can't traverse",
 		},
 		{
 			createOnlyProperties: codegen.NewStringSet("foo"),

--- a/provider/pkg/schema/gen_list_handler_schema_test.go
+++ b/provider/pkg/schema/gen_list_handler_schema_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep schema fixtures readable.
 package schema
 
 import (

--- a/provider/pkg/schema/gen_report.go
+++ b/provider/pkg/schema/gen_report.go
@@ -12,7 +12,8 @@ import (
 )
 
 type Reports struct {
-	// UnexpectedTagsShapes is a map of the resource token of resources which have a `Tags` field but don't match an expected pattern.
+	// UnexpectedTagsShapes is a map of the resource token of resources which have a `Tags` field but don't match an
+	// expected pattern.
 	UnexpectedTagsShapes map[string]interface{}
 	// MissedAutonaming is a map of the resource token of resources we haven't identified as autonameable.
 	MissedAutonaming map[string]interface{}

--- a/provider/pkg/schema/gen_tags.go
+++ b/provider/pkg/schema/gen_tags.go
@@ -1,15 +1,23 @@
+//nolint:goconst // Repeated domain and schema vocabulary is clearer inline.
 package schema
 
 import (
 	"strings"
 
 	jsschema "github.com/pulumi/jsschema"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 	"github.com/pulumi/pulumi-aws-native/provider/pkg/naming"
-	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
-func (ctx *cfSchemaContext) ApplyTagsTransformation(propName string, propertySpec *pschema.PropertySpec, spec *jsschema.Schema) default_tags.TagsStyle {
+const jsonStringType = "string"
+
+func (ctx *cfSchemaContext) ApplyTagsTransformation(
+	propName string,
+	propertySpec *pschema.PropertySpec,
+	spec *jsschema.Schema,
+) default_tags.TagsStyle {
 	tagsStyle := ctx.getTagsStyle(propName, &propertySpec.TypeSpec)
 	switch tagsStyle {
 	case default_tags.TagsStyleUntyped:
@@ -17,10 +25,10 @@ func (ctx *cfSchemaContext) ApplyTagsTransformation(propName string, propertySpe
 		// Nothing to do
 	case default_tags.TagsStyleKeyValueArray:
 		// Swap referenced type to shared definition and remove custom type.
-		propertySpec.TypeSpec.Items.Ref = "#/types/" + globalTagToken
+		propertySpec.Items.Ref = "#/types/" + globalTagToken
 	case default_tags.TagsStyleKeyValueArrayCreateOnly:
 		// Swap referenced type to shared definition and remove custom type.
-		propertySpec.TypeSpec.Items.Ref = "#/types/" + globalCreateOnlyTagToken
+		propertySpec.Items.Ref = "#/types/" + globalCreateOnlyTagToken
 	case default_tags.TagsStyleKeyValueArrayWithExtraProperties:
 		// Keep custom type
 	case default_tags.TagsStyleKeyValueArrayWithAlternateType:
@@ -72,7 +80,7 @@ func (ctx *cfSchemaContext) getTagsStyle(propName string, typeSpec *pschema.Type
 		return default_tags.TagsStyleUntyped
 	}
 
-	if typeSpec.AdditionalProperties != nil && typeSpec.AdditionalProperties.Type == "string" {
+	if typeSpec.AdditionalProperties != nil && typeSpec.AdditionalProperties.Type == jsonStringType {
 		return default_tags.TagsStyleStringMap
 	}
 
@@ -88,7 +96,10 @@ func (ctx *cfSchemaContext) getTagsStyle(propName string, typeSpec *pschema.Type
 	return default_tags.TagsStyleUnknown
 }
 
-func (ctx *cfSchemaContext) tagStyleIsKeyValueArray(propName string, typeSpec *pschema.TypeSpec) (bool, default_tags.TagsStyle) {
+func (ctx *cfSchemaContext) tagStyleIsKeyValueArray(
+	_ string,
+	typeSpec *pschema.TypeSpec,
+) (bool, default_tags.TagsStyle) {
 	if typeSpec == nil || typeSpec.Items == nil {
 		return false, default_tags.TagsStyleUnknown
 	}
@@ -106,7 +117,9 @@ func (ctx *cfSchemaContext) tagStyleIsKeyValueArray(propName string, typeSpec *p
 				}
 				return true, default_tags.TagsStyleKeyValueArray
 			}
-			if hasNestedTagsPropertyAndResourceType := hasNestedTagsPropertyAndResourceTypeProperty(&refType); hasNestedTagsPropertyAndResourceType {
+			if hasNestedTagsPropertyAndResourceType := hasNestedTagsPropertyAndResourceTypeProperty(
+				&refType,
+			); hasNestedTagsPropertyAndResourceType {
 				return true, default_tags.TagsStyleNestedKeyValueArrayWithResourceType
 			}
 		}
@@ -133,10 +146,11 @@ func (ctx *cfSchemaContext) isPropCreateOnly(propName string) bool {
 	return createOnlyProps.Has(naming.ToSdkName(propName))
 }
 
-// hasNestedTagsPropertyAndResourceTypeProperty checks if the type has a "Tags" property that is an array, and a "ResourceType" property that is a string.
-// These type of tags cannot be part of the "defaultTags" functionality because you have to specify the specific "ResourceType"
-// that you want to apply tags to. If you specify an invalid type it will error. An example of this is things like LaunchTemplates which might end
-// up creating multiple resources of different types. It will create an EC2 Instance and that instance will have Volumes, etc. The tag
+// hasNestedTagsPropertyAndResourceTypeProperty checks if the type has a "Tags" property that is an array, and a
+// "ResourceType" property that is a string. These type of tags cannot be part of the "defaultTags" functionality
+// because you have to specify the specific "ResourceType" that you want to apply tags to. If you specify an invalid
+// type it will error. An example of this is things like LaunchTemplates which might end up creating multiple resources
+// of different types. It will create an EC2 Instance and that instance will have Volumes, etc. The tag
 // specification can control the tag values per resource type
 func hasNestedTagsPropertyAndResourceTypeProperty(typeSpec *pschema.ComplexTypeSpec) bool {
 	if typeSpec == nil || typeSpec.Properties == nil {
@@ -144,17 +158,21 @@ func hasNestedTagsPropertyAndResourceTypeProperty(typeSpec *pschema.ComplexTypeS
 	}
 	tagsProp, tagsPropExists := typeSpec.Properties["tags"]
 	resourceTypeProp, resourceTypePropExists := typeSpec.Properties["resourceType"]
-	return tagsPropExists && resourceTypePropExists && tagsProp.Type == "array" && resourceTypeProp.Type == "string"
+	return tagsPropExists && resourceTypePropExists && tagsProp.Type == "array" &&
+		resourceTypeProp.Type == jsonStringType
 }
 
-func hasKeyValueStringPropertiesAndAdditions(typeSpec *pschema.ComplexTypeSpec) (hasKeyValueStringProperties bool, hasExtraProperties bool) {
+func hasKeyValueStringPropertiesAndAdditions(
+	typeSpec *pschema.ComplexTypeSpec,
+) (hasKeyValueStringProperties bool, hasExtraProperties bool) {
 	if typeSpec == nil || typeSpec.Properties == nil {
 		return false, false
 	}
 	keyProp, keyPropExists := typeSpec.Properties["key"]
 	valueProp, valuePropExists := typeSpec.Properties["value"]
 	// Check if the type has exactly two properties, "key" and "value", both of type "string"
-	hasKeyValueStrings := keyPropExists && valuePropExists && keyProp.Type == "string" && valueProp.Type == "string"
+	hasKeyValueStrings := keyPropExists && valuePropExists && keyProp.Type == jsonStringType &&
+		valueProp.Type == jsonStringType
 	if !hasKeyValueStrings {
 		return false, false
 	}

--- a/provider/pkg/schema/gen_tags_test.go
+++ b/provider/pkg/schema/gen_tags_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep table-driven test fixtures readable.
 package schema
 
 import (
@@ -6,11 +7,13 @@ import (
 	"path"
 	"testing"
 
-	jsschema "github.com/pulumi/jsschema"
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	jsschema "github.com/pulumi/jsschema"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/default_tags"
 )
 
 func TestGetTagsStyle(t *testing.T) {
@@ -157,5 +160,10 @@ func TestNoUnexpectedTagsShapes(t *testing.T) {
 	var unexpectedTagsShapes map[string]interface{}
 	err = json.Unmarshal(bytes, &unexpectedTagsShapes)
 	require.NoError(t, err)
-	assert.Empty(t, unexpectedTagsShapes, "reports/unexpectedTagsShapes.json should be empty, which means that we need to update getTagsStyle in gen_tags.go to cover new tags variations.")
+	assert.Empty(
+		t,
+		unexpectedTagsShapes,
+		//nolint:lll // Preserve the exact fixture or documentation text.
+		"reports/unexpectedTagsShapes.json should be empty, which means that we need to update getTagsStyle in gen_tags.go to cover new tags variations.",
+	)
 }

--- a/provider/pkg/schema/gen_test.go
+++ b/provider/pkg/schema/gen_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep schema and documentation fixtures readable.
 package schema
 
 import (
@@ -5,15 +6,21 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	jsschema "github.com/pulumi/jsschema"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/stretchr/testify/assert"
 )
 
 func marshalSpec(spec map[string]interface{}) *jsschema.Schema {
 	var s *jsschema.Schema
-	jsonSpec, _ := json.Marshal(spec)
-	json.Unmarshal(jsonSpec, &s)
+	jsonSpec, err := json.Marshal(spec)
+	if err != nil {
+		panic(fmt.Sprintf("marshaling test schema: %v", err))
+	}
+	if err := json.Unmarshal(jsonSpec, &s); err != nil {
+		panic(fmt.Sprintf("unmarshaling test schema: %v", err))
+	}
 	return s
 }
 
@@ -30,7 +37,12 @@ func runTest(t *testing.T, spec map[string]interface{}, docs Docs) (*schema.Pack
 	})
 }
 
-func runTestWithRegions(t *testing.T, spec map[string]interface{}, docs Docs, regions []RegionInfo) (*schema.PackageSpec, *Reports) {
+func runTestWithRegions(
+	t *testing.T,
+	spec map[string]interface{},
+	docs Docs,
+	regions []RegionInfo,
+) (*schema.PackageSpec, *Reports) {
 	s := marshalSpec(spec)
 	semanticsDocument, err := GatherSemantics("../../../provider/cmd/pulumi-resource-aws-native")
 	if err != nil {
@@ -111,11 +123,13 @@ func TestGatherPackage_docs_refProperty(t *testing.T) {
 			"AWS::Events::Rule.Target": {
 				Description: "", // want to make sure we don't pick this one
 				Properties: map[string]string{
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"Id": "The ID of the target within the specified rule. Use this ID to reference the target when updating the rule. We recommend using a memorable and unique string.",
 				},
 			},
 			"AWS::Events::Rule": {
 				Properties: map[string]string{
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"Targets": "Adds the specified targets to the specified rule, or updates the targets if they are already associated with the rule.\n\nTargets are the resources that are invoked when a rule is triggered.\n\nThe maximum number of entries per request is 10.\n\n> Each rule can have up to five (5) targets associated with it at one time. \n\nFor a list of services you can configure as targets for events, see [EventBridge targets](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html) in the *Amazon EventBridge User Guide* .\n\nCreating rules with built-in targets is supported only in the AWS Management Console . The built-in targets are:\n\n- `Amazon EBS CreateSnapshot API call`\n- `Amazon EC2 RebootInstances API call`\n- `Amazon EC2 StopInstances API call`\n- `Amazon EC2 TerminateInstances API call`\n\nFor some target types, `PutTargets` provides target-specific parameters. If the target is a Kinesis data stream, you can optionally specify which shard the event goes to by using the `KinesisParameters` argument. To invoke a command on multiple EC2 instances with one rule, you can use the `RunCommandParameters` field.\n\nTo be able to make API calls against the resources that you own, Amazon EventBridge needs the appropriate permissions:\n\n- For AWS Lambda and Amazon SNS resources, EventBridge relies on resource-based policies.\n- For EC2 instances, Kinesis Data Streams, AWS Step Functions state machines and API Gateway APIs, EventBridge relies on IAM roles that you specify in the `RoleARN` argument in `PutTargets` .\n\nFor more information, see [Authentication and Access Control](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) in the *Amazon EventBridge User Guide* .\n\nIf another AWS account is in the same region and has granted you permission (using `PutPermission` ), you can send events to that account. Set that account's event bus as a target of the rules in your account. To send the matched events to the other account, specify that account's event bus as the `Arn` value when you run `PutTargets` . If your account sends events to another account, your account is charged for each sent event. Each event sent to another account is charged as a custom event. The account receiving the event is not charged. For more information, see [Amazon EventBridge Pricing](https://docs.aws.amazon.com/eventbridge/pricing/) .\n\n> `Input` , `InputPath` , and `InputTransformer` are not available with `PutTarget` if the target is an event bus of a different AWS account. \n\nIf you are setting the event bus of another account as the target, and that account granted permission to your account through an organization instead of directly by the account ID, then you must specify a `RoleArn` with proper permissions in the `Target` structure. For more information, see [Sending and Receiving Events Between AWS Accounts](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html) in the *Amazon EventBridge User Guide* .\n\n> If you have an IAM role on a cross-account event bus target, a `PutTargets` call without a role on the same target (same `Id` and `Arn` ) will not remove the role. \n\nFor more information about enabling cross-account events, see [PutPermission](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html) .\n\n*Input* , *InputPath* , and *InputTransformer* are mutually exclusive and optional parameters of a target. When a rule is triggered due to a matched event:\n\n- If none of the following arguments are specified for a target, then the entire event is passed to the target in JSON format (unless the target is Amazon EC2 Run Command or Amazon ECS task, in which case nothing from the event is passed to the target).\n- If *Input* is specified in the form of valid JSON, then the matched event is overridden with this constant.\n- If *InputPath* is specified in the form of JSONPath (for example, `$.detail` ), then only the part of the event specified in the path is passed to the target (for example, only the detail part of the event is passed).\n- If *InputTransformer* is specified, then one or more specified JSONPaths are extracted from the event and used as values in a template that you specify as the input to the target.\n\nWhen you specify `InputPath` or `InputTransformer` , you must use JSON dot notation, not bracket notation.\n\nWhen you add targets to a rule and the associated rule triggers soon after, new or updated targets might not be immediately invoked. Allow a short period of time for changes to take effect.\n\nThis action can partially fail if too many requests are made at the same time. If that happens, `FailedEntryCount` is non-zero in the response and each entry in `FailedEntries` provides the ID of the failed target and the error code.",
 				},
 			},
@@ -125,12 +139,14 @@ func TestGatherPackage_docs_refProperty(t *testing.T) {
 	packageSpec, _ := runTest(t, spec, docs)
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"The ID of the target within the specified rule. Use this ID to reference the target when updating the rule. We recommend using a memorable and unique string.",
 		packageSpec.Types["aws-native:events:RuleTarget"].Properties["id"].Description,
 	)
 
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"Adds the specified targets to the specified rule, or updates the targets if they are already associated with the rule.\n\nTargets are the resources that are invoked when a rule is triggered.\n\nThe maximum number of entries per request is 10.\n\n> Each rule can have up to five (5) targets associated with it at one time. \n\nFor a list of services you can configure as targets for events, see [EventBridge targets](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-targets.html) in the *Amazon EventBridge User Guide* .\n\nCreating rules with built-in targets is supported only in the AWS Management Console . The built-in targets are:\n\n- `Amazon EBS CreateSnapshot API call`\n- `Amazon EC2 RebootInstances API call`\n- `Amazon EC2 StopInstances API call`\n- `Amazon EC2 TerminateInstances API call`\n\nFor some target types, `PutTargets` provides target-specific parameters. If the target is a Kinesis data stream, you can optionally specify which shard the event goes to by using the `KinesisParameters` argument. To invoke a command on multiple EC2 instances with one rule, you can use the `RunCommandParameters` field.\n\nTo be able to make API calls against the resources that you own, Amazon EventBridge needs the appropriate permissions:\n\n- For AWS Lambda and Amazon SNS resources, EventBridge relies on resource-based policies.\n- For EC2 instances, Kinesis Data Streams, AWS Step Functions state machines and API Gateway APIs, EventBridge relies on IAM roles that you specify in the `RoleARN` argument in `PutTargets` .\n\nFor more information, see [Authentication and Access Control](https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html) in the *Amazon EventBridge User Guide* .\n\nIf another AWS account is in the same region and has granted you permission (using `PutPermission` ), you can send events to that account. Set that account's event bus as a target of the rules in your account. To send the matched events to the other account, specify that account's event bus as the `Arn` value when you run `PutTargets` . If your account sends events to another account, your account is charged for each sent event. Each event sent to another account is charged as a custom event. The account receiving the event is not charged. For more information, see [Amazon EventBridge Pricing](https://docs.aws.amazon.com/eventbridge/pricing/) .\n\n> `Input` , `InputPath` , and `InputTransformer` are not available with `PutTarget` if the target is an event bus of a different AWS account. \n\nIf you are setting the event bus of another account as the target, and that account granted permission to your account through an organization instead of directly by the account ID, then you must specify a `RoleArn` with proper permissions in the `Target` structure. For more information, see [Sending and Receiving Events Between AWS Accounts](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html) in the *Amazon EventBridge User Guide* .\n\n> If you have an IAM role on a cross-account event bus target, a `PutTargets` call without a role on the same target (same `Id` and `Arn` ) will not remove the role. \n\nFor more information about enabling cross-account events, see [PutPermission](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutPermission.html) .\n\n*Input* , *InputPath* , and *InputTransformer* are mutually exclusive and optional parameters of a target. When a rule is triggered due to a matched event:\n\n- If none of the following arguments are specified for a target, then the entire event is passed to the target in JSON format (unless the target is Amazon EC2 Run Command or Amazon ECS task, in which case nothing from the event is passed to the target).\n- If *Input* is specified in the form of valid JSON, then the matched event is overridden with this constant.\n- If *InputPath* is specified in the form of JSONPath (for example, `$.detail` ), then only the part of the event specified in the path is passed to the target (for example, only the detail part of the event is passed).\n- If *InputTransformer* is specified, then one or more specified JSONPaths are extracted from the event and used as values in a template that you specify as the input to the target.\n\nWhen you specify `InputPath` or `InputTransformer` , you must use JSON dot notation, not bracket notation.\n\nWhen you add targets to a rule and the associated rule triggers soon after, new or updated targets might not be immediately invoked. Allow a short period of time for changes to take effect.\n\nThis action can partially fail if too many requests are made at the same time. If that happens, `FailedEntryCount` is non-zero in the response and each entry in `FailedEntries` provides the ID of the failed target and the error code.",
 		packageSpec.Resources["aws-native:events:Rule"].InputProperties["targets"].Description,
 	)
@@ -230,6 +246,7 @@ func TestGatherPackage_docs_nestedPropertyProperty(t *testing.T) {
 	assert.Equal(
 		t,
 		"The maximum length of a time to wait for events.",
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		packageSpec.Types["aws-native:pipes:PipeSourceKinesisStreamParameters"].Properties["maximumBatchingWindowInSeconds"].Description,
 	)
 
@@ -297,10 +314,12 @@ func TestGatherPackage_docs_nestedListProperty(t *testing.T) {
 		Types: map[string]DocsTypes{
 			"AWS::Pipes::Pipe.EcsContainerOverride": {
 				Properties: map[string]string{
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"EnvironmentFiles": "A list of files containing the environment variables to pass to a container. You can specify up to ten environment files. The file must have a `.env` file extension. Each line in an environment file should contain an environment variable in `VARIABLE=VALUE` format. Lines beginning with `#` are treated as comments and are ignored. For more information about the environment variable file syntax, see [Declare default environment variables in file](https://docs.aws.amazon.com/https://docs.docker.com/compose/env-file/) .\n\nIf there are environment variables specified using the `environment` parameter in a container definition, they take precedence over the variables contained within an environment file. If multiple environment files are specified that contain the same variable, they're processed from the top down. We recommend that you use unique variable names. For more information, see [Specifying environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html) in the *Amazon Elastic Container Service Developer Guide* .\n\nThis parameter is only supported for tasks hosted on Fargate using the following platform versions:\n\n- Linux platform version `1.4.0` or later.\n- Windows platform version `1.0.0` or later.",
 				},
 			},
 			"AWS::Pipes::Pipe.EcsEnvironmentFile": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "A list of files containing the environment variables to pass to a container. You can specify up to ten environment files. The file must have a `.env` file extension. Each line in an environment file should contain an environment variable in `VARIABLE=VALUE` format. Lines beginning with `#` are treated as comments and are ignored. For more information about the environment variable file syntax, see [Declare default environment variables in file](https://docs.aws.amazon.com/https://docs.docker.com/compose/env-file/) .\n\nIf there are environment variables specified using the `environment` parameter in a container definition, they take precedence over the variables contained within an environment file. If multiple environment files are specified that contain the same variable, they're processed from the top down. We recommend that you use unique variable names. For more information, see [Specifying environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html) in the *Amazon Elastic Container Service Developer Guide* .\n\nThis parameter is only supported for tasks hosted on Fargate using the following platform versions:\n\n- Linux platform version `1.4.0` or later.\n- Windows platform version `1.0.0` or later.",
 				Properties: map[string]string{
 					"Type":  "The file type to use. The only supported value is `s3` .",
@@ -313,6 +332,7 @@ func TestGatherPackage_docs_nestedListProperty(t *testing.T) {
 	packageSpec, _ := runTest(t, spec, docs)
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"A list of files containing the environment variables to pass to a container. You can specify up to ten environment files. The file must have a `.env` file extension. Each line in an environment file should contain an environment variable in `VARIABLE=VALUE` format. Lines beginning with `#` are treated as comments and are ignored. For more information about the environment variable file syntax, see [Declare default environment variables in file](https://docs.aws.amazon.com/https://docs.docker.com/compose/env-file/) .\n\nIf there are environment variables specified using the `environment` parameter in a container definition, they take precedence over the variables contained within an environment file. If multiple environment files are specified that contain the same variable, they're processed from the top down. We recommend that you use unique variable names. For more information, see [Specifying environment variables](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/taskdef-envfiles.html) in the *Amazon Elastic Container Service Developer Guide* .\n\nThis parameter is only supported for tasks hosted on Fargate using the following platform versions:\n\n- Linux platform version `1.4.0` or later.\n- Windows platform version `1.0.0` or later.",
 		packageSpec.Types["aws-native:pipes:PipeEcsContainerOverride"].Properties["environmentFiles"].Description,
 	)
@@ -355,6 +375,7 @@ func TestGatherPackage_docs_listProperty(t *testing.T) {
 	docs := Docs{
 		Types: map[string]DocsTypes{
 			"AWS::Pipes::Pipe.PipeSourceSelfManagedKafkaParameters": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "The parameters for using a self-managed Apache Kafka stream as a source.\n\nA *self managed* cluster refers to any Apache Kafka cluster not hosted by AWS . This includes both clusters you manage yourself, as well as those hosted by a third-party provider, such as [Confluent Cloud](https://docs.aws.amazon.com/https://www.confluent.io/) , [CloudKarafka](https://docs.aws.amazon.com/https://www.cloudkarafka.com/) , or [Redpanda](https://docs.aws.amazon.com/https://redpanda.com/) . For more information, see [Apache Kafka streams as a source](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-pipes-kafka.html) in the *Amazon EventBridge User Guide* .",
 				Properties: map[string]string{
 					"AdditionalBootstrapServers": "An array of server URLs.",
@@ -367,6 +388,7 @@ func TestGatherPackage_docs_listProperty(t *testing.T) {
 	assert.Equal(
 		t,
 		"An array of server URLs.",
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		packageSpec.Types["aws-native:pipes:PipeSourceSelfManagedKafkaParameters"].Properties["additionalBootstrapServers"].Description,
 	)
 }
@@ -380,6 +402,7 @@ func TestGatherPackage_docs_topLevelResource(t *testing.T) {
 	docs := Docs{
 		Types: map[string]DocsTypes{
 			"AWS::EC2::Volume": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Specifies an Amazon Elastic Block Store (Amazon EBS) volume.\n\nWhen you use AWS CloudFormation to update an Amazon EBS volume that modifies `Iops` , `Size` , or `VolumeType` , there is a cooldown period before another operation can occur. This can cause your stack to report being in `UPDATE_IN_PROGRESS` or `UPDATE_ROLLBACK_IN_PROGRESS` for long periods of time.\n\nAmazon EBS does not support sizing down an Amazon EBS volume. AWS CloudFormation does not attempt to modify an Amazon EBS volume to a smaller size on rollback.\n\nSome common scenarios when you might encounter a cooldown period for Amazon EBS include:\n\n- You successfully update an Amazon EBS volume and the update succeeds. When you attempt another update within the cooldown window, that update will be subject to a cooldown period.\n- You successfully update an Amazon EBS volume and the update succeeds but another change in your `update-stack` call fails. The rollback will be subject to a cooldown period.\n\nFor more information, see [Requirements for EBS volume modifications](https://docs.aws.amazon.com/ebs/latest/userguide/modify-volume-requirements.html) .\n\n*DeletionPolicy attribute*\n\nTo control how AWS CloudFormation handles the volume when the stack is deleted, set a deletion policy for your volume. You can choose to retain the volume, to delete the volume, or to create a snapshot of the volume. For more information, see [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) .\n\n> If you set a deletion policy that creates a snapshot, all tags on the volume are included in the snapshot.",
 				Properties:  map[string]string{},
 			},
@@ -389,6 +412,7 @@ func TestGatherPackage_docs_topLevelResource(t *testing.T) {
 	packageSpec, _ := runTest(t, spec, docs)
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"Specifies an Amazon Elastic Block Store (Amazon EBS) volume.\n\nWhen you use AWS CloudFormation to update an Amazon EBS volume that modifies `Iops` , `Size` , or `VolumeType` , there is a cooldown period before another operation can occur. This can cause your stack to report being in `UPDATE_IN_PROGRESS` or `UPDATE_ROLLBACK_IN_PROGRESS` for long periods of time.\n\nAmazon EBS does not support sizing down an Amazon EBS volume. AWS CloudFormation does not attempt to modify an Amazon EBS volume to a smaller size on rollback.\n\nSome common scenarios when you might encounter a cooldown period for Amazon EBS include:\n\n- You successfully update an Amazon EBS volume and the update succeeds. When you attempt another update within the cooldown window, that update will be subject to a cooldown period.\n- You successfully update an Amazon EBS volume and the update succeeds but another change in your `update-stack` call fails. The rollback will be subject to a cooldown period.\n\nFor more information, see [Requirements for EBS volume modifications](https://docs.aws.amazon.com/ebs/latest/userguide/modify-volume-requirements.html) .\n\n*DeletionPolicy attribute*\n\nTo control how AWS CloudFormation handles the volume when the stack is deleted, set a deletion policy for your volume. You can choose to retain the volume, to delete the volume, or to create a snapshot of the volume. For more information, see [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) .\n\n> If you set a deletion policy that creates a snapshot, all tags on the volume are included in the snapshot.",
 		packageSpec.Resources["aws-native:ec2:Volume"].Description,
 	)
@@ -396,7 +420,8 @@ func TestGatherPackage_docs_topLevelResource(t *testing.T) {
 
 func TestGatherPackage_docs_augmentation_topLevelResource(t *testing.T) {
 	spec := map[string]interface{}{
-		// AWS::EC2::Volume has forced augmentation turned on to replace bad schema descriptions with the docs descriptions
+		// AWS::EC2::Volume has forced augmentation turned on to replace bad schema descriptions with the docs
+		// descriptions
 		"typeName":    "AWS::EC2::Volume",
 		"description": "bad description",
 		"properties":  map[string]interface{}{},
@@ -405,6 +430,7 @@ func TestGatherPackage_docs_augmentation_topLevelResource(t *testing.T) {
 	docs := Docs{
 		Types: map[string]DocsTypes{
 			"AWS::EC2::Volume": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Specifies an Amazon Elastic Block Store (Amazon EBS) volume.\n\nWhen you use AWS CloudFormation to update an Amazon EBS volume that modifies `Iops` , `Size` , or `VolumeType` , there is a cooldown period before another operation can occur. This can cause your stack to report being in `UPDATE_IN_PROGRESS` or `UPDATE_ROLLBACK_IN_PROGRESS` for long periods of time.\n\nAmazon EBS does not support sizing down an Amazon EBS volume. AWS CloudFormation does not attempt to modify an Amazon EBS volume to a smaller size on rollback.\n\nSome common scenarios when you might encounter a cooldown period for Amazon EBS include:\n\n- You successfully update an Amazon EBS volume and the update succeeds. When you attempt another update within the cooldown window, that update will be subject to a cooldown period.\n- You successfully update an Amazon EBS volume and the update succeeds but another change in your `update-stack` call fails. The rollback will be subject to a cooldown period.\n\nFor more information, see [Requirements for EBS volume modifications](https://docs.aws.amazon.com/ebs/latest/userguide/modify-volume-requirements.html) .\n\n*DeletionPolicy attribute*\n\nTo control how AWS CloudFormation handles the volume when the stack is deleted, set a deletion policy for your volume. You can choose to retain the volume, to delete the volume, or to create a snapshot of the volume. For more information, see [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) .\n\n> If you set a deletion policy that creates a snapshot, all tags on the volume are included in the snapshot.",
 				Properties:  map[string]string{},
 			},
@@ -414,6 +440,7 @@ func TestGatherPackage_docs_augmentation_topLevelResource(t *testing.T) {
 	packageSpec, _ := runTest(t, spec, docs)
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"Specifies an Amazon Elastic Block Store (Amazon EBS) volume.\n\nWhen you use AWS CloudFormation to update an Amazon EBS volume that modifies `Iops` , `Size` , or `VolumeType` , there is a cooldown period before another operation can occur. This can cause your stack to report being in `UPDATE_IN_PROGRESS` or `UPDATE_ROLLBACK_IN_PROGRESS` for long periods of time.\n\nAmazon EBS does not support sizing down an Amazon EBS volume. AWS CloudFormation does not attempt to modify an Amazon EBS volume to a smaller size on rollback.\n\nSome common scenarios when you might encounter a cooldown period for Amazon EBS include:\n\n- You successfully update an Amazon EBS volume and the update succeeds. When you attempt another update within the cooldown window, that update will be subject to a cooldown period.\n- You successfully update an Amazon EBS volume and the update succeeds but another change in your `update-stack` call fails. The rollback will be subject to a cooldown period.\n\nFor more information, see [Requirements for EBS volume modifications](https://docs.aws.amazon.com/ebs/latest/userguide/modify-volume-requirements.html) .\n\n*DeletionPolicy attribute*\n\nTo control how AWS CloudFormation handles the volume when the stack is deleted, set a deletion policy for your volume. You can choose to retain the volume, to delete the volume, or to create a snapshot of the volume. For more information, see [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) .\n\n> If you set a deletion policy that creates a snapshot, all tags on the volume are included in the snapshot.",
 		packageSpec.Resources["aws-native:ec2:Volume"].Description,
 	)
@@ -440,18 +467,22 @@ func TestGatherPackage_docs_augmentation_nestedProperty(t *testing.T) {
 		"properties": map[string]interface{}{
 
 			"EncryptionConfiguration": map[string]interface{}{
-				"$ref":        "#/definitions/EncryptionConfiguration",
+				"$ref": "#/definitions/EncryptionConfiguration",
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				"description": "The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.",
 			},
 		},
-		"typeName":    "AWS::ECR::Repository",
+		"typeName": "AWS::ECR::Repository",
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"description": "The ``AWS::ECR::Repository`` resource specifies an Amazon Elastic Container Registry (Amazon ECR) repository, where users can push and pull Docker images, Open Container Initiative (OCI) images, and OCI compatible artifacts. For more information, see [Amazon ECR private repositories](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html) in the *Amazon ECR User Guide*.",
 	}
 	docs := Docs{
 		Types: map[string]DocsTypes{
 			"AWS::ECR::Repository.EncryptionConfiguration": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.\n\nBy default, when no encryption configuration is set or the `AES256` encryption type is used, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts your data at rest using an AES-256 encryption algorithm. This does not require any action on your part.\n\nFor more control over the encryption of the contents of your repository, you can use server-side encryption with AWS Key Management Service key stored in AWS Key Management Service ( AWS KMS ) to encrypt your images. For more information, see [Amazon ECR encryption at rest](https://docs.aws.amazon.com/AmazonECR/latest/userguide/encryption-at-rest.html) in the *Amazon Elastic Container Registry User Guide* .",
 				Properties: map[string]string{
+					//nolint:lll // Preserve the exact fixture or documentation text.
 					"EncryptionType": "The encryption type to use.\n\nIf you use the `KMS` encryption type, the contents of the repository will be encrypted using server-side encryption with AWS Key Management Service key stored in AWS KMS . When you use AWS KMS to encrypt your data, you can either use the default AWS managed AWS KMS key for Amazon ECR, or specify your own AWS KMS key, which you already created. For more information, see [Protecting data using server-side encryption with an AWS KMS key stored in AWS Key Management Service (SSE-KMS)](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html) in the *Amazon Simple Storage Service Console Developer Guide* .\n\nIf you use the `AES256` encryption type, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts the images in the repository using an AES-256 encryption algorithm. For more information, see [Protecting data using server-side encryption with Amazon S3-managed encryption keys (SSE-S3)](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) in the *Amazon Simple Storage Service Console Developer Guide* .",
 				},
 			},
@@ -461,6 +492,7 @@ func TestGatherPackage_docs_augmentation_nestedProperty(t *testing.T) {
 	packageSpec, _ := runTest(t, spec, docs)
 	assert.Equal(
 		t,
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"The encryption type to use.\n\nIf you use the `KMS` encryption type, the contents of the repository will be encrypted using server-side encryption with AWS Key Management Service key stored in AWS KMS . When you use AWS KMS to encrypt your data, you can either use the default AWS managed AWS KMS key for Amazon ECR, or specify your own AWS KMS key, which you already created. For more information, see [Protecting data using server-side encryption with an AWS KMS key stored in AWS Key Management Service (SSE-KMS)](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html) in the *Amazon Simple Storage Service Console Developer Guide* .\n\nIf you use the `AES256` encryption type, Amazon ECR uses server-side encryption with Amazon S3-managed encryption keys which encrypts the images in the repository using an AES-256 encryption algorithm. For more information, see [Protecting data using server-side encryption with Amazon S3-managed encryption keys (SSE-S3)](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) in the *Amazon Simple Storage Service Console Developer Guide* .",
 		packageSpec.Types["aws-native:ecr:RepositoryEncryptionConfiguration"].Properties["encryptionType"].Description,
 	)
@@ -487,11 +519,13 @@ func TestGatherPackage_docs_augmentation_unknownProperty(t *testing.T) {
 		"properties": map[string]interface{}{
 
 			"EncryptionConfiguration": map[string]interface{}{
-				"$ref":        "#/definitions/EncryptionConfiguration",
+				"$ref": "#/definitions/EncryptionConfiguration",
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				"description": "The encryption configuration for the repository. This determines how the contents of your repository are encrypted at rest.",
 			},
 		},
-		"typeName":    "AWS::ECR::Repository",
+		"typeName": "AWS::ECR::Repository",
+		//nolint:lll // Preserve the exact fixture or documentation text.
 		"description": "The ``AWS::ECR::Repository`` resource specifies an Amazon Elastic Container Registry (Amazon ECR) repository, where users can push and pull Docker images, Open Container Initiative (OCI) images, and OCI compatible artifacts. For more information, see [Amazon ECR private repositories](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Repositories.html) in the *Amazon ECR User Guide*.",
 	}
 	docs := Docs{
@@ -518,6 +552,7 @@ func TestGatherPackage_regionGeneration(t *testing.T) {
 	docs := Docs{
 		Types: map[string]DocsTypes{
 			"AWS::EC2::Volume": {
+				//nolint:lll // Preserve the exact fixture or documentation text.
 				Description: "Specifies an Amazon Elastic Block Store (Amazon EBS) volume.\n\nWhen you use AWS CloudFormation to update an Amazon EBS volume that modifies `Iops` , `Size` , or `VolumeType` , there is a cooldown period before another operation can occur. This can cause your stack to report being in `UPDATE_IN_PROGRESS` or `UPDATE_ROLLBACK_IN_PROGRESS` for long periods of time.\n\nAmazon EBS does not support sizing down an Amazon EBS volume. AWS CloudFormation does not attempt to modify an Amazon EBS volume to a smaller size on rollback.\n\nSome common scenarios when you might encounter a cooldown period for Amazon EBS include:\n\n- You successfully update an Amazon EBS volume and the update succeeds. When you attempt another update within the cooldown window, that update will be subject to a cooldown period.\n- You successfully update an Amazon EBS volume and the update succeeds but another change in your `update-stack` call fails. The rollback will be subject to a cooldown period.\n\nFor more information, see [Requirements for EBS volume modifications](https://docs.aws.amazon.com/ebs/latest/userguide/modify-volume-requirements.html) .\n\n*DeletionPolicy attribute*\n\nTo control how AWS CloudFormation handles the volume when the stack is deleted, set a deletion policy for your volume. You can choose to retain the volume, to delete the volume, or to create a snapshot of the volume. For more information, see [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) .\n\n> If you set a deletion policy that creates a snapshot, all tags on the volume are included in the snapshot.",
 				Properties:  map[string]string{},
 			},

--- a/provider/pkg/schema/inputs.go
+++ b/provider/pkg/schema/inputs.go
@@ -3,8 +3,9 @@
 package schema
 
 import (
-	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
 )
 
 func GetInputsFromState(res *metadata.CloudAPIResource, state resource.PropertyMap) (resource.PropertyMap, error) {

--- a/provider/pkg/schema/jsschema_util_test.go
+++ b/provider/pkg/schema/jsschema_util_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"testing/quick"
 
-	jsschema "github.com/pulumi/jsschema"
 	"github.com/stretchr/testify/assert"
+
+	jsschema "github.com/pulumi/jsschema"
 )
 
 func TestFlattenJSSchema(t *testing.T) {

--- a/provider/pkg/schema/loader.go
+++ b/provider/pkg/schema/loader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -28,7 +29,10 @@ func (l *inMemoryLoader) LoadPackage(pkg string, _ *semver.Version) (*schema.Pac
 	return nil, errors.Errorf("package %s not found in the in-memory map", pkg)
 }
 
-func (l *inMemoryLoader) LoadPackageV2(ctx context.Context, descriptor *schema.PackageDescriptor) (*schema.Package, error) {
+func (l *inMemoryLoader) LoadPackageV2(
+	_ context.Context,
+	descriptor *schema.PackageDescriptor,
+) (*schema.Package, error) {
 	if p, ok := l.pkgs[descriptor.Name]; ok {
 		return p, nil
 	}

--- a/provider/pkg/schema/resource_props_test.go
+++ b/provider/pkg/schema/resource_props_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
 package schema
 
 import (
@@ -106,7 +107,7 @@ func TestReadPropertyTransforms(t *testing.T) {
 		schema := &jsschema.Schema{
 			Extras: map[string]interface{}{
 				"propertyTransform": map[string]interface{}{
-					"/properties/Engine":                      "$lowercase(Engine)",
+					"/properties/Engine":                           "$lowercase(Engine)",
 					"/properties/SecurityGroupEgress/*/IpProtocol": "$lowercase(IpProtocol)",
 				},
 			},
@@ -134,7 +135,7 @@ func TestReadPropertyTransforms(t *testing.T) {
 		schema := &jsschema.Schema{
 			Extras: map[string]interface{}{
 				"propertyTransform": map[string]interface{}{
-					"/properties/Valid":   "$lowercase(Valid)",
+					"/properties/Valid":    "$lowercase(Valid)",
 					"/definitions/Invalid": "$lowercase(Invalid)", // Invalid path
 				},
 			},

--- a/provider/tools/ref-parser/cat.go
+++ b/provider/tools/ref-parser/cat.go
@@ -37,7 +37,9 @@ var categorizationRules = []categorizationRule{
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("When you pass the logical ID of this resource to the intrinsic .Ref..?function, .Ref.?.?returns the ARN"),
+		Pattern: regexp.MustCompile(
+			"When you pass the logical ID of this resource to the intrinsic .Ref..?function, .Ref.?.?returns the ARN",
+		),
 	},
 	{
 		Category: ShouldNotBeUsed,
@@ -45,47 +47,73 @@ var categorizationRules = []categorizationRule{
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the Arn of the .* that is created by the"),
+		Pattern: regexp.MustCompile(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the Arn of the .* that is created by the",
+		),
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the .* ARN"),
+		Pattern: regexp.MustCompile(
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the .* ARN",
+		),
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the resource ARN"),
+		Pattern: regexp.MustCompile(
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the resource ARN",
+		),
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the Amazon Resource Name"),
+		Pattern: regexp.MustCompile(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the Amazon Resource Name",
+		),
 	},
 	{
 		Category: RefReturnsArn,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of .* resource to the intrinsic .Ref.?.?function, the function returns the Amazon Resource Name"),
+		Pattern: regexp.MustCompile(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"^When you pass the logical ID of .* resource to the intrinsic .Ref.?.?function, the function returns the Amazon Resource Name",
+		),
 	},
 	{
 		Category: RefReturnsName,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the value of [`][^`]*Name[`]"),
+		Pattern: regexp.MustCompile(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the value of [`][^`]*Name[`]",
+		),
 	},
 	{
 		Category: RefReturnsName,
-		Pattern:  regexp.MustCompile("When the logical ID of this resource is provided to the Ref intrinsic function, .Ref. returns the .* name"),
+		Pattern: regexp.MustCompile(
+			"When the logical ID of this resource is provided to the Ref intrinsic function, .Ref. returns the .* name",
+		),
 	},
 	{
 		Category: RefReturnsName,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the name"),
+		Pattern: regexp.MustCompile(
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the name",
+		),
 	},
 	{
 		Category: RefReturnsName,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the .* name"),
+		Pattern: regexp.MustCompile(
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the .* name",
+		),
 	},
 	{
 		Category: RefReturnsID,
-		Pattern:  regexp.MustCompile("^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the.*ID"),
+		Pattern: regexp.MustCompile(
+			"^When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns the.*ID",
+		),
 	},
 	{
 		Category: RefReturnsID,
-		Pattern:  regexp.MustCompile("When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns a .* ID"),
+		Pattern: regexp.MustCompile(
+			"When you pass the logical ID of this resource to the intrinsic .Ref.?.?function, .Ref.?.?returns a .* ID",
+		),
 	},
 }
 

--- a/provider/tools/ref-parser/cat_test.go
+++ b/provider/tools/ref-parser/cat_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCategorize(t *testing.T) {
@@ -10,55 +11,118 @@ func TestCategorize(t *testing.T) {
 		RefReturnsArn,
 		Categorize("\nThe Amazon Resource Name \\(ARN\\) of the certificate authority\\.\n\n"))
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the ARN of the analyzer created\\.\n\nFor more information about using the `Ref`function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html"))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the ARN of the analyzer created\\.\n\nFor more information about using the `Ref`function, see [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		ShouldNotBeUsed,
-		Categorize("\nThis reference should not be used in CloudFormation templates\\. Instead, use `AWS::ACMPCA::Certificate.Arn` to identify a certificate, and use `AWS::ACMPCA::Certificate.CertificateAuthorityArn` to identify a certificate authority\\.\n\n"))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"\nThis reference should not be used in CloudFormation templates\\. Instead, use `AWS::ACMPCA::Certificate.Arn` to identify a certificate, and use `AWS::ACMPCA::Certificate.CertificateAuthorityArn` to identify a certificate authority\\.\n\n",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the Arn of the Cost Category that is created by the template\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the Arn of the Cost Category that is created by the template\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the resource ARN\\. For example:"))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the resource ARN\\. For example:",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsName,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the value of `DashboardName`\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the value of `DashboardName`\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsName,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the name of the resource\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the name of the resource\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsName,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the DB instance name\\."))
+		Categorize(
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the DB instance name\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the scheduling policy ARN, such as `arn:aws:batch:us-east-1:111122223333:scheduling-policy/HighPriority`\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the scheduling policy ARN, such as `arn:aws:batch:us-east-1:111122223333:scheduling-policy/HighPriority`\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsID,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the wireless device ID\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the wireless device ID\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsID,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns a generated ID, such as `us-east-2_zgaEXAMPLE`\\."))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns a generated ID, such as `us-east-2_zgaEXAMPLE`\\.",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the Amazon Resource Name \\(ARN\\) of the endpoint configuration, such as `arn:aws:sagemaker:us-west-2:012345678901:notebook-instance-lifecycle-config/mylifecycleconfig`"))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of this resource to the intrinsic `Ref`function, `Ref`returns the Amazon Resource Name \\(ARN\\) of the endpoint configuration, such as `arn:aws:sagemaker:us-west-2:012345678901:notebook-instance-lifecycle-config/mylifecycleconfig`",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsName,
-		Categorize("When the logical ID of this resource is provided to the Ref intrinsic function, .Ref. returns the resource name"))
+		Categorize(
+			"When the logical ID of this resource is provided to the Ref intrinsic function, .Ref. returns the resource name",
+		),
+	)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		RefReturnsArn,
-		Categorize("When you pass the logical ID of an `AWS::RoboMaker::SimulationApplication` resource to the intrinsic `Ref` function, the function returns the Amazon Resource Name \\(ARN\\) of the simulation application, such as `arn:aws:robomaker:us-west-2:123456789012:simulation-application/MySimulationApplication/1546541201334`\\. "))
+		Categorize(
+			//nolint:lll // Preserve the exact fixture or documentation text.
+			"When you pass the logical ID of an `AWS::RoboMaker::SimulationApplication` resource to the intrinsic `Ref` function, the function returns the Amazon Resource Name \\(ARN\\) of the simulation application, such as `arn:aws:robomaker:us-west-2:123456789012:simulation-application/MySimulationApplication/1546541201334`\\. ",
+		),
+	)
 }

--- a/provider/tools/ref-parser/game.go
+++ b/provider/tools/ref-parser/game.go
@@ -31,7 +31,7 @@ func game(schemaAbsPath, dbFile string, allResources map[string]resourceFile) er
 
 		res, ok := allResources[r]
 		if !ok {
-			return fmt.Errorf("Resource not found: %s", res)
+			return fmt.Errorf("resource not found: %s", res)
 		}
 
 		props, err := findProperties(schemaAbsPath, r)

--- a/provider/tools/ref-parser/main.go
+++ b/provider/tools/ref-parser/main.go
@@ -119,7 +119,7 @@ type resourceFile struct {
 	Category   Category
 }
 
-var resourceIdPattern = regexp.MustCompile(`^[#]\s*([^<\n]+)`)
+var resourceIDPattern = regexp.MustCompile(`^[#]\s*([^<\n]+)`)
 var refPattern = regexp.MustCompile(`(?m)^[#]+[ ]*Ref[^\n]*[\n]([^#]+)`)
 
 func parseResourceFile(file string) (resourceFile, error) {
@@ -129,11 +129,11 @@ func parseResourceFile(file string) (resourceFile, error) {
 	}
 	rf := resourceFile{}
 
-	if m := resourceIdPattern.FindSubmatch(fbytes); m != nil {
+	if m := resourceIDPattern.FindSubmatch(fbytes); m != nil {
 		rf.ResourceID = string(m[1])
 	}
 	if rf.ResourceID == "" {
-		return resourceFile{}, fmt.Errorf("Could not parse ResourceID from %q", file)
+		return resourceFile{}, fmt.Errorf("could not parse ResourceID from %q", file)
 	}
 
 	if m := refPattern.FindSubmatch(fbytes); m != nil {

--- a/provider/tools/ref-parser/reports.go
+++ b/provider/tools/ref-parser/reports.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
-	"fmt"
 	metadata "github.com/pulumi/pulumi-aws-native/provider/pkg/refdb"
 )
 
@@ -51,9 +51,9 @@ func reportOnRefAsPrimaryIdentifier(dbFile, schemaAbsPath string) error {
 			return err
 		}
 
-		if sr.RefReturns.CfRefBehavior.Property != "" {
+		if sr.RefReturns.Property != "" {
 			fmt.Printf("Strange resource: %s --> %q (pid=#%v)\n", refID,
-				sr.RefReturns.CfRefBehavior.Property,
+				sr.RefReturns.Property,
 				strings.Join(sch.PrimaryIdentifier, "|"))
 		} else {
 			fmt.Printf("Strange resource: %s --> %#v\n", refID, sr.RefReturns.CfRefBehavior)


### PR DESCRIPTION
## Summary

- Reduce the provider's golangci-lint backlog from 473 findings to zero.
- Enable lint checks in the normal generated CI workflows.
- Make lint, provider builds, and fast tests work in clean checkouts by creating
  their required ignored schema and metadata artifacts automatically.
- Document the one-command local workspace setup.
- Run the ci-mgmt generator from `@master` instead of a stale commit pin.

This PR does not independently change the Go version; current master now uses Go 1.25.11.

## Scope

This touches provider Go sources and tests, the root Makefile, contributor
setup documentation, `.ci-mgmt.yaml`, and its generated workflow changes.

Most Go changes are lint-driven formatting and cleanup. Correctness findings
also resulted in stricter archive traversal checks, delete-state unmarshal
error propagation, protobuf cloning instead of copying lock state, and error
handling for diagnostic writes.

This intentionally does not regenerate the schema or any SDK.

## Validation

- [x] `mise exec -- make lint`
- [x] `mise exec -- make test_provider_fast`
- [ ] `mise exec -- make test_provider` (not run; may require live AWS credentials)
- [ ] `mise exec -- make test` (not needed; integration contracts are unchanged)
- [x] `mise exec -- make provider`
- [x] `mise exec -- go test -count=1 ./cmd/pulumi-gen-aws-native ./tools/ref-parser`
- [x] Uncapped golangci-lint 2.12.2 run (`0 issues`)
- [x] Clean-checkout artifact preparation via `mise exec -- make prepare_local_workspace`
- [x] `git diff --check`

## Generation / Drift Checks

- [x] No hand-edits to generated files, including `sdk/**` and generated schema artifacts
- [ ] Ran `make generate_schema` (not needed; schema/codegen inputs are unchanged)
- [ ] Ran `make local_generate` (not needed; SDK/API surface is unchanged)
- [x] Ran `mise exec -- make ci-mgmt` after changing `.ci-mgmt.yaml`

## Risk

The diff is broad because lint cleanup spans the provider and its fixtures.
The main behavioral risk is in the correctness fixes listed above; fast
provider and focused codegen tests pass.

`make lint` now creates the ignored gzip embed artifacts through Make
prerequisites. This avoids mutating source files while keeping clean-checkout
lint runs self-contained.

## Rollback

Revert commits `bcf728ff21`, `e5b74bccdf`, and `695e93d363` to restore the
previous lint configuration, CI wiring, and provider source.


