### PR TITLE
feat(schema): preserve unordered collection metadata

### DIFF
--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -41,7 +41,8 @@ type CloudAPIResource struct {
 	WriteOnly []string `json:"writeOnly,omitempty"`
 	// UnorderedCollections contains SDK-name slash paths for arrays whose
 	// CloudFormation schema declares insertionOrder: false. Array element
-	// traversal uses "*" path segments.
+	// traversal uses "*" path segments, including a terminal "*" when an array
+	// item is itself an unordered array.
 	UnorderedCollections []string               `json:"unorderedCollections,omitempty"`
 	IrreversibleNames    map[string]string      `json:"irreversibleNames,omitempty"`
 	TagsProperty         string                 `json:"tagsProperty,omitempty"`

--- a/provider/pkg/metadata/metadata.go
+++ b/provider/pkg/metadata/metadata.go
@@ -37,11 +37,15 @@ type CloudAPIResource struct {
 	//   ]
 	//
 	// NOTE: The values in this property will have been converted from CFN casing to pulumi sdk casing
-	ReadOnly          []string               `json:"readOnly,omitempty"`
-	WriteOnly         []string               `json:"writeOnly,omitempty"`
-	IrreversibleNames map[string]string      `json:"irreversibleNames,omitempty"`
-	TagsProperty      string                 `json:"tagsProperty,omitempty"`
-	TagsStyle         default_tags.TagsStyle `json:"tagsStyle,omitempty"`
+	ReadOnly  []string `json:"readOnly,omitempty"`
+	WriteOnly []string `json:"writeOnly,omitempty"`
+	// UnorderedCollections contains SDK-name slash paths for arrays whose
+	// CloudFormation schema declares insertionOrder: false. Array element
+	// traversal uses "*" path segments.
+	UnorderedCollections []string               `json:"unorderedCollections,omitempty"`
+	IrreversibleNames    map[string]string      `json:"irreversibleNames,omitempty"`
+	TagsProperty         string                 `json:"tagsProperty,omitempty"`
+	TagsStyle            default_tags.TagsStyle `json:"tagsStyle,omitempty"`
 
 	// Describes the behavior of the CF Ref intrinsic for this resource.
 	CfRef *CfRefBehavior `json:"cfRef,omitempty"`

--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1122,6 +1122,7 @@ func (ctx *cfSchemaContext) gatherResourceType() error {
 		AutoNamingSpec:        autoNamingSpec,
 		WriteOnly:             writeOnlyProperties.SortedValues(),
 		ReadOnly:              readPropSdkNames(ctx.resourceSpec, "readOnlyProperties").SortedValues(),
+		UnorderedCollections:  readUnorderedCollections(ctx.resourceSpec),
 		IrreversibleNames:     irreversibleNames,
 		TagsProperty:          naming.ToSdkName(tagsProp),
 		TagsStyle:             tagsStyle,

--- a/provider/pkg/schema/gen_unordered_collections.go
+++ b/provider/pkg/schema/gen_unordered_collections.go
@@ -1,0 +1,273 @@
+// Copyright 2026, Pulumi Corporation.
+
+package schema
+
+import (
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+
+	jsschema "github.com/pulumi/jsschema"
+)
+
+const insertionOrderProperty = "insertionOrder"
+
+// CloudFormation resource schemas put unordered-array semantics on the array
+// node itself. insertionOrder is a CloudFormation extension rather than a field
+// modeled by jsschema, so it is available through Schema.Extras. For example:
+//
+//	"Policies": {
+//	  "type": "array",
+//	  "insertionOrder": false,
+//	  "items": {"$ref": "#/definitions/Policy"}
+//	}
+//
+// Pulumi package schemas and SDK array types have no corresponding annotation.
+// The provider therefore records the source semantics in CloudAPIResource as
+// resource-relative SDK-name paths. The example above produces "policies".
+//
+// Nested arrays may be reached through both array items and definitions:
+//
+//	"ContainerDefinitions": {
+//	  "type": "array",
+//	  "items": {"$ref": "#/definitions/ContainerDefinition"}
+//	}
+//	"ContainerDefinition": {
+//	  "properties": {
+//	    "Environment": {"type": "array", "insertionOrder": false}
+//	  }
+//	}
+//
+// That shape produces "containerDefinitions/*/environment". At runtime the
+// wildcard matches concrete diff paths such as
+// "containerDefinitions/0/environment". Walking from each resource property,
+// rather than collecting annotations directly from definitions, is necessary
+// because one definition can be referenced at several resource paths.
+//
+// unorderedSchemaBranch represents one effective schema alternative at a
+// resource path. refs is the reference stack for that path; it prevents cycles
+// without preventing the same definition from being visited at another path.
+type unorderedSchemaBranch struct {
+	schema *jsschema.Schema
+	refs   map[string]struct{}
+}
+
+// readUnorderedCollections walks the resource's reachable property graph and
+// returns SDK-name paths for arrays that every applicable CloudFormation schema
+// branch explicitly declares unordered. The sorted result is persisted in
+// CloudAPIResource.UnorderedCollections for refresh, Diff, and patch handling.
+func readUnorderedCollections(resourceSpec *jsschema.Schema) []string {
+	if resourceSpec == nil {
+		return nil
+	}
+
+	paths := map[string]struct{}{}
+	for _, name := range slices.Sorted(maps.Keys(resourceSpec.Properties)) {
+		walkUnorderedCollections(resourceSpec, []unorderedSchemaBranch{{
+			schema: resourceSpec.Properties[name],
+			refs:   map[string]struct{}{},
+		}}, []string{name}, paths)
+	}
+
+	if len(paths) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(paths))
+	for path := range paths {
+		result = append(result, path)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// walkUnorderedCollections carries the resource-relative CloudFormation path
+// while traversing object properties and array items. Array item traversal adds
+// "*" because metadata describes all elements rather than one concrete index.
+func walkUnorderedCollections(
+	root *jsschema.Schema,
+	branches []unorderedSchemaBranch,
+	path []string,
+	paths map[string]struct{},
+) {
+	branches = expandUnorderedAlternatives(root, branches)
+	if len(branches) == 0 {
+		return
+	}
+
+	arrayBranches := make([]unorderedSchemaBranch, 0, len(branches))
+	for _, branch := range branches {
+		if schemaIsArray(branch.schema) {
+			arrayBranches = append(arrayBranches, branch)
+		}
+	}
+	if len(arrayBranches) > 0 && everyArrayBranchIsUnordered(arrayBranches) {
+		paths[ResourceProperty(strings.Join(path, "/")).ToSdkName()] = struct{}{}
+	}
+
+	properties := map[string][]unorderedSchemaBranch{}
+	for _, branch := range branches {
+		for name, property := range branch.schema.Properties {
+			properties[name] = append(properties[name], unorderedSchemaBranch{
+				schema: property,
+				refs:   branch.refs,
+			})
+		}
+	}
+	for _, name := range slices.Sorted(maps.Keys(properties)) {
+		walkUnorderedCollections(root, properties[name], appendPath(path, name), paths)
+	}
+
+	items := []unorderedSchemaBranch{}
+	for _, branch := range arrayBranches {
+		if branch.schema.Items == nil {
+			continue
+		}
+		for _, item := range branch.schema.Items.Schemas {
+			items = append(items, unorderedSchemaBranch{schema: item, refs: branch.refs})
+		}
+	}
+	if len(items) > 0 {
+		walkUnorderedCollections(root, items, appendPath(path, "*"), paths)
+	}
+}
+
+// expandUnorderedAlternatives resolves local references and ordinary oneOf or
+// anyOf alternatives. Ambiguous composition is omitted conservatively: allOf
+// requires merging constraints, and combining oneOf with anyOf requires a
+// Cartesian expansion that is not warranted by current CloudFormation schemas.
+func expandUnorderedAlternatives(
+	root *jsschema.Schema,
+	branches []unorderedSchemaBranch,
+) []unorderedSchemaBranch {
+	result := []unorderedSchemaBranch{}
+	for _, branch := range branches {
+		result = append(result, expandUnorderedAlternative(root, branch)...)
+	}
+	return result
+}
+
+// expandUnorderedAlternative turns one schema node into the effective branches
+// that must agree before unordered semantics can be emitted for its path.
+func expandUnorderedAlternative(
+	root *jsschema.Schema,
+	branch unorderedSchemaBranch,
+) []unorderedSchemaBranch {
+	if branch.schema == nil {
+		return nil
+	}
+
+	if branch.schema.Reference != "" {
+		return expandUnorderedReference(root, branch)
+	}
+
+	if len(branch.schema.AllOf) > 0 ||
+		(len(branch.schema.AnyOf) > 0 && len(branch.schema.OneOf) > 0) {
+		return nil
+	}
+	if len(branch.schema.AnyOf) == 0 && len(branch.schema.OneOf) == 0 {
+		return []unorderedSchemaBranch{branch}
+	}
+
+	alternatives := branch.schema.AnyOf
+	if len(alternatives) == 0 {
+		alternatives = branch.schema.OneOf
+	}
+	base := cloneJSSchema(branch.schema)
+	base.AnyOf = nil
+	base.OneOf = nil
+
+	result := []unorderedSchemaBranch{}
+	for _, alternative := range alternatives {
+		merged := cloneJSSchema(base)
+		MergeJSSchema(merged, alternative)
+		result = append(result, expandUnorderedAlternative(root, unorderedSchemaBranch{
+			schema: merged,
+			refs:   branch.refs,
+		})...)
+	}
+	return result
+}
+
+// expandUnorderedReference overlays a referenced definition with any fields
+// next to the $ref, then continues walking with path-local cycle protection.
+func expandUnorderedReference(
+	root *jsschema.Schema,
+	branch unorderedSchemaBranch,
+) []unorderedSchemaBranch {
+	ref := branch.schema.Reference
+	withoutRef := cloneJSSchema(branch.schema)
+	withoutRef.Reference = ""
+	if _, seen := branch.refs[ref]; seen {
+		return expandUnorderedAlternative(root, unorderedSchemaBranch{
+			schema: withoutRef,
+			refs:   branch.refs,
+		})
+	}
+
+	target, ok := resolveLocalDefinition(root, ref)
+	if !ok {
+		return expandUnorderedAlternative(root, unorderedSchemaBranch{
+			schema: withoutRef,
+			refs:   branch.refs,
+		})
+	}
+	merged := cloneJSSchema(target)
+	MergeJSSchema(merged, withoutRef)
+	refs := cloneRefStack(branch.refs)
+	refs[ref] = struct{}{}
+	return expandUnorderedAlternative(root, unorderedSchemaBranch{schema: merged, refs: refs})
+}
+
+func cloneJSSchema(schema *jsschema.Schema) *jsschema.Schema {
+	result := jsschema.New()
+	MergeJSSchema(result, schema)
+	return result
+}
+
+// resolveLocalDefinition resolves the local definition references used by
+// CloudFormation resource schemas, including JSON Pointer escaping.
+func resolveLocalDefinition(root *jsschema.Schema, ref string) (*jsschema.Schema, bool) {
+	const prefix = "#/definitions/"
+	if !strings.HasPrefix(ref, prefix) {
+		return nil, false
+	}
+	name := strings.TrimPrefix(ref, prefix)
+	name = strings.ReplaceAll(name, "~1", "/")
+	name = strings.ReplaceAll(name, "~0", "~")
+	definition, ok := root.Definitions[name]
+	return definition, ok
+}
+
+// schemaIsArray recognizes both explicit array types and the item-bearing
+// shape that the main generator also normalizes to an array.
+func schemaIsArray(schema *jsschema.Schema) bool {
+	return schema != nil && (schema.Type.Contains(jsschema.ArrayType) ||
+		(schema.Items != nil && len(schema.Items.Schemas) > 0))
+}
+
+// everyArrayBranchIsUnordered requires explicit insertionOrder: false on each
+// applicable array alternative. Missing, malformed, or true values are ordered.
+func everyArrayBranchIsUnordered(branches []unorderedSchemaBranch) bool {
+	for _, branch := range branches {
+		value, ok := branch.schema.Extras[insertionOrderProperty].(bool)
+		if !ok || value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneRefStack(refs map[string]struct{}) map[string]struct{} {
+	result := make(map[string]struct{}, len(refs)+1)
+	for ref := range refs {
+		result[ref] = struct{}{}
+	}
+	return result
+}
+
+func appendPath(path []string, segment string) []string {
+	result := make([]string, len(path), len(path)+1)
+	copy(result, path)
+	return append(result, segment)
+}

--- a/provider/pkg/schema/gen_unordered_collections.go
+++ b/provider/pkg/schema/gen_unordered_collections.go
@@ -41,9 +41,11 @@ const insertionOrderProperty = "insertionOrder"
 //
 // That shape produces "containerDefinitions/*/environment". At runtime the
 // wildcard matches concrete diff paths such as
-// "containerDefinitions/0/environment". Walking from each resource property,
-// rather than collecting annotations directly from definitions, is necessary
-// because one definition can be referenced at several resource paths.
+// "containerDefinitions/0/environment". When an array item is itself an
+// unordered array, the inner collection path ends in "*"; for example,
+// "outer/*" matches the inner array at "outer/0". Walking from each resource
+// property, rather than collecting annotations directly from definitions, is
+// necessary because one definition can be referenced at several resource paths.
 //
 // unorderedSchemaBranch represents one effective schema alternative at a
 // resource path. refs is the reference stack for that path; it prevents cycles

--- a/provider/pkg/schema/gen_unordered_collections_test.go
+++ b/provider/pkg/schema/gen_unordered_collections_test.go
@@ -12,6 +12,8 @@ import (
 
 const (
 	childrenProperty = "Children"
+	outerProperty    = "Outer"
+	parentProperty   = "Parent"
 	valuesProperty   = "Values"
 )
 
@@ -40,7 +42,7 @@ func TestReadUnorderedCollections(t *testing.T) {
 		},
 		"nested array": {
 			schema: resourceSchema(map[string]*jsschema.Schema{
-				"Outer": orderedArraySchema(&jsschema.Schema{
+				outerProperty: orderedArraySchema(&jsschema.Schema{
 					Type: jsschema.PrimitiveTypes{jsschema.ObjectType},
 					Properties: map[string]*jsschema.Schema{
 						"InnerValues": unorderedArraySchema(stringSchema()),
@@ -48,6 +50,12 @@ func TestReadUnorderedCollections(t *testing.T) {
 				}),
 			}),
 			expected: []string{"outer/*/innerValues"},
+		},
+		"unordered array of unordered arrays": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				outerProperty: unorderedArraySchema(unorderedArraySchema(stringSchema())),
+			}),
+			expected: []string{"outer", "outer/*"},
 		},
 		"same definition at multiple paths": {
 			schema: &jsschema.Schema{
@@ -74,7 +82,7 @@ func TestReadUnorderedCollections(t *testing.T) {
 		},
 		"ordered parent and unordered child": {
 			schema: resourceSchema(map[string]*jsschema.Schema{
-				"Parent": orderedArraySchema(&jsschema.Schema{
+				parentProperty: orderedArraySchema(&jsschema.Schema{
 					Properties: map[string]*jsschema.Schema{
 						childrenProperty: unorderedArraySchema(stringSchema()),
 					},
@@ -84,7 +92,7 @@ func TestReadUnorderedCollections(t *testing.T) {
 		},
 		"unordered parent and ordered child": {
 			schema: resourceSchema(map[string]*jsschema.Schema{
-				"Parent": unorderedArraySchema(&jsschema.Schema{
+				parentProperty: unorderedArraySchema(&jsschema.Schema{
 					Properties: map[string]*jsschema.Schema{
 						childrenProperty: orderedArraySchema(stringSchema()),
 					},
@@ -151,7 +159,7 @@ func TestReadUnorderedCollections(t *testing.T) {
 		},
 		"multiple item schemas": {
 			schema: resourceSchema(map[string]*jsschema.Schema{
-				"Outer": {
+				outerProperty: {
 					Type: jsschema.PrimitiveTypes{jsschema.ArrayType},
 					Items: &jsschema.ItemSpec{TupleMode: true, Schemas: jsschema.SchemaList{
 						{Properties: map[string]*jsschema.Schema{
@@ -175,6 +183,28 @@ func TestReadUnorderedCollections(t *testing.T) {
 				},
 			},
 			expected: []string{"values"},
+		},
+		"missing local definition preserves sibling fields": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				parentProperty: {
+					Reference: "#/definitions/Missing",
+					Properties: map[string]*jsschema.Schema{
+						valuesProperty: unorderedArraySchema(stringSchema()),
+					},
+				},
+			}),
+			expected: []string{"parent/values"},
+		},
+		"unsupported reference preserves sibling fields": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				parentProperty: {
+					Reference: "#/$defs/Values",
+					Properties: map[string]*jsschema.Schema{
+						valuesProperty: unorderedArraySchema(stringSchema()),
+					},
+				},
+			}),
+			expected: []string{"parent/values"},
 		},
 	}
 

--- a/provider/pkg/schema/gen_unordered_collections_test.go
+++ b/provider/pkg/schema/gen_unordered_collections_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026, Pulumi Corporation.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	jsschema "github.com/pulumi/jsschema"
+)
+
+const (
+	childrenProperty = "Children"
+	valuesProperty   = "Values"
+)
+
+func TestReadUnorderedCollections(t *testing.T) {
+	tests := map[string]struct {
+		schema   *jsschema.Schema
+		expected []string
+	}{
+		"nil schema": {},
+		"top-level primitive array": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"Names": unorderedArraySchema(stringSchema()),
+			}),
+			expected: []string{"names"},
+		},
+		"definition reference and SDK casing": {
+			schema: &jsschema.Schema{
+				Properties: map[string]*jsschema.Schema{
+					"SomeARNs": {Reference: "#/definitions/Arns"},
+				},
+				Definitions: map[string]*jsschema.Schema{
+					"Arns": unorderedArraySchema(stringSchema()),
+				},
+			},
+			expected: []string{"someArns"},
+		},
+		"nested array": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"Outer": orderedArraySchema(&jsschema.Schema{
+					Type: jsschema.PrimitiveTypes{jsschema.ObjectType},
+					Properties: map[string]*jsschema.Schema{
+						"InnerValues": unorderedArraySchema(stringSchema()),
+					},
+				}),
+			}),
+			expected: []string{"outer/*/innerValues"},
+		},
+		"same definition at multiple paths": {
+			schema: &jsschema.Schema{
+				Properties: map[string]*jsschema.Schema{
+					"First":  {Reference: "#/definitions/Names"},
+					"Second": {Reference: "#/definitions/Names"},
+				},
+				Definitions: map[string]*jsschema.Schema{
+					"Names": unorderedArraySchema(stringSchema()),
+				},
+			},
+			expected: []string{"first", "second"},
+		},
+		"true absent malformed and non-array annotations": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"True":      arraySchema(true, stringSchema()),
+				"Absent":    orderedArraySchema(stringSchema()),
+				"Malformed": arraySchema("false", stringSchema()),
+				"NotArray": {
+					Type:   jsschema.PrimitiveTypes{jsschema.StringType},
+					Extras: map[string]interface{}{insertionOrderProperty: false},
+				},
+			}),
+		},
+		"ordered parent and unordered child": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"Parent": orderedArraySchema(&jsschema.Schema{
+					Properties: map[string]*jsschema.Schema{
+						childrenProperty: unorderedArraySchema(stringSchema()),
+					},
+				}),
+			}),
+			expected: []string{"parent/*/children"},
+		},
+		"unordered parent and ordered child": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"Parent": unorderedArraySchema(&jsschema.Schema{
+					Properties: map[string]*jsschema.Schema{
+						childrenProperty: orderedArraySchema(stringSchema()),
+					},
+				}),
+			}),
+			expected: []string{"parent"},
+		},
+		"duplicate composition paths": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				valuesProperty: {
+					AnyOf: jsschema.SchemaList{
+						unorderedArraySchema(stringSchema()),
+						unorderedArraySchema(stringSchema()),
+					},
+				},
+			}),
+			expected: []string{"values"},
+		},
+		"allOf composition is conservatively omitted": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				valuesProperty: {
+					Extras: map[string]interface{}{insertionOrderProperty: false},
+					AllOf: jsschema.SchemaList{
+						orderedArraySchema(stringSchema()),
+					},
+				},
+			}),
+		},
+		"mixed anyOf and oneOf composition is conservatively omitted": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				valuesProperty: {
+					AnyOf: jsschema.SchemaList{unorderedArraySchema(stringSchema())},
+					OneOf: jsschema.SchemaList{unorderedArraySchema(stringSchema())},
+				},
+			}),
+		},
+		"array alternative without annotation is conservative": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				valuesProperty: {
+					OneOf: jsschema.SchemaList{
+						unorderedArraySchema(stringSchema()),
+						orderedArraySchema(stringSchema()),
+					},
+				},
+			}),
+		},
+		"reference cycle": {
+			schema: &jsschema.Schema{
+				Properties: map[string]*jsschema.Schema{
+					"Nodes": {Reference: "#/definitions/Node"},
+				},
+				Definitions: map[string]*jsschema.Schema{
+					"Node": {
+						Type: jsschema.PrimitiveTypes{jsschema.ObjectType},
+						Properties: map[string]*jsschema.Schema{
+							childrenProperty: unorderedArraySchema(&jsschema.Schema{
+								Reference: "#/definitions/Node",
+							}),
+						},
+					},
+				},
+			},
+			expected: []string{"nodes/children"},
+		},
+		"multiple item schemas": {
+			schema: resourceSchema(map[string]*jsschema.Schema{
+				"Outer": {
+					Type: jsschema.PrimitiveTypes{jsschema.ArrayType},
+					Items: &jsschema.ItemSpec{TupleMode: true, Schemas: jsschema.SchemaList{
+						{Properties: map[string]*jsschema.Schema{
+							"Inner": unorderedArraySchema(stringSchema()),
+						}},
+						{Properties: map[string]*jsschema.Schema{
+							"Inner": unorderedArraySchema(stringSchema()),
+						}},
+					}},
+				},
+			}),
+			expected: []string{"outer/*/inner"},
+		},
+		"escaped local definition": {
+			schema: &jsschema.Schema{
+				Properties: map[string]*jsschema.Schema{
+					valuesProperty: {Reference: "#/definitions/Foo~1Bar"},
+				},
+				Definitions: map[string]*jsschema.Schema{
+					"Foo/Bar": unorderedArraySchema(stringSchema()),
+				},
+			},
+			expected: []string{"values"},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, readUnorderedCollections(tt.schema))
+		})
+	}
+}
+
+func resourceSchema(properties map[string]*jsschema.Schema) *jsschema.Schema {
+	return &jsschema.Schema{Properties: properties}
+}
+
+func stringSchema() *jsschema.Schema {
+	return &jsschema.Schema{Type: jsschema.PrimitiveTypes{jsschema.StringType}}
+}
+
+func unorderedArraySchema(items ...*jsschema.Schema) *jsschema.Schema {
+	return arraySchema(false, items...)
+}
+
+func orderedArraySchema(items ...*jsschema.Schema) *jsschema.Schema {
+	return &jsschema.Schema{
+		Type:  jsschema.PrimitiveTypes{jsschema.ArrayType},
+		Items: &jsschema.ItemSpec{Schemas: items},
+	}
+}
+
+func arraySchema(insertionOrder interface{}, items ...*jsschema.Schema) *jsschema.Schema {
+	return &jsschema.Schema{
+		Type:   jsschema.PrimitiveTypes{jsschema.ArrayType},
+		Items:  &jsschema.ItemSpec{Schemas: items},
+		Extras: map[string]interface{}{insertionOrderProperty: insertionOrder},
+	}
+}


### PR DESCRIPTION
## Why

CloudFormation knows whether an array is ordered or unordered through its
`insertionOrder` setting.

AWS Native currently throws that information away during schema generation. By
the time the provider compares a user's inputs with AWS state, it cannot tell
whether changing an array's order is meaningful.

This is the first half of the fix for #3066. It gives the runtime the information
needed by #3083 to avoid unnecessary updates when AWS returns an unordered array
in a different order.

## What this PR does

When a CloudFormation schema explicitly declares:

```json
"insertionOrder": false
```

the generator records that array's path in the resource's runtime metadata.

For example:

```text
policies
containerDefinitions/*/environment
```

The paths use Pulumi property names, `/` separators, and `*` for array elements.

The generated metadata currently records 2,850 unordered collection paths
across 1,416 resources.

## Why this is a separate PR

This PR only records metadata. It does not change refresh, Diff, updates, the
Pulumi package schema, or any generated SDK API.

Keeping metadata generation separate from runtime behavior makes it possible to
review whether we interpreted the CloudFormation schemas correctly before that
information affects users.

The runtime behavior is implemented in the stacked PR, #3083.

## Safety and tradeoffs

The generator only records arrays explicitly marked `insertionOrder: false`. It
does not guess based on property names, `uniqueItems`, or observed AWS behavior.

Schema references and ordinary alternatives are followed when the unordered
meaning is clear. Ambiguous schema combinations are skipped rather than
producing a path that might be wrong.

Generated paths are sorted and deduplicated so regeneration is deterministic.

Skipping an uncertain path means the provider may continue to report an
unnecessary order-only diff for that property. That is preferable to incorrectly
treating an ordered array as unordered and hiding a real change.

## Stack

This is the metadata foundation for #3083, which uses these paths during
refresh, Diff, and CloudControl patch generation.

Together, the two PRs address #3066.

## Validation

- `mise exec -- make codegen`
- `mise exec -- make generate_schema`
- `mise exec -- make test_provider_fast`
- Changed-lines `golangci-lint`: 0 issues
- Regeneration left the worktree clean
