### PR TITLE
Fix secret nesting amplification for write-only properties on refresh

### DIFF
--- a/provider/pkg/resources/checkpoint.go
+++ b/provider/pkg/resources/checkpoint.go
@@ -12,23 +12,61 @@ func CheckpointObject(inputs resource.PropertyMap, outputs map[string]interface{
 }
 
 // CheckpointPropertyMap puts inputs in the `__inputs` field of the state.
+// Consecutive secret wrappers are collapsed so that checkpointed state never
+// grows an extra layer of secret nesting per operation.
 func CheckpointPropertyMap(inputs resource.PropertyMap, outputs resource.PropertyMap) resource.PropertyMap {
-	var props resource.PropertyMap
-	if outputs == nil {
-		props = resource.PropertyMap{}
-	} else {
-		props = outputs.Copy()
+	props := resource.PropertyMap{}
+	for key, value := range outputs {
+		props[key] = CollapseConsecutiveSecrets(value)
 	}
 
-	props["__inputs"] = resource.MakeSecret(resource.NewObjectProperty(inputs))
+	props["__inputs"] = resource.MakeSecret(CollapseConsecutiveSecrets(resource.NewObjectProperty(inputs)))
 	return props
 }
 
 // ParseCheckpointObject returns inputs that are saved in the `__inputs` field of the state.
+// Consecutive secret wrappers are collapsed so that states written by older
+// versions with nested secrets are healed when they are next read.
 func ParseCheckpointObject(obj resource.PropertyMap) resource.PropertyMap {
 	if inputs, ok := obj["__inputs"]; ok {
-		return inputs.SecretValue().Element.ObjectValue()
+		return CollapseConsecutiveSecrets(inputs).SecretValue().Element.ObjectValue()
 	}
 
 	return nil
+}
+
+// CollapseConsecutiveSecrets returns a value in which every chain of directly
+// nested secrets is replaced by a single secret wrapper. Secret(Secret(v)) and
+// Secret(v) mark the same value secret, but each extra wrapper doubles the
+// JSON-escaped size of the encrypted state entry. The value is rebuilt rather
+// than mutated, so callers can safely pass values that alias other maps.
+func CollapseConsecutiveSecrets(v resource.PropertyValue) resource.PropertyValue {
+	switch {
+	case v.IsSecret():
+		element := CollapseConsecutiveSecrets(v.SecretValue().Element)
+		if element.IsSecret() {
+			return element
+		}
+		return resource.MakeSecret(element)
+	case v.IsObject():
+		obj := v.ObjectValue()
+		result := make(resource.PropertyMap, len(obj))
+		for key, element := range obj {
+			result[key] = CollapseConsecutiveSecrets(element)
+		}
+		return resource.NewObjectProperty(result)
+	case v.IsArray():
+		arr := v.ArrayValue()
+		result := make([]resource.PropertyValue, len(arr))
+		for i, element := range arr {
+			result[i] = CollapseConsecutiveSecrets(element)
+		}
+		return resource.NewArrayProperty(result)
+	case v.IsOutput():
+		output := v.OutputValue()
+		output.Element = CollapseConsecutiveSecrets(output.Element)
+		return resource.NewOutputProperty(output)
+	default:
+		return v
+	}
 }

--- a/provider/pkg/resources/checkpoint_test.go
+++ b/provider/pkg/resources/checkpoint_test.go
@@ -126,6 +126,56 @@ func TestCheckpointPropertyMap(t *testing.T) {
 	assert.Equal(t, inputs, secretInputs)
 }
 
+func TestCheckpointCollapsesConsecutiveSecrets(t *testing.T) {
+	t.Parallel()
+
+	nested := resource.MakeSecret(resource.MakeSecret(resource.NewStringProperty("value")))
+	inputs := resource.PropertyMap{
+		"config": resource.NewObjectProperty(resource.PropertyMap{
+			"apiKey": nested,
+		}),
+	}
+	outputs := resource.PropertyMap{
+		"config": resource.NewObjectProperty(resource.PropertyMap{
+			"apiKey": nested,
+		}),
+	}
+
+	result := CheckpointPropertyMap(inputs, outputs)
+
+	outLeaf := result["config"].ObjectValue()["apiKey"]
+	assert.True(t, outLeaf.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), outLeaf.SecretValue().Element)
+
+	inLeaf := result["__inputs"].SecretValue().Element.ObjectValue()["config"].ObjectValue()["apiKey"]
+	assert.True(t, inLeaf.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), inLeaf.SecretValue().Element)
+}
+
+func TestParseCheckpointObjectCollapsesConsecutiveSecrets(t *testing.T) {
+	t.Parallel()
+
+	inputs := resource.PropertyMap{
+		"apiKey": resource.MakeSecret(resource.MakeSecret(resource.NewStringProperty("value"))),
+		"items": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.MakeSecret(resource.MakeSecret(resource.NewStringProperty("elem"))),
+		}),
+	}
+	obj := resource.PropertyMap{
+		"__inputs": resource.MakeSecret(resource.NewObjectProperty(inputs)),
+	}
+
+	parsed := ParseCheckpointObject(obj)
+
+	apiKey := parsed["apiKey"]
+	assert.True(t, apiKey.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), apiKey.SecretValue().Element)
+
+	item := parsed["items"].ArrayValue()[0]
+	assert.True(t, item.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("elem"), item.SecretValue().Element)
+}
+
 func TestCheckpointPropertyMapWithNilOutputs(t *testing.T) {
 	t.Parallel()
 

--- a/provider/pkg/resources/nested_secret_refresh_test.go
+++ b/provider/pkg/resources/nested_secret_refresh_test.go
@@ -1,0 +1,150 @@
+package resources
+
+import (
+	"testing"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+)
+
+// consecutiveSecretDepth counts consecutive secret wrappers around a value.
+func consecutiveSecretDepth(v resource.PropertyValue) int {
+	depth := 0
+	for v.IsSecret() {
+		depth++
+		v = v.SecretValue().Element
+	}
+	return depth
+}
+
+// canarySpec models AWS::Synthetics::Canary, whose runConfig/environmentVariables
+// is write-only: it is accepted on create/update but never returned by
+// CloudControl, so refresh must restore it from checkpointed old inputs.
+func canarySpec() (metadata.CloudAPIResource, map[string]metadata.CloudAPIType) {
+	spec := metadata.CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"name":      {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			"runConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+		},
+		Outputs: map[string]pschema.PropertySpec{
+			"name":      {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			"runConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+		},
+		WriteOnly: []string{"runConfig/environmentVariables"},
+	}
+	types := map[string]metadata.CloudAPIType{
+		"aws-native:test:RunConfig": {
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"timeoutInSeconds": {TypeSpec: pschema.TypeSpec{Type: "integer"}},
+				"environmentVariables": {TypeSpec: pschema.TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &pschema.TypeSpec{Type: "string"},
+				}},
+			},
+		},
+	}
+	return spec, types
+}
+
+// simulateRefreshRead mirrors the standard-resource refresh path of
+// cfnProvider.Read for a resource with a secret value under a write-only path.
+func simulateRefreshRead(t *testing.T, state resource.PropertyMap) resource.PropertyMap {
+	spec, types := canarySpec()
+	classifier := NewPathClassifier(&spec, types)
+
+	inputs := ParseCheckpointObject(state)
+	require.NotNil(t, inputs)
+
+	// CloudControl never returns write-only properties.
+	newStateProps := resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+		}),
+	}
+	classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
+	PreserveSecretWrappers(newStateProps, inputs)
+	baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
+	newInputs := SuppressBaselineDiffs("aws-native:test:Canary", &spec, inputs, baseline, NewTransformCache())
+	return CheckpointPropertyMap(newInputs, newStateProps)
+}
+
+// TestRefreshDoesNotNestWriteOnlySecrets asserts the invariant that repeated
+// refreshes keep a secret write-only value at exactly one secret wrapper in
+// both output state and checkpointed __inputs. Before the fix, the wrapper
+// depth doubled on every refresh (1, 2, 4, 8, 16, ...), and JSON escaping made
+// the encrypted state entry roughly double per level.
+func TestRefreshDoesNotNestWriteOnlySecrets(t *testing.T) {
+	t.Parallel()
+
+	inputs := resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+			"environmentVariables": resource.NewObjectProperty(resource.PropertyMap{
+				"API_KEY": resource.MakeSecret(resource.NewStringProperty("fake-36-character-secret-value-here")),
+			}),
+		}),
+	}
+	state := CheckpointPropertyMap(inputs, inputs.Copy())
+
+	for i := 0; i < 20; i++ {
+		state = simulateRefreshRead(t, state)
+
+		outLeaf, ok := GetPath(state, "runConfig/environmentVariables/API_KEY")
+		require.Truef(t, ok, "iteration %d: output leaf missing", i)
+		require.Equalf(t, 1, consecutiveSecretDepth(outLeaf), "iteration %d: output secret depth", i)
+		assert.Equal(t, resource.NewStringProperty("fake-36-character-secret-value-here"), outLeaf.SecretValue().Element)
+
+		inLeaf, ok := GetPath(ParseCheckpointObject(state), "runConfig/environmentVariables/API_KEY")
+		require.Truef(t, ok, "iteration %d: __inputs leaf missing", i)
+		require.Equalf(t, 1, consecutiveSecretDepth(inLeaf), "iteration %d: __inputs secret depth", i)
+	}
+}
+
+// TestRefreshHealsNestedSecretState asserts that a state poisoned by earlier
+// versions, with a deeply nested secret under a write-only path, collapses back
+// to a single wrapper on the next refresh instead of doubling further.
+func TestRefreshHealsNestedSecretState(t *testing.T) {
+	t.Parallel()
+
+	deep := resource.NewStringProperty("fake-36-character-secret-value-here")
+	for i := 0; i < 16; i++ {
+		deep = resource.MakeSecret(deep)
+	}
+	poisoned := resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+			"environmentVariables": resource.NewObjectProperty(resource.PropertyMap{
+				"API_KEY": deep,
+			}),
+		}),
+	}
+	state := resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+			"environmentVariables": resource.NewObjectProperty(resource.PropertyMap{
+				"API_KEY": deep,
+			}),
+		}),
+		"__inputs": resource.MakeSecret(resource.NewObjectProperty(poisoned)),
+	}
+
+	state = simulateRefreshRead(t, state)
+
+	outLeaf, ok := GetPath(state, "runConfig/environmentVariables/API_KEY")
+	require.True(t, ok)
+	assert.Equal(t, 1, consecutiveSecretDepth(outLeaf))
+	assert.Equal(t, resource.NewStringProperty("fake-36-character-secret-value-here"), outLeaf.SecretValue().Element)
+
+	inLeaf, ok := GetPath(ParseCheckpointObject(state), "runConfig/environmentVariables/API_KEY")
+	require.True(t, ok)
+	assert.Equal(t, 1, consecutiveSecretDepth(inLeaf))
+}

--- a/provider/pkg/resources/path_classifier.go
+++ b/provider/pkg/resources/path_classifier.go
@@ -312,7 +312,9 @@ func (c *PathClassifier) addWriteOnlyFallbacks(
 		}
 		for _, concretePath := range ExpandMatchingPaths(oldDesired, path) {
 			if value, ok := GetPath(oldDesired, concretePath); ok {
-				SetPathWithShape(result, oldDesired, concretePath, value)
+				// Clone so result does not alias oldDesired: later mutations of
+				// the restored subtree must not write through into old inputs.
+				SetPathWithShape(result, oldDesired, concretePath, clonePropertyValue(value))
 			}
 		}
 	}
@@ -400,7 +402,14 @@ func PreserveSecretWrappers(actual, oldDesired resource.PropertyMap) {
 
 func preserveSecretWrapper(actual, oldDesired resource.PropertyValue) resource.PropertyValue {
 	if oldDesired.IsSecret() {
-		return resource.MakeSecret(preserveSecretWrapper(actual, oldDesired.SecretValue().Element))
+		inner := preserveSecretWrapper(actual, oldDesired.SecretValue().Element)
+		if inner.IsSecret() {
+			// Already secret, for example a write-only value restored from old
+			// desired inputs. Wrapping again would nest secrets and double the
+			// serialized state size on every refresh.
+			return inner
+		}
+		return resource.MakeSecret(inner)
 	}
 	if actual.IsSecret() {
 		return actual

--- a/provider/pkg/resources/path_classifier_test.go
+++ b/provider/pkg/resources/path_classifier_test.go
@@ -200,6 +200,82 @@ func TestPathClassifierActualInputBaselinePreservesSecretWrappers(t *testing.T) 
 	assert.False(t, baseline["tags"].ObjectValue()["plain"].IsSecret())
 }
 
+func TestPreserveSecretWrappersDoesNotNestAlreadySecretValues(t *testing.T) {
+	t.Parallel()
+
+	actual := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{
+			// Write-only value restored from old desired inputs, already secret.
+			"password": resource.MakeSecret(resource.NewStringProperty("value")),
+		}),
+	}
+	oldDesired := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{
+			"password": resource.MakeSecret(resource.NewStringProperty("value")),
+		}),
+	}
+
+	PreserveSecretWrappers(actual, oldDesired)
+
+	password := actual["settings"].ObjectValue()["password"]
+	require.True(t, password.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), password.SecretValue().Element)
+
+	// The old desired inputs must not be modified either.
+	oldPassword := oldDesired["settings"].ObjectValue()["password"]
+	require.True(t, oldPassword.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), oldPassword.SecretValue().Element)
+}
+
+func TestAddWriteOnlyOutputFallbacksDoesNotAliasOldInputs(t *testing.T) {
+	t.Parallel()
+
+	spec := metadata.CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"settings": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:Settings"}},
+		},
+		Outputs: map[string]pschema.PropertySpec{
+			"settings": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:Settings"}},
+		},
+		WriteOnly: []string{"settings/environment"},
+	}
+	types := map[string]metadata.CloudAPIType{
+		"aws-native:test:Settings": {
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"environment": {TypeSpec: pschema.TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &pschema.TypeSpec{Type: "string"},
+				}},
+			},
+		},
+	}
+	classifier := NewPathClassifier(&spec, types)
+
+	oldDesired := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{
+			"environment": resource.NewObjectProperty(resource.PropertyMap{
+				"KEY": resource.MakeSecret(resource.NewStringProperty("value")),
+			}),
+		}),
+	}
+	result := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{}),
+	}
+
+	classifier.AddWriteOnlyOutputFallbacks(result, oldDesired)
+
+	restored, ok := GetPath(result, "settings/environment/KEY")
+	require.True(t, ok)
+	require.True(t, restored.IsSecret())
+
+	// Mutating the restored subtree must not write through into old inputs.
+	result["settings"].ObjectValue()["environment"].ObjectValue()["KEY"] = resource.NewStringProperty("mutated")
+	original, ok := GetPath(oldDesired, "settings/environment/KEY")
+	require.True(t, ok)
+	assert.True(t, original.IsSecret())
+}
+
 func TestPathClassifierArrayOwnership(t *testing.T) {
 	spec := metadata.CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{


### PR DESCRIPTION
## What

Refreshing a resource with a secret value under a write-only path (e.g. `AWS::Synthetics::Canary` `runConfig/environmentVariables`) doubles the value's secret wrapper depth on every refresh: 1 → 2 → 4 → 8 → 16 → … Each wrapper roughly doubles the JSON-escaped payload in the encrypted state, so a 36-character secret grew to ~438 KiB per occurrence after four refreshes on a production stack, and eventually `pulumi refresh` was OOM-killed.

Two defects combine:

1. `preserveSecretWrapper` re-wraps values that are already secret. Write-only values restored from old inputs by `AddWriteOnlyOutputFallbacks` are already secret, so each refresh stacks the old wrapper depth on top.
2. `addWriteOnlyFallbacks` aliases the old-input subtree into the new output state instead of copying, so the re-wrap also writes through into the parsed old inputs and flows into the new `__inputs` checkpoint — compounding across refreshes.

## Fix

- `preserveSecretWrapper` never wraps an already-secret value.
- `addWriteOnlyFallbacks` clones restored values instead of aliasing old inputs.
- `CollapseConsecutiveSecrets` collapses `Secret(Secret(x))` → `Secret(x)` at the checkpoint read/write boundary (`ParseCheckpointObject` / `CheckpointPropertyMap`), so states already poisoned by earlier versions heal on their next refresh.

## Tests

- Refresh-loop regression test asserting wrapper depth stays exactly 1 in outputs and `__inputs` over 20 simulated refreshes (fails with depth 2 on master at iteration 0).
- Healing test: a state with a 16-deep nested secret collapses to depth 1 after one refresh.
- Unit tests for the collapse at the checkpoint boundary, the no-nest behavior of `PreserveSecretWrappers`, and the no-alias behavior of `AddWriteOnlyOutputFallbacks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)