### PR TITLE
Install core provider agent skills

### DIFF
--- a/.agents/skills/aws-native-provider-runtime-design/agents/openai.yaml
+++ b/.agents/skills/aws-native-provider-runtime-design/agents/openai.yaml
@@ -1,7 +1,0 @@
-interface:
-  display_name: "AWS Native Runtime Design"
-  short_description: "Plan AWS Native provider lifecycle changes"
-  default_prompt: "Use $aws-native-provider-runtime-design to turn this AWS Native provider runtime issue into a repo-grounded behavior/design spec."
-
-policy:
-  allow_implicit_invocation: true

--- a/.agents/skills/aws-native-runtime-investigation/SKILL.md
+++ b/.agents/skills/aws-native-runtime-investigation/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: aws-native-provider-runtime-design
-description: Use when investigating or changing Pulumi AWS Native provider runtime behavior across the Pulumi provider protocol, generated CloudFormation metadata, and AWS Cloud Control API. Do not use for routine generated SDK churn or isolated schema/codegen edits with no runtime semantics.
+name: aws-native-runtime-investigation
+description: Use after triage or repository evidence establishes that an issue involves Pulumi AWS Native runtime behavior across the Pulumi provider protocol, generated CloudFormation metadata, and AWS Cloud Control API. Do not use for initial issue triage, routine generated SDK churn, or isolated schema/codegen edits with no runtime semantics.
 ---
 
-# AWS Native Provider Runtime
+# AWS Native Runtime Investigation
 
 Use this skill to find the relevant AWS Native lifecycle boundary and keep the
 change small. It is a routing aid, not a required planning framework or an

--- a/.agents/skills/aws-native-runtime-investigation/agents/openai.yaml
+++ b/.agents/skills/aws-native-runtime-investigation/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "AWS Native Runtime Investigation"
+  short_description: "Investigate AWS Native runtime behavior"
+  default_prompt: "Use $aws-native-runtime-investigation to trace this established AWS Native runtime issue to its owning boundary and identify the smallest evidence-backed next step."
+
+policy:
+  allow_implicit_invocation: true

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ aws-cloudformation-docs/
 
 # Local runtime artifacts (logs, temp files, etc.)
 .runtime/
+
+# APM-managed agent dependencies
+apm_modules/
+.agents/skills/*
+!.agents/skills/aws-native-runtime-investigation/
+.claude/skills/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,17 @@ This repository contains the Pulumi AWS Native provider: a Go provider plus gene
 Read `ARCHITECTURE.md` for a concise module map and system boundaries before making structural changes.
 For provider lifecycle changes, read `docs/provider-runtime.md` for the AWS Native boundary between the Pulumi engine, generated CloudFormation metadata, and AWS Cloud Control API.
 
+## AI Harness
+- Start issue investigation with the APM-managed `triage-provider-issue` skill
+  when ownership or the next evidence artifact is unclear.
+- Use the APM-managed `stage-pulumi-provider-repro` skill when triage selects a
+  durable Pulumi repro as the next step.
+- Use `aws-native-runtime-investigation` after the issue is known to involve
+  AWS Native runtime behavior across the Pulumi protocol, generated metadata,
+  and AWS Cloud Control API.
+- Core provider skills are declared in `apm.yml` and deployed locally; do not
+  edit their generated copies under `.agents/skills/` or `.claude/skills/`.
+
 ## High-Signal Paths
 - `Makefile`: canonical command surface
 - `provider/pkg/`: hand-written provider runtime logic

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,0 +1,278 @@
+lockfile_version: '1'
+generated_at: '2026-07-24T15:06:32.869046+00:00'
+apm_version: 0.26.0
+dependencies:
+- repo_url: pulumi-labs/provider-agent-skills
+  name: pulumi-provider-core
+  host: github.com
+  resolved_commit: d8cd869c23ce3ca699e8f8f03776af89d0d7eb8b
+  resolved_ref: v0.1.0
+  version: 0.1.0
+  virtual_path: packages/core
+  is_virtual: true
+  package_type: skill_bundle
+  deployed_files:
+  - .agents/skills/stage-pulumi-provider-repro
+  - .agents/skills/stage-pulumi-provider-repro/SKILL.md
+  - .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  - .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  - .agents/skills/triage-provider-issue
+  - .agents/skills/triage-provider-issue/SKILL.md
+  - .agents/skills/triage-provider-issue/agents/openai.yaml
+  - .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  - .agents/skills/triage-provider-issue/references/disposition-gates.md
+  - .agents/skills/triage-provider-issue/references/helper-switches.md
+  - .agents/skills/triage-provider-issue/references/provider-families.md
+  - .agents/skills/triage-provider-issue/references/workaround-investigation.md
+  - .claude/skills/stage-pulumi-provider-repro
+  - .claude/skills/stage-pulumi-provider-repro/SKILL.md
+  - .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  - .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  - .claude/skills/triage-provider-issue
+  - .claude/skills/triage-provider-issue/SKILL.md
+  - .claude/skills/triage-provider-issue/agents/openai.yaml
+  - .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  - .claude/skills/triage-provider-issue/references/disposition-gates.md
+  - .claude/skills/triage-provider-issue/references/helper-switches.md
+  - .claude/skills/triage-provider-issue/references/provider-families.md
+  - .claude/skills/triage-provider-issue/references/workaround-investigation.md
+  deployed_file_hashes:
+    .agents/skills/stage-pulumi-provider-repro/SKILL.md: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+    .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+    .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+    .agents/skills/triage-provider-issue/SKILL.md: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+    .agents/skills/triage-provider-issue/agents/openai.yaml: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+    .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+    .agents/skills/triage-provider-issue/references/disposition-gates.md: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+    .agents/skills/triage-provider-issue/references/helper-switches.md: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+    .agents/skills/triage-provider-issue/references/provider-families.md: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+    .agents/skills/triage-provider-issue/references/workaround-investigation.md: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+    .claude/skills/stage-pulumi-provider-repro/SKILL.md: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+    .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+    .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+    .claude/skills/triage-provider-issue/SKILL.md: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+    .claude/skills/triage-provider-issue/agents/openai.yaml: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+    .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+    .claude/skills/triage-provider-issue/references/disposition-gates.md: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+    .claude/skills/triage-provider-issue/references/helper-switches.md: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+    .claude/skills/triage-provider-issue/references/provider-families.md: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+    .claude/skills/triage-provider-issue/references/workaround-investigation.md: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+  content_hash: sha256:41aec87854c0b4b34e5fa6ed829796c282b1f68bb10ecc32f1253e037f1525a7
+  declared_license: Apache-2.0
+deployments:
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/disposition-gates.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/helper-switches.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/provider-families.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+- kind: project-relative
+  target: claude
+  value: .claude/skills/triage-provider-issue/references/workaround-investigation.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:c7c360d6fd2b233aa46a1aa3b76faaf203e9a7ab78db32a7afe38da4eecf94ac
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:4337ec0decb104f99be7438f63a3f21ec23bee5f2c1ebb7bc22ee3233d8b8717
+- kind: project-relative
+  target: codex
+  value: .agents/skills/stage-pulumi-provider-repro/references/repro-shape.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7b9f674da3fef893eafa0b9a66d1e54c319a8b5d3988e81e457ad10a05560bbf
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: null
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:36eb32b75090afe7533e7693d7a237beda0508f1f1dffe47280a444e4e74cfe9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/agents/openai.yaml
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:57cd6644e7c68fc00a57a2b8de657998b358d0e8bcf5bb036cdaa226392e0685
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/confidence-and-artifacts.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:9aade6826d780812f94ad8dc30f5b03f78d40d92811d0f85b7774c4ce7b613c9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/disposition-gates.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:7e5e7a5d04771672718e9a2688befe9b8aef8274fa6b8d2d68d9621267e27fa9
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/helper-switches.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:8f878eb7cd240b233d59e0f1f0fb4881bf7f5e27c216dc8ca28436f1e1751071
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/provider-families.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:88fa42888a37f5f24c5400979c01e2ad92a10a25cfe4c41f5b5596eb20c341d5
+- kind: project-relative
+  target: codex
+  value: .agents/skills/triage-provider-issue/references/workaround-investigation.md
+  runtime: null
+  scope: project
+  owners:
+  - pulumi-labs/provider-agent-skills/packages/core
+  active_owner: pulumi-labs/provider-agent-skills/packages/core
+  content_hash: sha256:6c05795586b00c78c69102d975a8c726e2f9e4fc8476dee4f4a21002d1c99930

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,11 @@
+name: pulumi-aws-native-agent-context
+version: "1.0.0"
+
+targets:
+  - codex
+  - claude
+  - opencode
+
+dependencies:
+  apm:
+    - pulumi-labs/provider-agent-skills/packages/core#v0.1.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,17 @@
+[settings]
+experimental = true
+
+[hooks]
+postinstall = "mise deps install agent-skills"
+
+[tools]
+"pipx:apm-cli" = "0.26.0"
+
+[deps.agent-skills]
+sources = ["apm.yml", "apm.lock.yaml"]
+outputs = [
+  "apm_modules/",
+  ".agents/skills/",
+  ".claude/skills/",
+]
+run = "apm install --frozen"


### PR DESCRIPTION
## Summary

Install the shared provider core skill pack through APM. This adds provider triage and durable Pulumi repro skills without checking their deployed copies into the repository.

The existing AWS Native specialist is renamed to `aws-native-runtime-investigation` and now applies only after triage or repository evidence establishes runtime ownership. This keeps initial issue routing separate from native lifecycle investigation.

## Scope

This changes only the agent harness and local skill installation. Provider runtime, schema generation, SDKs, and CI configuration are unchanged.

## Validation
- [ ] `make lint`
- [ ] `make test_provider_fast` (for provider code changes)
- [ ] `make test_provider` (if provider behavior/logic changed)
- [ ] `make test` (only when integration contracts changed)

Validated with:

- `mise deps install agent-skills`
- `apm audit`
- `git diff --check`

## Generation / Drift Checks
- [x] No hand-edits to generated files, including `sdk/**` and generated schema artifacts
- [ ] Ran `make generate_schema` (if schema/codegen inputs changed)
- [ ] Ran `make local_generate` (if SDK/API surface changed)
- [ ] Ran `make ci-mgmt` (if `.ci-mgmt.yaml` changed)

## Risk

The harness now depends on the locked APM package and `mise` post-install hook. `apm.lock.yaml` pins the deployed content, and `apm audit` reports no drift.

## Rollback

Revert this commit to remove the APM dependency and restore the previous runtime skill name and routing.
