### PR TITLE
fix(schema): preserve supported nested primitive collections

### DIFF
--- a/provider/pkg/schema/gen.go
+++ b/provider/pkg/schema/gen.go
@@ -1732,10 +1732,12 @@ func (ctx *cfSchemaContext) propertyTypeSpec(
 				return nil, err
 			}
 
-			// Where a map type has a value which is either a map or a list, replace the value with "Any" to appease Go
-			// codegen
-			// TODO: remove once Go codegen issue is solved: https://github.com/pulumi/pulumi/issues/15478
-			if valueType.Items != nil || valueType.AdditionalProperties != nil {
+			// Go codegen supports primitive collections up to three levels deep, but can still emit invalid
+			// helper types for deeper collections or collections of object values. The outer map returned below
+			// accounts for one collection level. Preserve Any for unsupported shapes.
+			// TODO: Allow nested object collections once https://github.com/pulumi/pulumi/issues/24063 is fixed.
+			if (valueType.Items != nil || valueType.AdditionalProperties != nil) &&
+				!isPrimitiveCollectionType(valueType, maxGoPrimitiveCollectionDepth-1) {
 				valueType = &pschema.TypeSpec{
 					Ref: "pulumi.json#/Any",
 				}
@@ -1919,6 +1921,31 @@ func (ctx *cfSchemaContext) propertyTypeSpec(
 
 	fmt.Printf("failed to generate property types for %+v\n", propSchema)
 	return &pschema.TypeSpec{Ref: "pulumi.json#/Any"}, nil
+}
+
+const maxGoPrimitiveCollectionDepth = 3
+
+func isPrimitiveCollectionType(typeSpec *pschema.TypeSpec, maxDepth int) bool {
+	if typeSpec == nil || maxDepth == 0 {
+		return false
+	}
+
+	var elementType *pschema.TypeSpec
+	switch {
+	case typeSpec.Items != nil:
+		elementType = typeSpec.Items
+	case typeSpec.AdditionalProperties != nil:
+		elementType = typeSpec.AdditionalProperties
+	default:
+		return false
+	}
+
+	switch elementType.Type {
+	case "boolean", "integer", "number", "string":
+		return true
+	default:
+		return isPrimitiveCollectionType(elementType, maxDepth-1)
+	}
 }
 
 // parseJsonType converts a JSON type with no additional information to a Pulumi type.

--- a/provider/pkg/schema/gen_examples_test.go
+++ b/provider/pkg/schema/gen_examples_test.go
@@ -28,6 +28,12 @@ func TestPropertyTypeSpec(t *testing.T) {
 	test := func(tt PropertyTypeSpecTestCase) func(t *testing.T) {
 		return func(t *testing.T) {
 			t.Helper()
+			parseSchema := func(source string) *jsschema.Schema {
+				t.Helper()
+				schema := jsschema.New()
+				require.NoError(t, schema.UnmarshalJSON([]byte(source)))
+				return schema
+			}
 			ctx := cfSchemaContext{
 				reports: NewReports(),
 				pkg: &pschema.PackageSpec{
@@ -56,6 +62,36 @@ func TestPropertyTypeSpec(t *testing.T) {
 								".+": jsschema.New(),
 							},
 						},
+						"StringArrayMapMap": parseSchema(`{
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "array",
+									"items": {"type": "string"}
+								}
+							}
+						}`),
+						"StringArrayMapMapMap": parseSchema(`{
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"additionalProperties": {
+									"type": "object",
+									"additionalProperties": {
+										"type": "array",
+										"items": {"type": "string"}
+									}
+								}
+							}
+						}`),
+						"ObjectMapMap": parseSchema(`{
+							"type": "object",
+							"additionalProperties": {
+								"type": "object",
+								"additionalProperties": {"$ref": "#/definitions/ObjLike1"}
+							}
+						}`),
 					},
 				},
 			}
@@ -193,6 +229,43 @@ func TestPropertyTypeSpec(t *testing.T) {
 	t.Run("ref-to-object-with-patternProperties", test(PropertyTypeSpecTestCase{
 		json: `{
 				"$ref": "#/definitions/ObjLike2"
+			 }`,
+		expected: pschema.TypeSpec{
+			Type: "object",
+			AdditionalProperties: &pschema.TypeSpec{
+				Ref: "pulumi.json#/Any",
+			},
+		},
+	}))
+	t.Run("ref-to-nested-primitive-collections", test(PropertyTypeSpecTestCase{
+		json: `{
+				"$ref": "#/definitions/StringArrayMapMap"
+			 }`,
+		expected: pschema.TypeSpec{
+			Type: "object",
+			AdditionalProperties: &pschema.TypeSpec{
+				Type: "object",
+				AdditionalProperties: &pschema.TypeSpec{
+					Type:  "array",
+					Items: &pschema.TypeSpec{Type: "string"},
+				},
+			},
+		},
+	}))
+	t.Run("ref-to-too-deep-primitive-collections", test(PropertyTypeSpecTestCase{
+		json: `{
+				"$ref": "#/definitions/StringArrayMapMapMap"
+			 }`,
+		expected: pschema.TypeSpec{
+			Type: "object",
+			AdditionalProperties: &pschema.TypeSpec{
+				Ref: "pulumi.json#/Any",
+			},
+		},
+	}))
+	t.Run("ref-to-nested-object-collections", test(PropertyTypeSpecTestCase{
+		json: `{
+				"$ref": "#/definitions/ObjectMapMap"
 			 }`,
 		expected: pschema.TypeSpec{
 			Type: "object",

--- a/reports/missedAutonaming.json
+++ b/reports/missedAutonaming.json
@@ -17126,7 +17126,10 @@
       "automationParameters": {
         "type": "object",
         "additionalProperties": {
-          "$ref": "pulumi.json#/Any"
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "description": "A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow."
       },

--- a/sdk/dotnet/AmplifyUiBuilder/Component.cs
+++ b/sdk/dotnet/AmplifyUiBuilder/Component.cs
@@ -85,7 +85,7 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder
         /// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         /// </summary>
         [Output("overrides")]
-        public Output<ImmutableDictionary<string, object>?> Overrides { get; private set; } = null!;
+        public Output<ImmutableDictionary<string, ImmutableDictionary<string, string>>?> Overrides { get; private set; } = null!;
 
         /// <summary>
         /// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
@@ -240,14 +240,14 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder
         public Input<string>? Name { get; set; }
 
         [Input("overrides")]
-        private InputMap<object>? _overrides;
+        private InputMap<ImmutableDictionary<string, string>>? _overrides;
 
         /// <summary>
         /// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         /// </summary>
-        public InputMap<object> Overrides
+        public InputMap<ImmutableDictionary<string, string>> Overrides
         {
-            get => _overrides ?? (_overrides = new InputMap<object>());
+            get => _overrides ?? (_overrides = new InputMap<ImmutableDictionary<string, string>>());
             set => _overrides = value;
         }
 

--- a/sdk/dotnet/AmplifyUiBuilder/GetComponent.cs
+++ b/sdk/dotnet/AmplifyUiBuilder/GetComponent.cs
@@ -126,7 +126,7 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder
         /// <summary>
         /// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         /// </summary>
-        public readonly ImmutableDictionary<string, object>? Overrides;
+        public readonly ImmutableDictionary<string, ImmutableDictionary<string, string>>? Overrides;
         /// <summary>
         /// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
         /// </summary>
@@ -168,7 +168,7 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder
 
             string? name,
 
-            ImmutableDictionary<string, object>? overrides,
+            ImmutableDictionary<string, ImmutableDictionary<string, string>>? overrides,
 
             ImmutableDictionary<string, Outputs.ComponentProperty>? properties,
 

--- a/sdk/dotnet/AmplifyUiBuilder/Inputs/ComponentVariantArgs.cs
+++ b/sdk/dotnet/AmplifyUiBuilder/Inputs/ComponentVariantArgs.cs
@@ -13,14 +13,14 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder.Inputs
     public sealed class ComponentVariantArgs : global::Pulumi.ResourceArgs
     {
         [Input("overrides")]
-        private InputMap<object>? _overrides;
+        private InputMap<ImmutableDictionary<string, string>>? _overrides;
 
         /// <summary>
         /// The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         /// </summary>
-        public InputMap<object> Overrides
+        public InputMap<ImmutableDictionary<string, string>> Overrides
         {
-            get => _overrides ?? (_overrides = new InputMap<object>());
+            get => _overrides ?? (_overrides = new InputMap<ImmutableDictionary<string, string>>());
             set => _overrides = value;
         }
 

--- a/sdk/dotnet/AmplifyUiBuilder/Outputs/ComponentVariant.cs
+++ b/sdk/dotnet/AmplifyUiBuilder/Outputs/ComponentVariant.cs
@@ -16,7 +16,7 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder.Outputs
         /// <summary>
         /// The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         /// </summary>
-        public readonly ImmutableDictionary<string, object>? Overrides;
+        public readonly ImmutableDictionary<string, ImmutableDictionary<string, string>>? Overrides;
         /// <summary>
         /// The combination of variants that comprise this variant.
         /// </summary>
@@ -24,7 +24,7 @@ namespace Pulumi.AwsNative.AmplifyUiBuilder.Outputs
 
         [OutputConstructor]
         private ComponentVariant(
-            ImmutableDictionary<string, object>? overrides,
+            ImmutableDictionary<string, ImmutableDictionary<string, string>>? overrides,
 
             ImmutableDictionary<string, string>? variantValues)
         {

--- a/sdk/dotnet/AppIntegrations/DataIntegration.cs
+++ b/sdk/dotnet/AppIntegrations/DataIntegration.cs
@@ -55,7 +55,7 @@ namespace Pulumi.AwsNative.AppIntegrations
         /// The configuration for what data should be pulled from the source.
         /// </summary>
         [Output("objectConfiguration")]
-        public Output<ImmutableDictionary<string, object>?> ObjectConfiguration { get; private set; } = null!;
+        public Output<ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>?> ObjectConfiguration { get; private set; } = null!;
 
         /// <summary>
         /// The name of the data and how often it should be pulled from the source.
@@ -151,14 +151,14 @@ namespace Pulumi.AwsNative.AppIntegrations
         public Input<string>? Name { get; set; }
 
         [Input("objectConfiguration")]
-        private InputMap<object>? _objectConfiguration;
+        private InputMap<ImmutableDictionary<string, ImmutableArray<string>>>? _objectConfiguration;
 
         /// <summary>
         /// The configuration for what data should be pulled from the source.
         /// </summary>
-        public InputMap<object> ObjectConfiguration
+        public InputMap<ImmutableDictionary<string, ImmutableArray<string>>> ObjectConfiguration
         {
-            get => _objectConfiguration ?? (_objectConfiguration = new InputMap<object>());
+            get => _objectConfiguration ?? (_objectConfiguration = new InputMap<ImmutableDictionary<string, ImmutableArray<string>>>());
             set => _objectConfiguration = value;
         }
 

--- a/sdk/dotnet/AppIntegrations/GetDataIntegration.cs
+++ b/sdk/dotnet/AppIntegrations/GetDataIntegration.cs
@@ -86,7 +86,7 @@ namespace Pulumi.AwsNative.AppIntegrations
         /// <summary>
         /// The configuration for what data should be pulled from the source.
         /// </summary>
-        public readonly ImmutableDictionary<string, object>? ObjectConfiguration;
+        public readonly ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>? ObjectConfiguration;
         /// <summary>
         /// The tags (keys and values) associated with the data integration.
         /// </summary>
@@ -104,7 +104,7 @@ namespace Pulumi.AwsNative.AppIntegrations
 
             string? name,
 
-            ImmutableDictionary<string, object>? objectConfiguration,
+            ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>? objectConfiguration,
 
             ImmutableArray<Pulumi.AwsNative.Outputs.Tag> tags)
         {

--- a/sdk/dotnet/BcmDataExports/Inputs/ExportDataQueryArgs.cs
+++ b/sdk/dotnet/BcmDataExports/Inputs/ExportDataQueryArgs.cs
@@ -19,14 +19,14 @@ namespace Pulumi.AwsNative.BcmDataExports.Inputs
         public Input<string> QueryStatement { get; set; } = null!;
 
         [Input("tableConfigurations")]
-        private InputMap<object>? _tableConfigurations;
+        private InputMap<ImmutableDictionary<string, string>>? _tableConfigurations;
 
         /// <summary>
         /// The table configuration.
         /// </summary>
-        public InputMap<object> TableConfigurations
+        public InputMap<ImmutableDictionary<string, string>> TableConfigurations
         {
-            get => _tableConfigurations ?? (_tableConfigurations = new InputMap<object>());
+            get => _tableConfigurations ?? (_tableConfigurations = new InputMap<ImmutableDictionary<string, string>>());
             set => _tableConfigurations = value;
         }
 

--- a/sdk/dotnet/BcmDataExports/Outputs/ExportDataQuery.cs
+++ b/sdk/dotnet/BcmDataExports/Outputs/ExportDataQuery.cs
@@ -20,13 +20,13 @@ namespace Pulumi.AwsNative.BcmDataExports.Outputs
         /// <summary>
         /// The table configuration.
         /// </summary>
-        public readonly ImmutableDictionary<string, object>? TableConfigurations;
+        public readonly ImmutableDictionary<string, ImmutableDictionary<string, string>>? TableConfigurations;
 
         [OutputConstructor]
         private ExportDataQuery(
             string queryStatement,
 
-            ImmutableDictionary<string, object>? tableConfigurations)
+            ImmutableDictionary<string, ImmutableDictionary<string, string>>? tableConfigurations)
         {
             QueryStatement = queryStatement;
             TableConfigurations = tableConfigurations;

--- a/sdk/dotnet/DataZone/Inputs/DataSourceSageMakerRunConfigurationInputArgs.cs
+++ b/sdk/dotnet/DataZone/Inputs/DataSourceSageMakerRunConfigurationInputArgs.cs
@@ -16,14 +16,14 @@ namespace Pulumi.AwsNative.DataZone.Inputs
     public sealed class DataSourceSageMakerRunConfigurationInputArgs : global::Pulumi.ResourceArgs
     {
         [Input("trackingAssets", required: true)]
-        private InputMap<object>? _trackingAssets;
+        private InputMap<ImmutableArray<string>>? _trackingAssets;
 
         /// <summary>
         /// The tracking assets of the Amazon SageMaker run.
         /// </summary>
-        public InputMap<object> TrackingAssets
+        public InputMap<ImmutableArray<string>> TrackingAssets
         {
-            get => _trackingAssets ?? (_trackingAssets = new InputMap<object>());
+            get => _trackingAssets ?? (_trackingAssets = new InputMap<ImmutableArray<string>>());
             set => _trackingAssets = value;
         }
 

--- a/sdk/dotnet/DataZone/Outputs/DataSourceSageMakerRunConfigurationInput.cs
+++ b/sdk/dotnet/DataZone/Outputs/DataSourceSageMakerRunConfigurationInput.cs
@@ -19,10 +19,10 @@ namespace Pulumi.AwsNative.DataZone.Outputs
         /// <summary>
         /// The tracking assets of the Amazon SageMaker run.
         /// </summary>
-        public readonly ImmutableDictionary<string, object> TrackingAssets;
+        public readonly ImmutableDictionary<string, ImmutableArray<string>> TrackingAssets;
 
         [OutputConstructor]
-        private DataSourceSageMakerRunConfigurationInput(ImmutableDictionary<string, object> trackingAssets)
+        private DataSourceSageMakerRunConfigurationInput(ImmutableDictionary<string, ImmutableArray<string>> trackingAssets)
         {
             TrackingAssets = trackingAssets;
         }

--- a/sdk/dotnet/InspectorV2/Inputs/CisScanConfigurationCisTargetsArgs.cs
+++ b/sdk/dotnet/InspectorV2/Inputs/CisScanConfigurationCisTargetsArgs.cs
@@ -21,10 +21,10 @@ namespace Pulumi.AwsNative.InspectorV2.Inputs
         }
 
         [Input("targetResourceTags", required: true)]
-        private InputMap<object>? _targetResourceTags;
-        public InputMap<object> TargetResourceTags
+        private InputMap<ImmutableArray<string>>? _targetResourceTags;
+        public InputMap<ImmutableArray<string>> TargetResourceTags
         {
-            get => _targetResourceTags ?? (_targetResourceTags = new InputMap<object>());
+            get => _targetResourceTags ?? (_targetResourceTags = new InputMap<ImmutableArray<string>>());
             set => _targetResourceTags = value;
         }
 

--- a/sdk/dotnet/InspectorV2/Outputs/CisScanConfigurationCisTargets.cs
+++ b/sdk/dotnet/InspectorV2/Outputs/CisScanConfigurationCisTargets.cs
@@ -14,13 +14,13 @@ namespace Pulumi.AwsNative.InspectorV2.Outputs
     public sealed class CisScanConfigurationCisTargets
     {
         public readonly ImmutableArray<string> AccountIds;
-        public readonly ImmutableDictionary<string, object> TargetResourceTags;
+        public readonly ImmutableDictionary<string, ImmutableArray<string>> TargetResourceTags;
 
         [OutputConstructor]
         private CisScanConfigurationCisTargets(
             ImmutableArray<string> accountIds,
 
-            ImmutableDictionary<string, object> targetResourceTags)
+            ImmutableDictionary<string, ImmutableArray<string>> targetResourceTags)
         {
             AccountIds = accountIds;
             TargetResourceTags = targetResourceTags;

--- a/sdk/dotnet/SsmQuickSetup/GetLifecycleAutomation.cs
+++ b/sdk/dotnet/SsmQuickSetup/GetLifecycleAutomation.cs
@@ -74,7 +74,7 @@ namespace Pulumi.AwsNative.SsmQuickSetup
         /// <summary>
         /// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         /// </summary>
-        public readonly ImmutableDictionary<string, object>? AutomationParameters;
+        public readonly ImmutableDictionary<string, ImmutableArray<string>>? AutomationParameters;
         /// <summary>
         /// Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
         /// </summary>
@@ -86,7 +86,7 @@ namespace Pulumi.AwsNative.SsmQuickSetup
 
             string? automationDocument,
 
-            ImmutableDictionary<string, object>? automationParameters,
+            ImmutableDictionary<string, ImmutableArray<string>>? automationParameters,
 
             ImmutableDictionary<string, string>? tags)
         {

--- a/sdk/dotnet/SsmQuickSetup/LifecycleAutomation.cs
+++ b/sdk/dotnet/SsmQuickSetup/LifecycleAutomation.cs
@@ -31,7 +31,7 @@ namespace Pulumi.AwsNative.SsmQuickSetup
         /// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         /// </summary>
         [Output("automationParameters")]
-        public Output<ImmutableDictionary<string, object>> AutomationParameters { get; private set; } = null!;
+        public Output<ImmutableDictionary<string, ImmutableArray<string>>> AutomationParameters { get; private set; } = null!;
 
         /// <summary>
         /// A unique identifier used for generating a unique logical ID for the custom resource
@@ -101,14 +101,14 @@ namespace Pulumi.AwsNative.SsmQuickSetup
         public Input<string> AutomationDocument { get; set; } = null!;
 
         [Input("automationParameters", required: true)]
-        private InputMap<object>? _automationParameters;
+        private InputMap<ImmutableArray<string>>? _automationParameters;
 
         /// <summary>
         /// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         /// </summary>
-        public InputMap<object> AutomationParameters
+        public InputMap<ImmutableArray<string>> AutomationParameters
         {
-            get => _automationParameters ?? (_automationParameters = new InputMap<object>());
+            get => _automationParameters ?? (_automationParameters = new InputMap<ImmutableArray<string>>());
             set => _automationParameters = value;
         }
 

--- a/sdk/go/aws/amplifyuibuilder/component.go
+++ b/sdk/go/aws/amplifyuibuilder/component.go
@@ -38,7 +38,7 @@ type Component struct {
 	// The name of the component.
 	Name pulumi.StringPtrOutput `pulumi:"name"`
 	// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides pulumi.MapOutput `pulumi:"overrides"`
+	Overrides pulumi.StringMapMapOutput `pulumi:"overrides"`
 	// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
 	Properties ComponentPropertyMapOutput `pulumi:"properties"`
 	// The schema version of the component when it was imported.
@@ -113,7 +113,7 @@ type componentArgs struct {
 	// The name of the component.
 	Name *string `pulumi:"name"`
 	// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides map[string]interface{} `pulumi:"overrides"`
+	Overrides map[string]map[string]string `pulumi:"overrides"`
 	// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
 	Properties map[string]ComponentProperty `pulumi:"properties"`
 	// The schema version of the component when it was imported.
@@ -145,7 +145,7 @@ type ComponentArgs struct {
 	// The name of the component.
 	Name pulumi.StringPtrInput
 	// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides pulumi.MapInput
+	Overrides pulumi.StringMapMapInput
 	// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
 	Properties ComponentPropertyMapInput
 	// The schema version of the component when it was imported.
@@ -251,8 +251,8 @@ func (o ComponentOutput) Name() pulumi.StringPtrOutput {
 }
 
 // Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-func (o ComponentOutput) Overrides() pulumi.MapOutput {
-	return o.ApplyT(func(v *Component) pulumi.MapOutput { return v.Overrides }).(pulumi.MapOutput)
+func (o ComponentOutput) Overrides() pulumi.StringMapMapOutput {
+	return o.ApplyT(func(v *Component) pulumi.StringMapMapOutput { return v.Overrides }).(pulumi.StringMapMapOutput)
 }
 
 // Describes the component's properties. You can't specify `tags` as a valid property for `properties` .

--- a/sdk/go/aws/amplifyuibuilder/getComponent.go
+++ b/sdk/go/aws/amplifyuibuilder/getComponent.go
@@ -51,7 +51,7 @@ type LookupComponentResult struct {
 	// The name of the component.
 	Name *string `pulumi:"name"`
 	// Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides map[string]interface{} `pulumi:"overrides"`
+	Overrides map[string]map[string]string `pulumi:"overrides"`
 	// Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
 	Properties map[string]ComponentProperty `pulumi:"properties"`
 	// The schema version of the component when it was imported.
@@ -146,8 +146,8 @@ func (o LookupComponentResultOutput) Name() pulumi.StringPtrOutput {
 }
 
 // Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
-func (o LookupComponentResultOutput) Overrides() pulumi.MapOutput {
-	return o.ApplyT(func(v LookupComponentResult) map[string]interface{} { return v.Overrides }).(pulumi.MapOutput)
+func (o LookupComponentResultOutput) Overrides() pulumi.StringMapMapOutput {
+	return o.ApplyT(func(v LookupComponentResult) map[string]map[string]string { return v.Overrides }).(pulumi.StringMapMapOutput)
 }
 
 // Describes the component's properties. You can't specify `tags` as a valid property for `properties` .

--- a/sdk/go/aws/amplifyuibuilder/pulumiTypes.go
+++ b/sdk/go/aws/amplifyuibuilder/pulumiTypes.go
@@ -2636,7 +2636,7 @@ func (o ComponentSortPropertyArrayOutput) Index(i pulumi.IntInput) ComponentSort
 
 type ComponentVariant struct {
 	// The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides map[string]interface{} `pulumi:"overrides"`
+	Overrides map[string]map[string]string `pulumi:"overrides"`
 	// The combination of variants that comprise this variant.
 	VariantValues map[string]string `pulumi:"variantValues"`
 }
@@ -2654,7 +2654,7 @@ type ComponentVariantInput interface {
 
 type ComponentVariantArgs struct {
 	// The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
-	Overrides pulumi.MapInput `pulumi:"overrides"`
+	Overrides pulumi.StringMapMapInput `pulumi:"overrides"`
 	// The combination of variants that comprise this variant.
 	VariantValues pulumi.StringMapInput `pulumi:"variantValues"`
 }
@@ -2711,8 +2711,8 @@ func (o ComponentVariantOutput) ToComponentVariantOutputWithContext(ctx context.
 }
 
 // The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
-func (o ComponentVariantOutput) Overrides() pulumi.MapOutput {
-	return o.ApplyT(func(v ComponentVariant) map[string]interface{} { return v.Overrides }).(pulumi.MapOutput)
+func (o ComponentVariantOutput) Overrides() pulumi.StringMapMapOutput {
+	return o.ApplyT(func(v ComponentVariant) map[string]map[string]string { return v.Overrides }).(pulumi.StringMapMapOutput)
 }
 
 // The combination of variants that comprise this variant.

--- a/sdk/go/aws/appintegrations/dataIntegration.go
+++ b/sdk/go/aws/appintegrations/dataIntegration.go
@@ -30,7 +30,7 @@ type DataIntegration struct {
 	// The name of the data integration.
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The configuration for what data should be pulled from the source.
-	ObjectConfiguration pulumi.MapOutput `pulumi:"objectConfiguration"`
+	ObjectConfiguration pulumi.StringArrayMapMapOutput `pulumi:"objectConfiguration"`
 	// The name of the data and how often it should be pulled from the source.
 	ScheduleConfig DataIntegrationScheduleConfigPtrOutput `pulumi:"scheduleConfig"`
 	// The URI of the data source.
@@ -100,7 +100,7 @@ type dataIntegrationArgs struct {
 	// The name of the data integration.
 	Name *string `pulumi:"name"`
 	// The configuration for what data should be pulled from the source.
-	ObjectConfiguration map[string]interface{} `pulumi:"objectConfiguration"`
+	ObjectConfiguration map[string]map[string][]string `pulumi:"objectConfiguration"`
 	// The name of the data and how often it should be pulled from the source.
 	ScheduleConfig *DataIntegrationScheduleConfig `pulumi:"scheduleConfig"`
 	// The URI of the data source.
@@ -120,7 +120,7 @@ type DataIntegrationArgs struct {
 	// The name of the data integration.
 	Name pulumi.StringPtrInput
 	// The configuration for what data should be pulled from the source.
-	ObjectConfiguration pulumi.MapInput
+	ObjectConfiguration pulumi.StringArrayMapMapInput
 	// The name of the data and how often it should be pulled from the source.
 	ScheduleConfig DataIntegrationScheduleConfigPtrInput
 	// The URI of the data source.
@@ -197,8 +197,8 @@ func (o DataIntegrationOutput) Name() pulumi.StringOutput {
 }
 
 // The configuration for what data should be pulled from the source.
-func (o DataIntegrationOutput) ObjectConfiguration() pulumi.MapOutput {
-	return o.ApplyT(func(v *DataIntegration) pulumi.MapOutput { return v.ObjectConfiguration }).(pulumi.MapOutput)
+func (o DataIntegrationOutput) ObjectConfiguration() pulumi.StringArrayMapMapOutput {
+	return o.ApplyT(func(v *DataIntegration) pulumi.StringArrayMapMapOutput { return v.ObjectConfiguration }).(pulumi.StringArrayMapMapOutput)
 }
 
 // The name of the data and how often it should be pulled from the source.

--- a/sdk/go/aws/appintegrations/getDataIntegration.go
+++ b/sdk/go/aws/appintegrations/getDataIntegration.go
@@ -40,7 +40,7 @@ type LookupDataIntegrationResult struct {
 	// The name of the data integration.
 	Name *string `pulumi:"name"`
 	// The configuration for what data should be pulled from the source.
-	ObjectConfiguration map[string]interface{} `pulumi:"objectConfiguration"`
+	ObjectConfiguration map[string]map[string][]string `pulumi:"objectConfiguration"`
 	// The tags (keys and values) associated with the data integration.
 	Tags []aws.Tag `pulumi:"tags"`
 }
@@ -103,8 +103,8 @@ func (o LookupDataIntegrationResultOutput) Name() pulumi.StringPtrOutput {
 }
 
 // The configuration for what data should be pulled from the source.
-func (o LookupDataIntegrationResultOutput) ObjectConfiguration() pulumi.MapOutput {
-	return o.ApplyT(func(v LookupDataIntegrationResult) map[string]interface{} { return v.ObjectConfiguration }).(pulumi.MapOutput)
+func (o LookupDataIntegrationResultOutput) ObjectConfiguration() pulumi.StringArrayMapMapOutput {
+	return o.ApplyT(func(v LookupDataIntegrationResult) map[string]map[string][]string { return v.ObjectConfiguration }).(pulumi.StringArrayMapMapOutput)
 }
 
 // The tags (keys and values) associated with the data integration.

--- a/sdk/go/aws/bcmdataexports/pulumiTypes.go
+++ b/sdk/go/aws/bcmdataexports/pulumiTypes.go
@@ -198,7 +198,7 @@ type ExportDataQuery struct {
 	// The query statement.
 	QueryStatement string `pulumi:"queryStatement"`
 	// The table configuration.
-	TableConfigurations map[string]interface{} `pulumi:"tableConfigurations"`
+	TableConfigurations map[string]map[string]string `pulumi:"tableConfigurations"`
 }
 
 // ExportDataQueryInput is an input type that accepts ExportDataQueryArgs and ExportDataQueryOutput values.
@@ -216,7 +216,7 @@ type ExportDataQueryArgs struct {
 	// The query statement.
 	QueryStatement pulumi.StringInput `pulumi:"queryStatement"`
 	// The table configuration.
-	TableConfigurations pulumi.MapInput `pulumi:"tableConfigurations"`
+	TableConfigurations pulumi.StringMapMapInput `pulumi:"tableConfigurations"`
 }
 
 func (ExportDataQueryArgs) ElementType() reflect.Type {
@@ -251,8 +251,8 @@ func (o ExportDataQueryOutput) QueryStatement() pulumi.StringOutput {
 }
 
 // The table configuration.
-func (o ExportDataQueryOutput) TableConfigurations() pulumi.MapOutput {
-	return o.ApplyT(func(v ExportDataQuery) map[string]interface{} { return v.TableConfigurations }).(pulumi.MapOutput)
+func (o ExportDataQueryOutput) TableConfigurations() pulumi.StringMapMapOutput {
+	return o.ApplyT(func(v ExportDataQuery) map[string]map[string]string { return v.TableConfigurations }).(pulumi.StringMapMapOutput)
 }
 
 type ExportDataQueryPtrOutput struct{ *pulumi.OutputState }
@@ -290,13 +290,13 @@ func (o ExportDataQueryPtrOutput) QueryStatement() pulumi.StringPtrOutput {
 }
 
 // The table configuration.
-func (o ExportDataQueryPtrOutput) TableConfigurations() pulumi.MapOutput {
-	return o.ApplyT(func(v *ExportDataQuery) map[string]interface{} {
+func (o ExportDataQueryPtrOutput) TableConfigurations() pulumi.StringMapMapOutput {
+	return o.ApplyT(func(v *ExportDataQuery) map[string]map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.TableConfigurations
-	}).(pulumi.MapOutput)
+	}).(pulumi.StringMapMapOutput)
 }
 
 type ExportDestinationConfigurations struct {

--- a/sdk/go/aws/datazone/pulumiTypes.go
+++ b/sdk/go/aws/datazone/pulumiTypes.go
@@ -8855,7 +8855,7 @@ func (o DataSourceRelationalFilterConfigurationArrayOutput) Index(i pulumi.IntIn
 // The configuration details of the Amazon SageMaker data source.
 type DataSourceSageMakerRunConfigurationInput struct {
 	// The tracking assets of the Amazon SageMaker run.
-	TrackingAssets map[string]interface{} `pulumi:"trackingAssets"`
+	TrackingAssets map[string][]string `pulumi:"trackingAssets"`
 }
 
 // DataSourceSageMakerRunConfigurationInputInput is an input type that accepts DataSourceSageMakerRunConfigurationInputArgs and DataSourceSageMakerRunConfigurationInputOutput values.
@@ -8872,7 +8872,7 @@ type DataSourceSageMakerRunConfigurationInputInput interface {
 // The configuration details of the Amazon SageMaker data source.
 type DataSourceSageMakerRunConfigurationInputArgs struct {
 	// The tracking assets of the Amazon SageMaker run.
-	TrackingAssets pulumi.MapInput `pulumi:"trackingAssets"`
+	TrackingAssets pulumi.StringArrayMapInput `pulumi:"trackingAssets"`
 }
 
 func (DataSourceSageMakerRunConfigurationInputArgs) ElementType() reflect.Type {
@@ -8954,8 +8954,8 @@ func (o DataSourceSageMakerRunConfigurationInputOutput) ToDataSourceSageMakerRun
 }
 
 // The tracking assets of the Amazon SageMaker run.
-func (o DataSourceSageMakerRunConfigurationInputOutput) TrackingAssets() pulumi.MapOutput {
-	return o.ApplyT(func(v DataSourceSageMakerRunConfigurationInput) map[string]interface{} { return v.TrackingAssets }).(pulumi.MapOutput)
+func (o DataSourceSageMakerRunConfigurationInputOutput) TrackingAssets() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v DataSourceSageMakerRunConfigurationInput) map[string][]string { return v.TrackingAssets }).(pulumi.StringArrayMapOutput)
 }
 
 type DataSourceSageMakerRunConfigurationInputPtrOutput struct{ *pulumi.OutputState }
@@ -8983,13 +8983,13 @@ func (o DataSourceSageMakerRunConfigurationInputPtrOutput) Elem() DataSourceSage
 }
 
 // The tracking assets of the Amazon SageMaker run.
-func (o DataSourceSageMakerRunConfigurationInputPtrOutput) TrackingAssets() pulumi.MapOutput {
-	return o.ApplyT(func(v *DataSourceSageMakerRunConfigurationInput) map[string]interface{} {
+func (o DataSourceSageMakerRunConfigurationInputPtrOutput) TrackingAssets() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v *DataSourceSageMakerRunConfigurationInput) map[string][]string {
 		if v == nil {
 			return nil
 		}
 		return v.TrackingAssets
-	}).(pulumi.MapOutput)
+	}).(pulumi.StringArrayMapOutput)
 }
 
 // The schedule of the data source runs.

--- a/sdk/go/aws/inspectorv2/pulumiTypes.go
+++ b/sdk/go/aws/inspectorv2/pulumiTypes.go
@@ -14,8 +14,8 @@ import (
 var _ = internal.GetEnvOrDefault
 
 type CisScanConfigurationCisTargets struct {
-	AccountIds         []string               `pulumi:"accountIds"`
-	TargetResourceTags map[string]interface{} `pulumi:"targetResourceTags"`
+	AccountIds         []string            `pulumi:"accountIds"`
+	TargetResourceTags map[string][]string `pulumi:"targetResourceTags"`
 }
 
 // CisScanConfigurationCisTargetsInput is an input type that accepts CisScanConfigurationCisTargetsArgs and CisScanConfigurationCisTargetsOutput values.
@@ -30,8 +30,8 @@ type CisScanConfigurationCisTargetsInput interface {
 }
 
 type CisScanConfigurationCisTargetsArgs struct {
-	AccountIds         pulumi.StringArrayInput `pulumi:"accountIds"`
-	TargetResourceTags pulumi.MapInput         `pulumi:"targetResourceTags"`
+	AccountIds         pulumi.StringArrayInput    `pulumi:"accountIds"`
+	TargetResourceTags pulumi.StringArrayMapInput `pulumi:"targetResourceTags"`
 }
 
 func (CisScanConfigurationCisTargetsArgs) ElementType() reflect.Type {
@@ -64,8 +64,8 @@ func (o CisScanConfigurationCisTargetsOutput) AccountIds() pulumi.StringArrayOut
 	return o.ApplyT(func(v CisScanConfigurationCisTargets) []string { return v.AccountIds }).(pulumi.StringArrayOutput)
 }
 
-func (o CisScanConfigurationCisTargetsOutput) TargetResourceTags() pulumi.MapOutput {
-	return o.ApplyT(func(v CisScanConfigurationCisTargets) map[string]interface{} { return v.TargetResourceTags }).(pulumi.MapOutput)
+func (o CisScanConfigurationCisTargetsOutput) TargetResourceTags() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v CisScanConfigurationCisTargets) map[string][]string { return v.TargetResourceTags }).(pulumi.StringArrayMapOutput)
 }
 
 type CisScanConfigurationCisTargetsPtrOutput struct{ *pulumi.OutputState }
@@ -101,13 +101,13 @@ func (o CisScanConfigurationCisTargetsPtrOutput) AccountIds() pulumi.StringArray
 	}).(pulumi.StringArrayOutput)
 }
 
-func (o CisScanConfigurationCisTargetsPtrOutput) TargetResourceTags() pulumi.MapOutput {
-	return o.ApplyT(func(v *CisScanConfigurationCisTargets) map[string]interface{} {
+func (o CisScanConfigurationCisTargetsPtrOutput) TargetResourceTags() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v *CisScanConfigurationCisTargets) map[string][]string {
 		if v == nil {
 			return nil
 		}
 		return v.TargetResourceTags
-	}).(pulumi.MapOutput)
+	}).(pulumi.StringArrayMapOutput)
 }
 
 type CisScanConfigurationDailySchedule struct {

--- a/sdk/go/aws/ssmquicksetup/getLifecycleAutomation.go
+++ b/sdk/go/aws/ssmquicksetup/getLifecycleAutomation.go
@@ -33,7 +33,7 @@ type LookupLifecycleAutomationResult struct {
 	// The name of the Automation document to execute
 	AutomationDocument *string `pulumi:"automationDocument"`
 	// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-	AutomationParameters map[string]interface{} `pulumi:"automationParameters"`
+	AutomationParameters map[string][]string `pulumi:"automationParameters"`
 	// Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
 	Tags map[string]string `pulumi:"tags"`
 }
@@ -81,8 +81,8 @@ func (o LookupLifecycleAutomationResultOutput) AutomationDocument() pulumi.Strin
 }
 
 // A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-func (o LookupLifecycleAutomationResultOutput) AutomationParameters() pulumi.MapOutput {
-	return o.ApplyT(func(v LookupLifecycleAutomationResult) map[string]interface{} { return v.AutomationParameters }).(pulumi.MapOutput)
+func (o LookupLifecycleAutomationResultOutput) AutomationParameters() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v LookupLifecycleAutomationResult) map[string][]string { return v.AutomationParameters }).(pulumi.StringArrayMapOutput)
 }
 
 // Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.

--- a/sdk/go/aws/ssmquicksetup/lifecycleAutomation.go
+++ b/sdk/go/aws/ssmquicksetup/lifecycleAutomation.go
@@ -21,7 +21,7 @@ type LifecycleAutomation struct {
 	// The name of the Automation document to execute
 	AutomationDocument pulumi.StringOutput `pulumi:"automationDocument"`
 	// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-	AutomationParameters pulumi.MapOutput `pulumi:"automationParameters"`
+	AutomationParameters pulumi.StringArrayMapOutput `pulumi:"automationParameters"`
 	// A unique identifier used for generating a unique logical ID for the custom resource
 	ResourceKey pulumi.StringOutput `pulumi:"resourceKey"`
 	// Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
@@ -84,7 +84,7 @@ type lifecycleAutomationArgs struct {
 	// The name of the Automation document to execute
 	AutomationDocument string `pulumi:"automationDocument"`
 	// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-	AutomationParameters map[string]interface{} `pulumi:"automationParameters"`
+	AutomationParameters map[string][]string `pulumi:"automationParameters"`
 	// A unique identifier used for generating a unique logical ID for the custom resource
 	ResourceKey string `pulumi:"resourceKey"`
 	// Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
@@ -96,7 +96,7 @@ type LifecycleAutomationArgs struct {
 	// The name of the Automation document to execute
 	AutomationDocument pulumi.StringInput
 	// A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-	AutomationParameters pulumi.MapInput
+	AutomationParameters pulumi.StringArrayMapInput
 	// A unique identifier used for generating a unique logical ID for the custom resource
 	ResourceKey pulumi.StringInput
 	// Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
@@ -151,8 +151,8 @@ func (o LifecycleAutomationOutput) AutomationDocument() pulumi.StringOutput {
 }
 
 // A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
-func (o LifecycleAutomationOutput) AutomationParameters() pulumi.MapOutput {
-	return o.ApplyT(func(v *LifecycleAutomation) pulumi.MapOutput { return v.AutomationParameters }).(pulumi.MapOutput)
+func (o LifecycleAutomationOutput) AutomationParameters() pulumi.StringArrayMapOutput {
+	return o.ApplyT(func(v *LifecycleAutomation) pulumi.StringArrayMapOutput { return v.AutomationParameters }).(pulumi.StringArrayMapOutput)
 }
 
 // A unique identifier used for generating a unique logical ID for the custom resource

--- a/sdk/nodejs/amplifyuibuilder/component.ts
+++ b/sdk/nodejs/amplifyuibuilder/component.ts
@@ -84,7 +84,7 @@ export class Component extends pulumi.CustomResource {
     /**
      * Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
      */
-    declare public readonly overrides: pulumi.Output<{[key: string]: any} | undefined>;
+    declare public readonly overrides: pulumi.Output<{[key: string]: {[key: string]: string}} | undefined>;
     /**
      * Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
      */
@@ -199,7 +199,7 @@ export interface ComponentArgs {
     /**
      * Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
      */
-    overrides?: pulumi.Input<{[key: string]: any} | undefined>;
+    overrides?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>} | undefined>;
     /**
      * Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
      */

--- a/sdk/nodejs/amplifyuibuilder/getComponent.ts
+++ b/sdk/nodejs/amplifyuibuilder/getComponent.ts
@@ -74,7 +74,7 @@ export interface GetComponentResult {
     /**
      * Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
      */
-    readonly overrides?: {[key: string]: any};
+    readonly overrides?: {[key: string]: {[key: string]: string}};
     /**
      * Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
      */

--- a/sdk/nodejs/appintegrations/dataIntegration.ts
+++ b/sdk/nodejs/appintegrations/dataIntegration.ts
@@ -64,7 +64,7 @@ export class DataIntegration extends pulumi.CustomResource {
     /**
      * The configuration for what data should be pulled from the source.
      */
-    declare public readonly objectConfiguration: pulumi.Output<{[key: string]: any} | undefined>;
+    declare public readonly objectConfiguration: pulumi.Output<{[key: string]: {[key: string]: string[]}} | undefined>;
     /**
      * The name of the data and how often it should be pulled from the source.
      */
@@ -147,7 +147,7 @@ export interface DataIntegrationArgs {
     /**
      * The configuration for what data should be pulled from the source.
      */
-    objectConfiguration?: pulumi.Input<{[key: string]: any} | undefined>;
+    objectConfiguration?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<string>[]>}>} | undefined>;
     /**
      * The name of the data and how often it should be pulled from the source.
      */

--- a/sdk/nodejs/appintegrations/getDataIntegration.ts
+++ b/sdk/nodejs/appintegrations/getDataIntegration.ts
@@ -48,7 +48,7 @@ export interface GetDataIntegrationResult {
     /**
      * The configuration for what data should be pulled from the source.
      */
-    readonly objectConfiguration?: {[key: string]: any};
+    readonly objectConfiguration?: {[key: string]: {[key: string]: string[]}};
     /**
      * The tags (keys and values) associated with the data integration.
      */

--- a/sdk/nodejs/ssmquicksetup/getLifecycleAutomation.ts
+++ b/sdk/nodejs/ssmquicksetup/getLifecycleAutomation.ts
@@ -33,7 +33,7 @@ export interface GetLifecycleAutomationResult {
     /**
      * A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
      */
-    readonly automationParameters?: {[key: string]: any};
+    readonly automationParameters?: {[key: string]: string[]};
     /**
      * Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
      */

--- a/sdk/nodejs/ssmquicksetup/lifecycleAutomation.ts
+++ b/sdk/nodejs/ssmquicksetup/lifecycleAutomation.ts
@@ -45,7 +45,7 @@ export class LifecycleAutomation extends pulumi.CustomResource {
     /**
      * A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
      */
-    declare public readonly automationParameters: pulumi.Output<{[key: string]: any}>;
+    declare public readonly automationParameters: pulumi.Output<{[key: string]: string[]}>;
     /**
      * A unique identifier used for generating a unique logical ID for the custom resource
      */
@@ -105,7 +105,7 @@ export interface LifecycleAutomationArgs {
     /**
      * A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
      */
-    automationParameters: pulumi.Input<{[key: string]: any}>;
+    automationParameters: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<string>[]>}>;
     /**
      * A unique identifier used for generating a unique logical ID for the custom resource
      */

--- a/sdk/python/pulumi_aws_native/amplifyuibuilder/_inputs.py
+++ b/sdk/python/pulumi_aws_native/amplifyuibuilder/_inputs.py
@@ -1596,7 +1596,7 @@ class ComponentSortPropertyArgs:
 
 
 class ComponentVariantArgsDict(TypedDict):
-    overrides: NotRequired[pulumi.Input[Optional[Mapping[str, Any]]]]
+    overrides: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]]
     """
     The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
     """
@@ -1608,10 +1608,10 @@ class ComponentVariantArgsDict(TypedDict):
 @pulumi.input_type
 class ComponentVariantArgs:
     def __init__(__self__, *,
-                 overrides: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 overrides: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]] = None,
                  variant_values: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
-        :param pulumi.Input[Mapping[str, Any]] overrides: The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]] overrides: The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] variant_values: The combination of variants that comprise this variant.
         """
         if overrides is not None:
@@ -1621,14 +1621,14 @@ class ComponentVariantArgs:
 
     @_builtins.property
     @pulumi.getter
-    def overrides(self) -> pulumi.Input[Optional[Mapping[str, Any]]]:
+    def overrides(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]:
         """
         The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         """
         return pulumi.get(self, "overrides")
 
     @overrides.setter
-    def overrides(self, value: pulumi.Input[Optional[Mapping[str, Any]]]):
+    def overrides(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]):
         pulumi.set(self, "overrides", value)
 
     @_builtins.property

--- a/sdk/python/pulumi_aws_native/amplifyuibuilder/component.py
+++ b/sdk/python/pulumi_aws_native/amplifyuibuilder/component.py
@@ -30,7 +30,7 @@ class ComponentArgs:
                  environment_name: pulumi.Input[Optional[_builtins.str]] = None,
                  events: pulumi.Input[Optional[Mapping[str, pulumi.Input['ComponentEventArgs']]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 overrides: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 overrides: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]] = None,
                  properties: pulumi.Input[Optional[Mapping[str, pulumi.Input['ComponentPropertyArgs']]]] = None,
                  schema_version: pulumi.Input[Optional[_builtins.str]] = None,
                  source_id: pulumi.Input[Optional[_builtins.str]] = None,
@@ -47,7 +47,7 @@ class ComponentArgs:
         :param pulumi.Input[_builtins.str] environment_name: The name of the backend environment that is a part of the Amplify app.
         :param pulumi.Input[Mapping[str, pulumi.Input['ComponentEventArgs']]] events: Describes the events that can be raised on the component. Use for the workflow feature in Amplify Studio that allows you to bind events and actions to components.
         :param pulumi.Input[_builtins.str] name: The name of the component.
-        :param pulumi.Input[Mapping[str, Any]] overrides: Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]] overrides: Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         :param pulumi.Input[Mapping[str, pulumi.Input['ComponentPropertyArgs']]] properties: Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
         :param pulumi.Input[_builtins.str] schema_version: The schema version of the component when it was imported.
         :param pulumi.Input[_builtins.str] source_id: The unique ID of the component in its original source system, such as Figma.
@@ -181,14 +181,14 @@ class ComponentArgs:
 
     @_builtins.property
     @pulumi.getter
-    def overrides(self) -> pulumi.Input[Optional[Mapping[str, Any]]]:
+    def overrides(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]:
         """
         Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         """
         return pulumi.get(self, "overrides")
 
     @overrides.setter
-    def overrides(self, value: pulumi.Input[Optional[Mapping[str, Any]]]):
+    def overrides(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]):
         pulumi.set(self, "overrides", value)
 
     @_builtins.property
@@ -266,7 +266,7 @@ class Component(pulumi.CustomResource):
                  environment_name: pulumi.Input[Optional[_builtins.str]] = None,
                  events: pulumi.Input[Optional[Mapping[str, pulumi.Input[Union['ComponentEventArgs', 'ComponentEventArgsDict']]]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 overrides: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 overrides: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]] = None,
                  properties: pulumi.Input[Optional[Mapping[str, pulumi.Input[Union['ComponentPropertyArgs', 'ComponentPropertyArgsDict']]]]] = None,
                  schema_version: pulumi.Input[Optional[_builtins.str]] = None,
                  source_id: pulumi.Input[Optional[_builtins.str]] = None,
@@ -286,7 +286,7 @@ class Component(pulumi.CustomResource):
         :param pulumi.Input[_builtins.str] environment_name: The name of the backend environment that is a part of the Amplify app.
         :param pulumi.Input[Mapping[str, pulumi.Input[Union['ComponentEventArgs', 'ComponentEventArgsDict']]]] events: Describes the events that can be raised on the component. Use for the workflow feature in Amplify Studio that allows you to bind events and actions to components.
         :param pulumi.Input[_builtins.str] name: The name of the component.
-        :param pulumi.Input[Mapping[str, Any]] overrides: Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]] overrides: Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         :param pulumi.Input[Mapping[str, pulumi.Input[Union['ComponentPropertyArgs', 'ComponentPropertyArgsDict']]]] properties: Describes the component's properties. You can't specify `tags` as a valid property for `properties` .
         :param pulumi.Input[_builtins.str] schema_version: The schema version of the component when it was imported.
         :param pulumi.Input[_builtins.str] source_id: The unique ID of the component in its original source system, such as Figma.
@@ -325,7 +325,7 @@ class Component(pulumi.CustomResource):
                  environment_name: pulumi.Input[Optional[_builtins.str]] = None,
                  events: pulumi.Input[Optional[Mapping[str, pulumi.Input[Union['ComponentEventArgs', 'ComponentEventArgsDict']]]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 overrides: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 overrides: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]] = None,
                  properties: pulumi.Input[Optional[Mapping[str, pulumi.Input[Union['ComponentPropertyArgs', 'ComponentPropertyArgsDict']]]]] = None,
                  schema_version: pulumi.Input[Optional[_builtins.str]] = None,
                  source_id: pulumi.Input[Optional[_builtins.str]] = None,
@@ -490,7 +490,7 @@ class Component(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def overrides(self) -> pulumi.Output[Optional[Mapping[str, Any]]]:
+    def overrides(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, _builtins.str]]]]:
         """
         Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         """

--- a/sdk/python/pulumi_aws_native/amplifyuibuilder/get_component.py
+++ b/sdk/python/pulumi_aws_native/amplifyuibuilder/get_component.py
@@ -146,7 +146,7 @@ class GetComponentResult:
 
     @_builtins.property
     @pulumi.getter
-    def overrides(self) -> Optional[Mapping[str, Any]]:
+    def overrides(self) -> Optional[Mapping[str, Mapping[str, _builtins.str]]]:
         """
         Describes the component's properties that can be overriden in a customized instance of the component. You can't specify `tags` as a valid property for `overrides` .
         """

--- a/sdk/python/pulumi_aws_native/amplifyuibuilder/outputs.py
+++ b/sdk/python/pulumi_aws_native/amplifyuibuilder/outputs.py
@@ -1171,10 +1171,10 @@ class ComponentVariant(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 overrides: Optional[Mapping[str, Any]] = None,
+                 overrides: Optional[Mapping[str, Mapping[str, _builtins.str]]] = None,
                  variant_values: Optional[Mapping[str, _builtins.str]] = None):
         """
-        :param Mapping[str, Any] overrides: The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
+        :param Mapping[str, Mapping[str, _builtins.str]] overrides: The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         :param Mapping[str, _builtins.str] variant_values: The combination of variants that comprise this variant.
         """
         if overrides is not None:
@@ -1184,7 +1184,7 @@ class ComponentVariant(dict):
 
     @_builtins.property
     @pulumi.getter
-    def overrides(self) -> Optional[Mapping[str, Any]]:
+    def overrides(self) -> Optional[Mapping[str, Mapping[str, _builtins.str]]]:
         """
         The properties of the component variant that can be overriden when customizing an instance of the component. You can't specify `tags` as a valid property for `overrides` .
         """

--- a/sdk/python/pulumi_aws_native/appintegrations/data_integration.py
+++ b/sdk/python/pulumi_aws_native/appintegrations/data_integration.py
@@ -28,7 +28,7 @@ class DataIntegrationArgs:
                  description: pulumi.Input[Optional[_builtins.str]] = None,
                  file_configuration: pulumi.Input[Optional['DataIntegrationFileConfigurationArgs']] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 object_configuration: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 object_configuration: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]]] = None,
                  schedule_config: pulumi.Input[Optional['DataIntegrationScheduleConfigArgs']] = None,
                  tags: pulumi.Input[Optional[Sequence[pulumi.Input['_root_inputs.TagArgs']]]] = None):
         """
@@ -39,7 +39,7 @@ class DataIntegrationArgs:
         :param pulumi.Input[_builtins.str] description: The data integration description.
         :param pulumi.Input['DataIntegrationFileConfigurationArgs'] file_configuration: The configuration for what files should be pulled from the source.
         :param pulumi.Input[_builtins.str] name: The name of the data integration.
-        :param pulumi.Input[Mapping[str, Any]] object_configuration: The configuration for what data should be pulled from the source.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]] object_configuration: The configuration for what data should be pulled from the source.
         :param pulumi.Input['DataIntegrationScheduleConfigArgs'] schedule_config: The name of the data and how often it should be pulled from the source.
         :param pulumi.Input[Sequence[pulumi.Input['_root_inputs.TagArgs']]] tags: The tags (keys and values) associated with the data integration.
         """
@@ -120,14 +120,14 @@ class DataIntegrationArgs:
 
     @_builtins.property
     @pulumi.getter(name="objectConfiguration")
-    def object_configuration(self) -> pulumi.Input[Optional[Mapping[str, Any]]]:
+    def object_configuration(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]]]:
         """
         The configuration for what data should be pulled from the source.
         """
         return pulumi.get(self, "object_configuration")
 
     @object_configuration.setter
-    def object_configuration(self, value: pulumi.Input[Optional[Mapping[str, Any]]]):
+    def object_configuration(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]]]):
         pulumi.set(self, "object_configuration", value)
 
     @_builtins.property
@@ -165,7 +165,7 @@ class DataIntegration(pulumi.CustomResource):
                  file_configuration: pulumi.Input[Optional[Union['DataIntegrationFileConfigurationArgs', 'DataIntegrationFileConfigurationArgsDict']]] = None,
                  kms_key: pulumi.Input[Optional[_builtins.str]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 object_configuration: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 object_configuration: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]]] = None,
                  schedule_config: pulumi.Input[Optional[Union['DataIntegrationScheduleConfigArgs', 'DataIntegrationScheduleConfigArgsDict']]] = None,
                  source_uri: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Sequence[pulumi.Input[Union['_root_inputs.TagArgs', '_root_inputs.TagArgsDict']]]]] = None,
@@ -179,7 +179,7 @@ class DataIntegration(pulumi.CustomResource):
         :param pulumi.Input[Union['DataIntegrationFileConfigurationArgs', 'DataIntegrationFileConfigurationArgsDict']] file_configuration: The configuration for what files should be pulled from the source.
         :param pulumi.Input[_builtins.str] kms_key: The KMS key of the data integration.
         :param pulumi.Input[_builtins.str] name: The name of the data integration.
-        :param pulumi.Input[Mapping[str, Any]] object_configuration: The configuration for what data should be pulled from the source.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]] object_configuration: The configuration for what data should be pulled from the source.
         :param pulumi.Input[Union['DataIntegrationScheduleConfigArgs', 'DataIntegrationScheduleConfigArgsDict']] schedule_config: The name of the data and how often it should be pulled from the source.
         :param pulumi.Input[_builtins.str] source_uri: The URI of the data source.
         :param pulumi.Input[Sequence[pulumi.Input[Union['_root_inputs.TagArgs', '_root_inputs.TagArgsDict']]]] tags: The tags (keys and values) associated with the data integration.
@@ -212,7 +212,7 @@ class DataIntegration(pulumi.CustomResource):
                  file_configuration: pulumi.Input[Optional[Union['DataIntegrationFileConfigurationArgs', 'DataIntegrationFileConfigurationArgsDict']]] = None,
                  kms_key: pulumi.Input[Optional[_builtins.str]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
-                 object_configuration: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 object_configuration: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]]]] = None,
                  schedule_config: pulumi.Input[Optional[Union['DataIntegrationScheduleConfigArgs', 'DataIntegrationScheduleConfigArgsDict']]] = None,
                  source_uri: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Sequence[pulumi.Input[Union['_root_inputs.TagArgs', '_root_inputs.TagArgsDict']]]]] = None,
@@ -325,7 +325,7 @@ class DataIntegration(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="objectConfiguration")
-    def object_configuration(self) -> pulumi.Output[Optional[Mapping[str, Any]]]:
+    def object_configuration(self) -> pulumi.Output[Optional[Mapping[str, Mapping[str, Sequence[_builtins.str]]]]]:
         """
         The configuration for what data should be pulled from the source.
         """

--- a/sdk/python/pulumi_aws_native/appintegrations/get_data_integration.py
+++ b/sdk/python/pulumi_aws_native/appintegrations/get_data_integration.py
@@ -90,7 +90,7 @@ class GetDataIntegrationResult:
 
     @_builtins.property
     @pulumi.getter(name="objectConfiguration")
-    def object_configuration(self) -> Optional[Mapping[str, Any]]:
+    def object_configuration(self) -> Optional[Mapping[str, Mapping[str, Sequence[_builtins.str]]]]:
         """
         The configuration for what data should be pulled from the source.
         """

--- a/sdk/python/pulumi_aws_native/bcmdataexports/_inputs.py
+++ b/sdk/python/pulumi_aws_native/bcmdataexports/_inputs.py
@@ -160,7 +160,7 @@ class ExportDataQueryArgsDict(TypedDict):
     """
     The query statement.
     """
-    table_configurations: NotRequired[pulumi.Input[Optional[Mapping[str, Any]]]]
+    table_configurations: NotRequired[pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]]
     """
     The table configuration.
     """
@@ -169,10 +169,10 @@ class ExportDataQueryArgsDict(TypedDict):
 class ExportDataQueryArgs:
     def __init__(__self__, *,
                  query_statement: pulumi.Input[_builtins.str],
-                 table_configurations: pulumi.Input[Optional[Mapping[str, Any]]] = None):
+                 table_configurations: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]] = None):
         """
         :param pulumi.Input[_builtins.str] query_statement: The query statement.
-        :param pulumi.Input[Mapping[str, Any]] table_configurations: The table configuration.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]] table_configurations: The table configuration.
         """
         pulumi.set(__self__, "query_statement", query_statement)
         if table_configurations is not None:
@@ -192,14 +192,14 @@ class ExportDataQueryArgs:
 
     @_builtins.property
     @pulumi.getter(name="tableConfigurations")
-    def table_configurations(self) -> pulumi.Input[Optional[Mapping[str, Any]]]:
+    def table_configurations(self) -> pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]:
         """
         The table configuration.
         """
         return pulumi.get(self, "table_configurations")
 
     @table_configurations.setter
-    def table_configurations(self, value: pulumi.Input[Optional[Mapping[str, Any]]]):
+    def table_configurations(self, value: pulumi.Input[Optional[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]]]]]):
         pulumi.set(self, "table_configurations", value)
 
 

--- a/sdk/python/pulumi_aws_native/bcmdataexports/outputs.py
+++ b/sdk/python/pulumi_aws_native/bcmdataexports/outputs.py
@@ -146,10 +146,10 @@ class ExportDataQuery(dict):
 
     def __init__(__self__, *,
                  query_statement: _builtins.str,
-                 table_configurations: Optional[Mapping[str, Any]] = None):
+                 table_configurations: Optional[Mapping[str, Mapping[str, _builtins.str]]] = None):
         """
         :param _builtins.str query_statement: The query statement.
-        :param Mapping[str, Any] table_configurations: The table configuration.
+        :param Mapping[str, Mapping[str, _builtins.str]] table_configurations: The table configuration.
         """
         pulumi.set(__self__, "query_statement", query_statement)
         if table_configurations is not None:
@@ -165,7 +165,7 @@ class ExportDataQuery(dict):
 
     @_builtins.property
     @pulumi.getter(name="tableConfigurations")
-    def table_configurations(self) -> Optional[Mapping[str, Any]]:
+    def table_configurations(self) -> Optional[Mapping[str, Mapping[str, _builtins.str]]]:
         """
         The table configuration.
         """

--- a/sdk/python/pulumi_aws_native/datazone/_inputs.py
+++ b/sdk/python/pulumi_aws_native/datazone/_inputs.py
@@ -2776,7 +2776,7 @@ class DataSourceSageMakerRunConfigurationInputArgsDict(TypedDict):
     """
     The configuration details of the Amazon SageMaker data source.
     """
-    tracking_assets: pulumi.Input[Mapping[str, Any]]
+    tracking_assets: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]
     """
     The tracking assets of the Amazon SageMaker run.
     """
@@ -2784,24 +2784,24 @@ class DataSourceSageMakerRunConfigurationInputArgsDict(TypedDict):
 @pulumi.input_type
 class DataSourceSageMakerRunConfigurationInputArgs:
     def __init__(__self__, *,
-                 tracking_assets: pulumi.Input[Mapping[str, Any]]):
+                 tracking_assets: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]):
         """
         The configuration details of the Amazon SageMaker data source.
 
-        :param pulumi.Input[Mapping[str, Any]] tracking_assets: The tracking assets of the Amazon SageMaker run.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]] tracking_assets: The tracking assets of the Amazon SageMaker run.
         """
         pulumi.set(__self__, "tracking_assets", tracking_assets)
 
     @_builtins.property
     @pulumi.getter(name="trackingAssets")
-    def tracking_assets(self) -> pulumi.Input[Mapping[str, Any]]:
+    def tracking_assets(self) -> pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]:
         """
         The tracking assets of the Amazon SageMaker run.
         """
         return pulumi.get(self, "tracking_assets")
 
     @tracking_assets.setter
-    def tracking_assets(self, value: pulumi.Input[Mapping[str, Any]]):
+    def tracking_assets(self, value: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]):
         pulumi.set(self, "tracking_assets", value)
 
 

--- a/sdk/python/pulumi_aws_native/datazone/outputs.py
+++ b/sdk/python/pulumi_aws_native/datazone/outputs.py
@@ -2814,17 +2814,17 @@ class DataSourceSageMakerRunConfigurationInput(dict):
         return super().get(key, default)
 
     def __init__(__self__, *,
-                 tracking_assets: Mapping[str, Any]):
+                 tracking_assets: Mapping[str, Sequence[_builtins.str]]):
         """
         The configuration details of the Amazon SageMaker data source.
 
-        :param Mapping[str, Any] tracking_assets: The tracking assets of the Amazon SageMaker run.
+        :param Mapping[str, Sequence[_builtins.str]] tracking_assets: The tracking assets of the Amazon SageMaker run.
         """
         pulumi.set(__self__, "tracking_assets", tracking_assets)
 
     @_builtins.property
     @pulumi.getter(name="trackingAssets")
-    def tracking_assets(self) -> Mapping[str, Any]:
+    def tracking_assets(self) -> Mapping[str, Sequence[_builtins.str]]:
         """
         The tracking assets of the Amazon SageMaker run.
         """

--- a/sdk/python/pulumi_aws_native/inspectorv2/_inputs.py
+++ b/sdk/python/pulumi_aws_native/inspectorv2/_inputs.py
@@ -66,13 +66,13 @@ __all__ = [
 
 class CisScanConfigurationCisTargetsArgsDict(TypedDict):
     account_ids: pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]
-    target_resource_tags: pulumi.Input[Mapping[str, Any]]
+    target_resource_tags: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]
 
 @pulumi.input_type
 class CisScanConfigurationCisTargetsArgs:
     def __init__(__self__, *,
                  account_ids: pulumi.Input[Sequence[pulumi.Input[_builtins.str]]],
-                 target_resource_tags: pulumi.Input[Mapping[str, Any]]):
+                 target_resource_tags: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]):
         pulumi.set(__self__, "account_ids", account_ids)
         pulumi.set(__self__, "target_resource_tags", target_resource_tags)
 
@@ -87,11 +87,11 @@ class CisScanConfigurationCisTargetsArgs:
 
     @_builtins.property
     @pulumi.getter(name="targetResourceTags")
-    def target_resource_tags(self) -> pulumi.Input[Mapping[str, Any]]:
+    def target_resource_tags(self) -> pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]:
         return pulumi.get(self, "target_resource_tags")
 
     @target_resource_tags.setter
-    def target_resource_tags(self, value: pulumi.Input[Mapping[str, Any]]):
+    def target_resource_tags(self, value: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]):
         pulumi.set(self, "target_resource_tags", value)
 
 

--- a/sdk/python/pulumi_aws_native/inspectorv2/outputs.py
+++ b/sdk/python/pulumi_aws_native/inspectorv2/outputs.py
@@ -65,7 +65,7 @@ class CisScanConfigurationCisTargets(dict):
 
     def __init__(__self__, *,
                  account_ids: Sequence[_builtins.str],
-                 target_resource_tags: Mapping[str, Any]):
+                 target_resource_tags: Mapping[str, Sequence[_builtins.str]]):
         pulumi.set(__self__, "account_ids", account_ids)
         pulumi.set(__self__, "target_resource_tags", target_resource_tags)
 
@@ -76,7 +76,7 @@ class CisScanConfigurationCisTargets(dict):
 
     @_builtins.property
     @pulumi.getter(name="targetResourceTags")
-    def target_resource_tags(self) -> Mapping[str, Any]:
+    def target_resource_tags(self) -> Mapping[str, Sequence[_builtins.str]]:
         return pulumi.get(self, "target_resource_tags")
 
 

--- a/sdk/python/pulumi_aws_native/ssmquicksetup/get_lifecycle_automation.py
+++ b/sdk/python/pulumi_aws_native/ssmquicksetup/get_lifecycle_automation.py
@@ -55,7 +55,7 @@ class GetLifecycleAutomationResult:
 
     @_builtins.property
     @pulumi.getter(name="automationParameters")
-    def automation_parameters(self) -> Optional[Mapping[str, Any]]:
+    def automation_parameters(self) -> Optional[Mapping[str, Sequence[_builtins.str]]]:
         """
         A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         """

--- a/sdk/python/pulumi_aws_native/ssmquicksetup/lifecycle_automation.py
+++ b/sdk/python/pulumi_aws_native/ssmquicksetup/lifecycle_automation.py
@@ -20,14 +20,14 @@ __all__ = ['LifecycleAutomationArgs', 'LifecycleAutomation']
 class LifecycleAutomationArgs:
     def __init__(__self__, *,
                  automation_document: pulumi.Input[_builtins.str],
-                 automation_parameters: pulumi.Input[Mapping[str, Any]],
+                 automation_parameters: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]],
                  resource_key: pulumi.Input[_builtins.str],
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None):
         """
         The set of arguments for constructing a LifecycleAutomation resource.
 
         :param pulumi.Input[_builtins.str] automation_document: The name of the Automation document to execute
-        :param pulumi.Input[Mapping[str, Any]] automation_parameters: A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]] automation_parameters: A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         :param pulumi.Input[_builtins.str] resource_key: A unique identifier used for generating a unique logical ID for the custom resource
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
         """
@@ -51,14 +51,14 @@ class LifecycleAutomationArgs:
 
     @_builtins.property
     @pulumi.getter(name="automationParameters")
-    def automation_parameters(self) -> pulumi.Input[Mapping[str, Any]]:
+    def automation_parameters(self) -> pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]:
         """
         A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         """
         return pulumi.get(self, "automation_parameters")
 
     @automation_parameters.setter
-    def automation_parameters(self, value: pulumi.Input[Mapping[str, Any]]):
+    def automation_parameters(self, value: pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]):
         pulumi.set(self, "automation_parameters", value)
 
     @_builtins.property
@@ -93,7 +93,7 @@ class LifecycleAutomation(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  automation_document: pulumi.Input[Optional[_builtins.str]] = None,
-                 automation_parameters: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 automation_parameters: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]] = None,
                  resource_key: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
@@ -103,7 +103,7 @@ class LifecycleAutomation(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] automation_document: The name of the Automation document to execute
-        :param pulumi.Input[Mapping[str, Any]] automation_parameters: A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
+        :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]] automation_parameters: A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         :param pulumi.Input[_builtins.str] resource_key: A unique identifier used for generating a unique logical ID for the custom resource
         :param pulumi.Input[Mapping[str, pulumi.Input[_builtins.str]]] tags: Tags applied to the underlying SSM Association created by this resource. Tags help identify and organize automation executions.
         """
@@ -132,7 +132,7 @@ class LifecycleAutomation(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  automation_document: pulumi.Input[Optional[_builtins.str]] = None,
-                 automation_parameters: pulumi.Input[Optional[Mapping[str, Any]]] = None,
+                 automation_parameters: pulumi.Input[Optional[Mapping[str, pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]]] = None,
                  resource_key: pulumi.Input[Optional[_builtins.str]] = None,
                  tags: pulumi.Input[Optional[Mapping[str, pulumi.Input[_builtins.str]]]] = None,
                  __props__=None):
@@ -204,7 +204,7 @@ class LifecycleAutomation(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter(name="automationParameters")
-    def automation_parameters(self) -> pulumi.Output[Mapping[str, Any]]:
+    def automation_parameters(self) -> pulumi.Output[Mapping[str, Sequence[_builtins.str]]]:
         """
         A map of key-value parameters passed to the Automation document during execution. Each parameter name maps to a list of values, even for single values. Parameters can include configuration-specific values for your automation workflow.
         """


### PR DESCRIPTION
## Summary

Referenced CloudFormation map definitions currently lose their nested map or list value types because an old Go codegen workaround replaces every nested collection with `Any`. Current Pulumi Go codegen supports nested primitive collections up to three levels, so this unnecessarily produces untyped SDK APIs such as `map[string]interface{}` for properties whose schemas declare `map[string][]string`.

This preserves nested collection types when the leaf is a JSON primitive and the total collection depth is supported by the Go SDK. For example, InspectorV2 `targetResourceTags` is now generated as `map[string][]string`, and AppIntegrations `objectConfiguration` as `map[string]map[string][]string`.

Nested object collections and primitive collections deeper than three levels continue to use `Any`. Removing that fallback entirely still produces an uncompilable Go SDK for ARC Region Switch; the remaining codegen bug is tracked by https://github.com/pulumi/pulumi/issues/24063.

## Scope

This changes referenced-map schema generation, adds tests for the supported and fallback boundaries, and regenerates schema metadata, reports, and SDKs. It does not change provider runtime serialization or enable nested custom-object collections.

The generated SDK types become more specific for six logical properties. No valid CloudFormation payload changes, but callers that construct valid values through generic map or `Any` wrappers may need source changes to use the corresponding typed collection wrappers. Inline literals generally continue to work in structurally typed languages.

<details>
<summary>Source compatibility examples by language</summary>

All examples below represent the same valid payload for InspectorV2 `targetResourceTags`:

```json
{"Environment": ["production"]}
```

### Go

The input changes from `pulumi.MapInput` to `pulumi.StringArrayMapInput`.

Before:

```go
tags := pulumi.Map{
    "Environment": pulumi.StringArray{pulumi.String("production")},
}
```

After:

```go
tags := pulumi.StringArrayMap{
    "Environment": pulumi.StringArray{pulumi.String("production")},
}
```

The serialized value is unchanged, but `pulumi.Map` does not implement `pulumi.StringArrayMapInput`.

### TypeScript / JavaScript

The TypeScript property changes from:

```ts
pulumi.Input<{[key: string]: any}>
```

to:

```ts
pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<string>[]>}>
```

A generically typed variable may need to become more specific:

```ts
// Before
const tags: Record<string, unknown> = {
    Environment: ["production"],
};

// After
const tags: Record<string, string[]> = {
    Environment: ["production"],
};
```

Inline literals already matching the schema generally need no update. JavaScript has no static source-compatibility change.

### Python

The annotation changes from `pulumi.Input[Mapping[str, Any]]` to a mapping whose values are string sequences.

```python
# Before
from typing import Mapping

tags: Mapping[str, object] = {
    "Environment": ["production"],
}

# After
from typing import Mapping, Sequence

tags: Mapping[str, Sequence[str]] = {
    "Environment": ["production"],
}
```

Ordinary untyped Python code continues to run unchanged; this primarily affects static type checking.

### .NET

The property changes from `InputMap<object>` to `InputMap<ImmutableArray<string>>`.

```csharp
// Before
var tags = new InputMap<object>
{
    { "Environment", new[] { "production" } },
};

// After
var tags = new InputMap<ImmutableArray<string>>
{
    { "Environment", ImmutableArray.Create("production") },
};
```

### Java

The builder argument changes from `Map<String, Object>` to `Map<String, List<String>>`.

```java
// Before
Map<String, Object> tags =
    Map.of("Environment", List.of("production"));

// After
Map<String, List<String>> tags =
    Map.of("Environment", List.of("production"));
```

An inline `Map.of(...)` call generally infers the more specific type and needs no update.

Output consumers can see the same kind of source change. For example, Go's `pulumi.MapOutput` becomes `pulumi.StringArrayMapOutput`.

</details>

## Validation

- [x] `mise exec -- make lint`
- [x] `mise exec -- make test_provider_fast` (for provider code changes)
- [ ] `make test_provider` (not run; no provider runtime behavior changed)
- [ ] `make test` (not run; no integration contract changed)
- [x] `mise exec -- make build_go`

## Generation / Drift Checks

- [x] No hand-edits to generated files, including `sdk/**` and generated schema artifacts
- [x] Ran `mise exec -- make generate_schema`
- [x] Ran `mise exec -- make local_generate`
- [ ] Ran `make ci-mgmt` (not applicable)

## Risk

The main compatibility impact is the intentional SDK type narrowing. The conservative fallback keeps unsupported Go collection shapes unchanged, and the regenerated Go SDK compiles successfully.

## Rollback

Revert this commit and regenerate the schema and SDKs to restore all nested referenced-map values to `Any`.
