### PR TITLE
Fix write-only secret nesting during refresh

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1100,12 +1100,10 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 		} else {
 			newStateProps := resource.NewPropertyMapFromMap(rawState)
 			classifier := resources.NewPathClassifier(&spec, p.resourceMap.Types)
-			// Preserve live readable values before restoring write-only values, which
-			// already carry their secret wrappers from inputs.
-			resources.PreserveSecretWrappers(newStateProps, inputs)
-			classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
 			baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
 			newInputs = resources.SuppressBaselineDiffs(resourceToken, &spec, inputs, baseline, p.transformCache)
+			classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
+			resources.PreserveSecretWrappers(newStateProps, inputs)
 			newState = resources.CheckpointPropertyMap(newInputs, newStateProps)
 		}
 		if newState == nil {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1100,8 +1100,10 @@ func (p *cfnProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pu
 		} else {
 			newStateProps := resource.NewPropertyMapFromMap(rawState)
 			classifier := resources.NewPathClassifier(&spec, p.resourceMap.Types)
-			classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
+			// Preserve live readable values before restoring write-only values, which
+			// already carry their secret wrappers from inputs.
 			resources.PreserveSecretWrappers(newStateProps, inputs)
+			classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
 			baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
 			newInputs = resources.SuppressBaselineDiffs(resourceToken, &spec, inputs, baseline, p.transformCache)
 			newState = resources.CheckpointPropertyMap(newInputs, newStateProps)

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -1787,6 +1787,77 @@ func TestRead(t *testing.T) {
 		assert.Equal(t, "2012-10-17", inputDoc["Version"].StringValue())
 	})
 
+	t.Run("StandardResource/RestoresWriteOnlyValueUnderSecretParent", func(t *testing.T) {
+		const token = "aws-native:test:SecretParent"
+		provider.resourceMap.Resources[token] = metadata.CloudAPIResource{
+			CfType: "AWS::Test::SecretParent",
+			Inputs: map[string]schema.PropertySpec{
+				"name":      {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"runConfig": {TypeSpec: schema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+			},
+			Outputs: map[string]schema.PropertySpec{
+				"name":      {TypeSpec: schema.TypeSpec{Type: "string"}},
+				"runConfig": {TypeSpec: schema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+			},
+			WriteOnly: []string{"runConfig/environmentVariables"},
+		}
+		oldTypes := provider.resourceMap.Types
+		t.Cleanup(func() { provider.resourceMap.Types = oldTypes })
+		provider.resourceMap.Types = map[string]metadata.CloudAPIType{
+			"aws-native:test:RunConfig": {
+				Type: "object",
+				Properties: map[string]schema.PropertySpec{
+					"timeoutInSeconds": {TypeSpec: schema.TypeSpec{Type: "integer"}},
+					"environmentVariables": {TypeSpec: schema.TypeSpec{
+						Type:                 "object",
+						AdditionalProperties: &schema.TypeSpec{Type: "string"},
+					}},
+				},
+			},
+		}
+
+		runConfig := resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+			"environmentVariables": resource.NewObjectProperty(resource.PropertyMap{
+				"API_KEY": resource.NewStringProperty("secret-value"),
+			}),
+		}))
+		inputs := resource.PropertyMap{
+			"name":      resource.NewStringProperty("canary"),
+			"runConfig": runConfig,
+		}
+		readRequest := &pulumirpc.ReadRequest{
+			Urn: string(resource.NewURN("stack", "project", "parent", token, "name")),
+			Id:  "resource-id",
+			Properties: mustMarshalProperties(t, resource.PropertyMap{
+				"name":      resource.NewStringProperty("canary"),
+				"runConfig": runConfig,
+				"__inputs":  resource.MakeSecret(resource.NewObjectProperty(inputs)),
+			}),
+		}
+
+		mockCCC.EXPECT().Read(ctx, "AWS::Test::SecretParent", "resource-id").Return(
+			map[string]interface{}{
+				"name": "canary",
+				"runConfig": map[string]interface{}{
+					"timeoutInSeconds": 60,
+				},
+			}, true, nil,
+		)
+
+		resp, err := provider.Read(ctx, readRequest)
+		require.NoError(t, err)
+		props := mustUnmarshalProperties(t, resp.Properties)
+		refreshedRunConfig := props["runConfig"]
+		require.True(t, refreshedRunConfig.IsSecret())
+		assert.True(t, refreshedRunConfig.SecretValue().Element.ObjectValue().HasValue("environmentVariables"))
+
+		refreshedInputs := mustUnmarshalProperties(t, resp.Inputs)
+		refreshedInputRunConfig := refreshedInputs["runConfig"]
+		require.True(t, refreshedInputRunConfig.IsSecret())
+		assert.True(t, refreshedInputRunConfig.SecretValue().Element.ObjectValue().HasValue("environmentVariables"))
+	})
+
 	t.Run("StandardResource/NotFound", func(t *testing.T) {
 		req.Urn = string(resource.NewURN("stack", "project", "parent", "unknown:resource", "name"))
 

--- a/provider/pkg/resources/nested_secret_refresh_test.go
+++ b/provider/pkg/resources/nested_secret_refresh_test.go
@@ -69,10 +69,10 @@ func simulateRefreshRead(t *testing.T, state resource.PropertyMap) resource.Prop
 			"timeoutInSeconds": resource.NewNumberProperty(60),
 		}),
 	}
-	PreserveSecretWrappers(newStateProps, inputs)
-	classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
 	baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
 	newInputs := SuppressBaselineDiffs("aws-native:test:Canary", &spec, inputs, baseline, NewTransformCache())
+	classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
+	PreserveSecretWrappers(newStateProps, inputs)
 	return CheckpointPropertyMap(newInputs, newStateProps)
 }
 
@@ -111,6 +111,26 @@ func TestRefreshDoesNotNestWriteOnlySecrets(t *testing.T) {
 		require.Truef(t, ok, "iteration %d: __inputs leaf missing", i)
 		require.Equalf(t, 1, consecutiveSecretDepth(inLeaf), "iteration %d: __inputs secret depth", i)
 	}
+}
+
+func TestRefreshRestoresWriteOnlyValuesUnderSecretParent(t *testing.T) {
+	t.Parallel()
+
+	inputs := canaryInputs(resource.NewStringProperty("fake-36-character-secret-value-here"))
+	inputs["runConfig"] = resource.MakeSecret(inputs["runConfig"])
+	state := CheckpointPropertyMap(inputs, clonePropertyMap(inputs))
+
+	state = simulateRefreshRead(t, state)
+
+	runConfig := state["runConfig"]
+	require.Equal(t, 1, consecutiveSecretDepth(runConfig))
+	_, ok := runConfig.SecretValue().Element.ObjectValue()["environmentVariables"]
+	assert.True(t, ok)
+
+	checkpointRunConfig := ParseCheckpointObject(state)["runConfig"]
+	require.Equal(t, 1, consecutiveSecretDepth(checkpointRunConfig))
+	_, ok = checkpointRunConfig.SecretValue().Element.ObjectValue()["environmentVariables"]
+	assert.True(t, ok)
 }
 
 func TestRefreshHealsNestedWriteOnlySecrets(t *testing.T) {

--- a/provider/pkg/resources/nested_secret_refresh_test.go
+++ b/provider/pkg/resources/nested_secret_refresh_test.go
@@ -1,0 +1,135 @@
+//nolint:goconst // Repeated literals keep test and schema fixtures readable.
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-aws-native/provider/pkg/metadata"
+)
+
+// consecutiveSecretDepth counts consecutive secret wrappers around a value.
+func consecutiveSecretDepth(v resource.PropertyValue) int {
+	depth := 0
+	for v.IsSecret() {
+		depth++
+		v = v.SecretValue().Element
+	}
+	return depth
+}
+
+// canarySpec models AWS::Synthetics::Canary, whose runConfig/environmentVariables
+// is write-only: it is accepted on create/update but never returned by
+// CloudControl, so refresh must restore it from checkpointed old inputs.
+func canarySpec() (metadata.CloudAPIResource, map[string]metadata.CloudAPIType) {
+	spec := metadata.CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"name":      {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			"runConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+		},
+		Outputs: map[string]pschema.PropertySpec{
+			"name":      {TypeSpec: pschema.TypeSpec{Type: "string"}},
+			"runConfig": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:RunConfig"}},
+		},
+		WriteOnly: []string{"runConfig/environmentVariables"},
+	}
+	types := map[string]metadata.CloudAPIType{
+		"aws-native:test:RunConfig": {
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"timeoutInSeconds": {TypeSpec: pschema.TypeSpec{Type: "integer"}},
+				"environmentVariables": {TypeSpec: pschema.TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &pschema.TypeSpec{Type: "string"},
+				}},
+			},
+		},
+	}
+	return spec, types
+}
+
+// simulateRefreshRead mirrors the standard-resource refresh path of
+// cfnProvider.Read for a resource with a secret value under a write-only path.
+func simulateRefreshRead(t *testing.T, state resource.PropertyMap) resource.PropertyMap {
+	spec, types := canarySpec()
+	classifier := NewPathClassifier(&spec, types)
+
+	inputs := ParseCheckpointObject(state)
+	require.NotNil(t, inputs)
+
+	// CloudControl never returns write-only properties.
+	newStateProps := resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+		}),
+	}
+	PreserveSecretWrappers(newStateProps, inputs)
+	classifier.AddWriteOnlyOutputFallbacks(newStateProps, inputs)
+	baseline := classifier.ActualInputBaselineFromOutputs(inputs, newStateProps, inputs)
+	newInputs := SuppressBaselineDiffs("aws-native:test:Canary", &spec, inputs, baseline, NewTransformCache())
+	return CheckpointPropertyMap(newInputs, newStateProps)
+}
+
+func canaryInputs(apiKey resource.PropertyValue) resource.PropertyMap {
+	return resource.PropertyMap{
+		"name": resource.NewStringProperty("canary"),
+		"runConfig": resource.NewObjectProperty(resource.PropertyMap{
+			"timeoutInSeconds": resource.NewNumberProperty(60),
+			"environmentVariables": resource.NewObjectProperty(resource.PropertyMap{
+				"API_KEY": apiKey,
+			}),
+		}),
+	}
+}
+
+// TestRefreshDoesNotNestWriteOnlySecrets asserts the invariant that repeated
+// refreshes keep a secret write-only value at exactly one secret wrapper in
+// both output state and checkpointed __inputs. Before the fix, the wrapper
+// depth doubled on every refresh (1, 2, 4, 8, 16, ...), and JSON escaping made
+// the encrypted state entry roughly double per level.
+func TestRefreshDoesNotNestWriteOnlySecrets(t *testing.T) {
+	t.Parallel()
+
+	inputs := canaryInputs(resource.MakeSecret(resource.NewStringProperty("fake-36-character-secret-value-here")))
+	state := CheckpointPropertyMap(inputs, clonePropertyMap(inputs))
+
+	for i := 0; i < 20; i++ {
+		state = simulateRefreshRead(t, state)
+
+		outLeaf, ok := GetPath(state, "runConfig/environmentVariables/API_KEY")
+		require.Truef(t, ok, "iteration %d: output leaf missing", i)
+		require.Equalf(t, 1, consecutiveSecretDepth(outLeaf), "iteration %d: output secret depth", i)
+		assert.Equal(t, resource.NewStringProperty("fake-36-character-secret-value-here"), outLeaf.SecretValue().Element)
+
+		inLeaf, ok := GetPath(ParseCheckpointObject(state), "runConfig/environmentVariables/API_KEY")
+		require.Truef(t, ok, "iteration %d: __inputs leaf missing", i)
+		require.Equalf(t, 1, consecutiveSecretDepth(inLeaf), "iteration %d: __inputs secret depth", i)
+	}
+}
+
+func TestRefreshHealsNestedWriteOnlySecrets(t *testing.T) {
+	t.Parallel()
+
+	secret := resource.NewStringProperty("fake-36-character-secret-value-here")
+	for range 4 {
+		secret = resource.MakeSecret(secret)
+	}
+	state := CheckpointPropertyMap(canaryInputs(secret), canaryInputs(secret))
+
+	state = simulateRefreshRead(t, state)
+
+	output, ok := GetPath(state, "runConfig/environmentVariables/API_KEY")
+	require.True(t, ok)
+	assert.Equal(t, 1, consecutiveSecretDepth(output))
+	assert.Equal(t, resource.NewStringProperty("fake-36-character-secret-value-here"), output.SecretValue().Element)
+
+	input, ok := GetPath(ParseCheckpointObject(state), "runConfig/environmentVariables/API_KEY")
+	require.True(t, ok)
+	assert.Equal(t, 1, consecutiveSecretDepth(input))
+}

--- a/provider/pkg/resources/path_classifier.go
+++ b/provider/pkg/resources/path_classifier.go
@@ -150,6 +150,8 @@ func (c *PathClassifier) actualInputBaseline(
 	oldDesired, projectedActual, newDesired resource.PropertyMap,
 ) resource.PropertyMap {
 	result := clonePropertyMap(projectedActual)
+	// Preserve live readable values before restoring write-only values, which
+	// already carry their secret wrappers from oldDesired.
 	PreserveSecretWrappers(result, oldDesired)
 	c.addWriteOnlyFallbacks(result, oldDesired, true)
 	c.pruneUnownedComputed(result, oldDesired, newDesired, "")
@@ -312,9 +314,39 @@ func (c *PathClassifier) addWriteOnlyFallbacks(
 		}
 		for _, concretePath := range ExpandMatchingPaths(oldDesired, path) {
 			if value, ok := GetPath(oldDesired, concretePath); ok {
-				SetPathWithShape(result, oldDesired, concretePath, value)
+				SetPathWithShape(result, oldDesired, concretePath, cloneWriteOnlyFallback(value))
 			}
 		}
+	}
+}
+
+// cloneWriteOnlyFallback deep-copies a checkpointed fallback and collapses
+// consecutive secret wrappers left by older provider versions. Scoping this
+// normalization to write-only values heals affected state without rewriting
+// unrelated outputs or inputs.
+func cloneWriteOnlyFallback(v resource.PropertyValue) resource.PropertyValue {
+	switch {
+	case v.IsSecret():
+		element := v.SecretValue().Element
+		for element.IsSecret() {
+			element = element.SecretValue().Element
+		}
+		return resource.MakeSecret(cloneWriteOnlyFallback(element))
+	case v.IsObject():
+		result := resource.PropertyMap{}
+		for key, value := range v.ObjectValue() {
+			result[key] = cloneWriteOnlyFallback(value)
+		}
+		return resource.NewObjectProperty(result)
+	case v.IsArray():
+		values := v.ArrayValue()
+		result := make([]resource.PropertyValue, len(values))
+		for i, value := range values {
+			result[i] = cloneWriteOnlyFallback(value)
+		}
+		return resource.NewArrayProperty(result)
+	default:
+		return v
 	}
 }
 
@@ -399,11 +431,18 @@ func PreserveSecretWrappers(actual, oldDesired resource.PropertyMap) {
 }
 
 func preserveSecretWrapper(actual, oldDesired resource.PropertyValue) resource.PropertyValue {
-	if oldDesired.IsSecret() {
-		return resource.MakeSecret(preserveSecretWrapper(actual, oldDesired.SecretValue().Element))
-	}
+	// PreserveSecretWrappers is intentionally idempotent. Callers may provide
+	// values that already carry a secret wrapper.
 	if actual.IsSecret() {
 		return actual
+	}
+	if oldDesired.IsSecret() {
+		// Secret wrappers are boolean metadata. Apply one wrapper even if legacy
+		// oldDesired state contains the same marker more than once.
+		for oldDesired.IsSecret() {
+			oldDesired = oldDesired.SecretValue().Element
+		}
+		return resource.MakeSecret(preserveSecretWrapper(actual, oldDesired))
 	}
 	if actual.IsObject() && oldDesired.IsObject() {
 		PreserveSecretWrappers(actual.ObjectValue(), oldDesired.ObjectValue())

--- a/provider/pkg/resources/path_classifier.go
+++ b/provider/pkg/resources/path_classifier.go
@@ -150,10 +150,8 @@ func (c *PathClassifier) actualInputBaseline(
 	oldDesired, projectedActual, newDesired resource.PropertyMap,
 ) resource.PropertyMap {
 	result := clonePropertyMap(projectedActual)
-	// Preserve live readable values before restoring write-only values, which
-	// already carry their secret wrappers from oldDesired.
-	PreserveSecretWrappers(result, oldDesired)
 	c.addWriteOnlyFallbacks(result, oldDesired, true)
+	PreserveSecretWrappers(result, oldDesired)
 	c.pruneUnownedComputed(result, oldDesired, newDesired, "")
 	return result
 }

--- a/provider/pkg/resources/path_classifier_test.go
+++ b/provider/pkg/resources/path_classifier_test.go
@@ -200,6 +200,86 @@ func TestPathClassifierActualInputBaselinePreservesSecretWrappers(t *testing.T) 
 	assert.False(t, baseline["tags"].ObjectValue()["plain"].IsSecret())
 }
 
+func TestPreserveSecretWrapperAddsAtMostOneWrapper(t *testing.T) {
+	t.Parallel()
+
+	plain := resource.NewStringProperty("refreshed")
+	secret := resource.MakeSecret(plain)
+	oldSecret := resource.MakeSecret(resource.NewStringProperty("old"))
+	tests := []struct {
+		name       string
+		actual     resource.PropertyValue
+		oldDesired resource.PropertyValue
+	}{
+		{name: "adds missing wrapper", actual: plain, oldDesired: oldSecret},
+		{name: "keeps existing wrapper", actual: secret, oldDesired: oldSecret},
+		{
+			name:       "does not reproduce legacy nested wrappers",
+			actual:     plain,
+			oldDesired: resource.MakeSecret(oldSecret),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := preserveSecretWrapper(tt.actual, tt.oldDesired)
+			require.True(t, actual.IsSecret())
+			assert.Equal(t, plain, actual.SecretValue().Element)
+		})
+	}
+}
+
+func TestAddWriteOnlyOutputFallbacksClonesAndNormalizesOldInputs(t *testing.T) {
+	t.Parallel()
+
+	spec := metadata.CloudAPIResource{
+		Inputs: map[string]pschema.PropertySpec{
+			"settings": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:Settings"}},
+		},
+		Outputs: map[string]pschema.PropertySpec{
+			"settings": {TypeSpec: pschema.TypeSpec{Ref: "#/types/aws-native:test:Settings"}},
+		},
+		WriteOnly: []string{"settings/environment"},
+	}
+	types := map[string]metadata.CloudAPIType{
+		"aws-native:test:Settings": {
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"environment": {TypeSpec: pschema.TypeSpec{
+					Type:                 "object",
+					AdditionalProperties: &pschema.TypeSpec{Type: "string"},
+				}},
+			},
+		},
+	}
+	classifier := NewPathClassifier(&spec, types)
+
+	nestedSecret := resource.MakeSecret(resource.MakeSecret(resource.NewStringProperty("value")))
+	oldDesired := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{
+			"environment": resource.NewObjectProperty(resource.PropertyMap{
+				"KEY": nestedSecret,
+			}),
+		}),
+	}
+	result := resource.PropertyMap{
+		"settings": resource.NewObjectProperty(resource.PropertyMap{}),
+	}
+
+	classifier.AddWriteOnlyOutputFallbacks(result, oldDesired)
+
+	restored, ok := GetPath(result, "settings/environment/KEY")
+	require.True(t, ok)
+	require.True(t, restored.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), restored.SecretValue().Element)
+
+	// Mutating the restored subtree must not write through into old inputs.
+	result["settings"].ObjectValue()["environment"].ObjectValue()["KEY"] = resource.NewStringProperty("mutated")
+	original, ok := GetPath(oldDesired, "settings/environment/KEY")
+	require.True(t, ok)
+	assert.Equal(t, nestedSecret, original)
+}
+
 func TestPathClassifierArrayOwnership(t *testing.T) {
 	spec := metadata.CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{

--- a/provider/pkg/resources/path_classifier_test.go
+++ b/provider/pkg/resources/path_classifier_test.go
@@ -280,6 +280,23 @@ func TestAddWriteOnlyOutputFallbacksClonesAndNormalizesOldInputs(t *testing.T) {
 	assert.Equal(t, nestedSecret, original)
 }
 
+func TestCloneWriteOnlyFallbackNormalizesArrays(t *testing.T) {
+	t.Parallel()
+
+	nestedSecret := resource.MakeSecret(resource.MakeSecret(resource.NewStringProperty("value")))
+	original := resource.NewArrayProperty([]resource.PropertyValue{
+		resource.NewObjectProperty(resource.PropertyMap{"secret": nestedSecret}),
+	})
+
+	cloned := cloneWriteOnlyFallback(original)
+	secret := cloned.ArrayValue()[0].ObjectValue()["secret"]
+	require.True(t, secret.IsSecret())
+	assert.Equal(t, resource.NewStringProperty("value"), secret.SecretValue().Element)
+
+	cloned.ArrayValue()[0].ObjectValue()["secret"] = resource.NewStringProperty("mutated")
+	assert.Equal(t, nestedSecret, original.ArrayValue()[0].ObjectValue()["secret"])
+}
+
 func TestPathClassifierArrayOwnership(t *testing.T) {
 	spec := metadata.CloudAPIResource{
 		Inputs: map[string]pschema.PropertySpec{
@@ -431,15 +448,15 @@ func TestPathHelpersNestedReadWriteDelete(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestPathHelpersSetPathWithShapeUsesArrayGuide(t *testing.T) {
+func TestPathHelpersSetPathWithShapeUsesSecretArrayGuide(t *testing.T) {
 	shape := resource.PropertyMap{
-		"defaultActions": resource.NewArrayProperty([]resource.PropertyValue{
+		"defaultActions": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 			resource.NewObjectProperty(resource.PropertyMap{
 				"authenticateOidcConfig": resource.NewObjectProperty(resource.PropertyMap{
 					"clientSecret": resource.NewStringProperty("old-secret"),
 				}),
 			}),
-		}),
+		})),
 	}
 	m := resource.PropertyMap{}
 	SetPathWithShape(
@@ -455,9 +472,9 @@ func TestPathHelpersSetPathWithShapeUsesArrayGuide(t *testing.T) {
 	assert.Equal(t, "secret", secret.StringValue())
 }
 
-func TestExpandMatchingPaths(t *testing.T) {
+func TestExpandMatchingPathsThroughSecretAncestor(t *testing.T) {
 	inputs := resource.PropertyMap{
-		"defaultActions": resource.NewArrayProperty([]resource.PropertyValue{
+		"defaultActions": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
 			resource.NewObjectProperty(resource.PropertyMap{
 				"authenticateOidcConfig": resource.NewObjectProperty(resource.PropertyMap{
 					"clientSecret": resource.NewStringProperty("secret-0"),
@@ -468,7 +485,7 @@ func TestExpandMatchingPaths(t *testing.T) {
 					"clientSecret": resource.NewStringProperty("secret-1"),
 				}),
 			}),
-		}),
+		})),
 	}
 
 	assert.Equal(t, []string{

--- a/provider/pkg/resources/path_helpers.go
+++ b/provider/pkg/resources/path_helpers.go
@@ -16,12 +16,21 @@ import (
 //	}
 //
 // Array indices are written as decimal path segments, such as
-// "defaultActions/0/authenticateOidcConfig/clientSecret".
+// "defaultActions/0/authenticateOidcConfig/clientSecret". Secret wrappers on
+// ancestor values are transparent because they do not change the value's shape.
 func GetPath(m resource.PropertyMap, path string) (resource.PropertyValue, bool) {
+	current := resource.NewObjectProperty(m)
 	if path == "" {
-		return resource.NewObjectProperty(m), true
+		return current, true
 	}
-	return slashPathForValue(resource.NewObjectProperty(m), path).Get(resource.NewObjectProperty(m))
+	for _, segment := range strings.Split(path, "/") {
+		child, ok := getPathChild(current, segment)
+		if !ok {
+			return resource.PropertyValue{}, false
+		}
+		current = child
+	}
+	return current, true
 }
 
 // SetPath writes a slash-delimited SDK path into a property map.
@@ -50,6 +59,7 @@ func DeletePath(m resource.PropertyMap, path string) {
 }
 
 // ExpandMatchingPaths expands a metadata path pattern against concrete values.
+// Secret wrappers on ancestor values are transparent during expansion.
 //
 // For example, given:
 //
@@ -84,6 +94,7 @@ func expandMatchingPaths(v resource.PropertyValue, segments []string, prefix []s
 		*result = append(*result, strings.Join(prefix, "/"))
 		return
 	}
+	v = unwrapSecretValue(v)
 	segment := segments[0]
 	if segment == "*" {
 		if v.IsArray() {
@@ -146,6 +157,7 @@ func slashPathForValueWithShape(root, shape resource.PropertyValue, path string)
 	current := root
 	currentShape := shape
 	for _, segment := range segments {
+		currentShape = unwrapSecretValue(currentShape)
 		if current.IsArray() || currentShape.IsArray() {
 			i, err := strconv.Atoi(segment)
 			if err == nil {
@@ -187,7 +199,10 @@ func slashPathForValueWithShape(root, shape resource.PropertyValue, path string)
 }
 
 // getPathChild reads one child segment from an object or array property value.
+// Secret wrappers are transparent for path lookup because they annotate the
+// wrapped value rather than changing its object or array shape.
 func getPathChild(v resource.PropertyValue, segment string) (resource.PropertyValue, bool) {
+	v = unwrapSecretValue(v)
 	if v.IsObject() {
 		child, ok := v.ObjectValue()[resource.PropertyKey(segment)]
 		return child, ok
@@ -200,6 +215,13 @@ func getPathChild(v resource.PropertyValue, segment string) (resource.PropertyVa
 		return v.ArrayValue()[i], true
 	}
 	return resource.PropertyValue{}, false
+}
+
+func unwrapSecretValue(v resource.PropertyValue) resource.PropertyValue {
+	for v.IsSecret() {
+		v = v.SecretValue().Element
+	}
+	return v
 }
 
 // clonePropertyMap deep-copies a PropertyMap for mutation.


### PR DESCRIPTION
## Problem

Refreshing a resource with a secret under a write-only path could double its secret-wrapper depth on every refresh: `1 → 2 → 4 → 8`. The refresh path reapplied secret markers to values that were already secret, and restored subtrees aliased the old inputs, allowing nested values to flow into the next `__inputs` checkpoint.

## Solution

- Restore write-only values into raw CloudControl state before reapplying secret markers, treating secret-wrapped checkpoint ancestors as transparent for path lookup.
- Make secret preservation idempotent and clone restored write-only subtrees.
- Collapse consecutive wrappers only within write-only fallbacks, healing affected state from `4 → 1` without rewriting unrelated checkpoint values.

Based on the investigation and initial fix in #3113 by @yukimotochern. This version moves healing from the global checkpoint boundary to the write-only fallback path.

## Validation

- Added repeated-refresh and targeted-healing tests based on Synthetics Canary environment variables.
- Added direct provider `Read` coverage for a secret parent containing a nested write-only value, plus array fallback coverage.
- Ran `mise exec -- make lint` and `mise exec -- make test_provider_fast`.
